### PR TITLE
Fix/burndown sprint domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 > **Upgrades:** No breaking changes in **3.7.x** / **3.8.x** / **3.9.x** / **3.10.x** / **3.11.x** / **3.12.x** / **3.13.x** / **3.14.x** / **3.15.x** / **3.16.x** unless noted below.
 
+## [3.16.1] - 2026-05-26
+
+### Fixed
+
+- **Real burndown chart (sprint domain)** - Sprint charts use UTC day boundaries for the time axis and subtitle range, filter sprint points with half-open day intervals, and show clear fallback copy when data is empty, sprint-scoped but unusable, or only a single sample (instead of mounting a misleading one-point chart).
+
+- **Settings → Charts burndown** - Sprint list cache invalidates when the active board slug changes, so burndown navigation and sprint-scoped fetches stay aligned after switching projects.
+
+- **Board realtime refresh during drag** - SSE-driven board reloads no longer schedule a forced refresh while a card drag is active, and drag-in-progress always defers (never force-flushes) pending refreshes, fixing intermittent freezes when moving notes between lanes.
+
+### Tests
+
+- **Burndown** - UTC sprint bounds, single-sample fallback, and mount guard behavior.
+- **Settings charts** - Sprint cache keyed by slug and default sprint index selection.
+- **Board realtime** - Drag vs non-drag guard deferral and force-timer behavior.
+
 ## [3.16.0] - 2026-05-15
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.16.0-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.16.1-blue" alt="version" />
   <a href="LICENSE">
     <img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" />
   </a>

--- a/internal/httpapi/web/dist/charts/burndown.js
+++ b/internal/httpapi/web/dist/charts/burndown.js
@@ -14,7 +14,33 @@ function toTimestampMs(value) {
     return Number.isFinite(ts) ? ts : null;
 }
 function formatShortDate(tsMs) {
-    return new Date(tsMs).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    return new Date(tsMs).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+    });
+}
+function startOfUtcDay(tsMs) {
+    const d = new Date(tsMs);
+    return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}
+function resolveSprintChartBoundsMs(currentSprint) {
+    if (!currentSprint) {
+        return null;
+    }
+    const sprintStartMs = toTimestampMs(currentSprint.plannedStartAt);
+    const sprintEndMs = toTimestampMs(currentSprint.plannedEndAt);
+    if (sprintStartMs == null || sprintEndMs == null || sprintEndMs < sprintStartMs) {
+        return null;
+    }
+    const startMs = startOfUtcDay(sprintStartMs);
+    const endMs = startOfUtcDay(sprintEndMs) + MS_PER_DAY;
+    const safeEndMs = endMs > startMs ? endMs : startMs + MS_PER_DAY;
+    return {
+        startMs,
+        endMs: safeEndMs,
+        displayEndMs: safeEndMs - 1,
+    };
 }
 function resolveTimeDomainMs(chartData, currentSprint) {
     const firstDataMs = toTimestampMs(chartData[0]?.date ?? '');
@@ -24,21 +50,22 @@ function resolveTimeDomainMs(chartData, currentSprint) {
     }
     let startMs = firstDataMs;
     let endMs = lastDataMs;
-    if (currentSprint) {
-        const sprintStartMs = toTimestampMs(currentSprint.plannedStartAt);
-        const sprintEndMs = toTimestampMs(currentSprint.plannedEndAt);
-        if (sprintStartMs != null && sprintEndMs != null && sprintEndMs >= sprintStartMs) {
-            startMs = sprintStartMs;
-            endMs = sprintEndMs;
-        }
+    let displayEndMs = endMs;
+    const sprintBounds = resolveSprintChartBoundsMs(currentSprint);
+    if (sprintBounds) {
+        startMs = sprintBounds.startMs;
+        endMs = sprintBounds.endMs;
+        displayEndMs = sprintBounds.displayEndMs;
     }
     if (endMs <= startMs) {
         endMs = startMs + MS_PER_DAY;
+        displayEndMs = endMs - 1;
     }
     return {
         startMs,
         endMs,
         durationMs: Math.max(endMs - startMs, 1),
+        displayEndMs,
     };
 }
 /** Filter and sort data; optionally restrict to sprint range. */
@@ -48,28 +75,59 @@ function prepareChartData(data, currentSprint, dataIsSprintScoped) {
         .sort((a, b) => (toTimestampMs(a.date) - toTimestampMs(b.date)));
     // Skip date filter when data is already sprint-scoped (from backend sprint endpoint)
     if (currentSprint && !dataIsSprintScoped) {
-        const startMs = toTimestampMs(currentSprint.plannedStartAt);
-        const endMs = toTimestampMs(currentSprint.plannedEndAt);
-        if (startMs != null && endMs != null) {
+        const sprintBounds = resolveSprintChartBoundsMs(currentSprint);
+        if (sprintBounds) {
             chartData = chartData.filter((p) => {
                 const t = toTimestampMs(p.date);
-                return t >= startMs && t <= endMs;
+                return t >= sprintBounds.startMs && t < sprintBounds.endMs;
             });
         }
     }
     return chartData;
 }
+function resolveUsePoints(chartData, initialScopePoints) {
+    const hasAnyPoints = chartData.some((p) => toNumeric(p.remainingPoints) != null);
+    return hasAnyPoints && initialScopePoints != null;
+}
+function countVisibleRealSamples(chartData, usePoints) {
+    let count = 0;
+    for (const point of chartData) {
+        const value = usePoints ? toNumeric(point.remainingPoints) : toNumeric(point.remainingWork);
+        if (value != null) {
+            count++;
+        }
+    }
+    return count;
+}
+function resolveFallbackMessage(data, chartData) {
+    if (!Array.isArray(data) || data.length === 0) {
+        return 'No data available. Create some todos to see the burndown chart.';
+    }
+    if (chartData.length === 0) {
+        return 'No data for this sprint. Create some todos during the sprint to see the burndown chart.';
+    }
+    const initialScopePoints = toNumeric(chartData[0]?.initialScopePoints) != null
+        ? toNumeric(chartData[0]?.initialScopePoints)
+        : null;
+    const usePoints = resolveUsePoints(chartData, initialScopePoints);
+    const visibleRealSamples = countVisibleRealSamples(chartData, usePoints);
+    if (visibleRealSamples === 0) {
+        return 'No usable burndown data available.';
+    }
+    if (visibleRealSamples === 1) {
+        return 'Not enough burndown history yet. Check back after more sprint progress is recorded.';
+    }
+    return null;
+}
 /** Renders the chart wrapper HTML (header, nav, mount div). Does not draw the chart. */
 export function renderRealBurndownChart(data, currentSprint, sprintNav, dataIsSprintScoped) {
     const chartData = Array.isArray(data) && data.length > 0 ? prepareChartData(data, currentSprint, dataIsSprintScoped) : [];
-    const validPoints = chartData.filter((p) => toNumeric(p.remainingPoints) != null);
-    const validWork = chartData.filter((p) => toNumeric(p.remainingWork) != null);
-    const hasDataToPlot = validPoints.length > 0 || validWork.length > 0;
     const domain = chartData.length > 0 ? resolveTimeDomainMs(chartData, currentSprint) : null;
+    const noDataMessage = resolveFallbackMessage(data, chartData);
     let dateRangeSubtitle;
     if (domain) {
         dateRangeSubtitle = currentSprint
-            ? `${currentSprint.name} | ${formatShortDate(domain.startMs)} - ${formatShortDate(domain.endMs)}`
+            ? `${currentSprint.name} | ${formatShortDate(domain.startMs)} - ${formatShortDate(domain.displayEndMs)}`
             : `${formatShortDate(domain.startMs)} - ${formatShortDate(domain.endMs)}`;
     }
     else if (currentSprint) {
@@ -77,16 +135,6 @@ export function renderRealBurndownChart(data, currentSprint, sprintNav, dataIsSp
     }
     else {
         dateRangeSubtitle = 'No data available';
-    }
-    let noDataMessage = null;
-    if (!Array.isArray(data) || data.length === 0) {
-        noDataMessage = 'No data available. Create some todos to see the burndown chart.';
-    }
-    else if (chartData.length === 0) {
-        noDataMessage = 'No data for this sprint. Create some todos during the sprint to see the burndown chart.';
-    }
-    else if (!hasDataToPlot) {
-        noDataMessage = 'No usable burndown data available.';
     }
     const subtitleWithNav = currentSprint && sprintNav
         ? `<div class="burndown-chart__subtitle-row">
@@ -144,9 +192,8 @@ function buildUplotData(chartData, initialScope, initialScopePoints, currentSpri
     }
     const { startMs, endMs, durationMs } = domain;
     const startSec = Math.floor(startMs / 1000);
-    const endSec = Math.ceil(endMs / 1000);
-    const hasAnyPoints = chartData.some((p) => toNumeric(p.remainingPoints) != null);
-    const usePoints = hasAnyPoints && initialScopePoints != null;
+    const endSec = Math.floor(endMs / 1000);
+    const usePoints = resolveUsePoints(chartData, initialScopePoints);
     const totalScope = usePoints && initialScopePoints != null ? initialScopePoints : initialScope;
     const pointBySecond = new Map();
     for (const p of chartData) {
@@ -229,6 +276,13 @@ export function mountBurndownChart(container, data, currentSprint, dataIsSprintS
     const chartData = prepareChartData(data, currentSprint, dataIsSprintScoped);
     if (chartData.length === 0) {
         return; // renderRealBurndownChart already put a message in the container
+    }
+    const fallbackMessage = resolveFallbackMessage(data, chartData);
+    if (fallbackMessage) {
+        if (!container.querySelector('.burndown-chart__no-data')) {
+            container.innerHTML = `<div class="burndown-chart__no-data muted">${fallbackMessage}</div>`;
+        }
+        return;
     }
     const border = getThemeColor('--border');
     const text = getThemeColor('--text');
@@ -332,7 +386,11 @@ export function mountBurndownChart(container, data, currentSprint, dataIsSprintS
                 font: '12px system-ui, sans-serif',
                 values: (_u, vals) => vals.map((v) => {
                     const d = new Date(v * 1000); // scale values are in seconds
-                    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+                    return d.toLocaleDateString('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                        timeZone: 'UTC',
+                    });
                 }),
             },
             {

--- a/internal/httpapi/web/dist/dialogs/settings.js
+++ b/internal/httpapi/web/dist/dialogs/settings.js
@@ -54,6 +54,7 @@ let burndownSprintIndex = 0;
 let cachedRealBurndownData = null;
 let cachedRealBurndownURL = null;
 let cachedSprintsForCharts = null;
+let cachedSprintsForChartsSlug = null;
 /** Update all user-avatar elements outside the settings dialog (e.g. topbar) after avatar change. */
 function refreshAvatarsOutsideSettings() {
     const user = getUser();
@@ -123,6 +124,7 @@ function computeDefaultBurndownSprintIndex(sprints) {
 }
 function invalidateSprintsForChartsCache() {
     cachedSprintsForCharts = null;
+    cachedSprintsForChartsSlug = null;
     cachedRealBurndownData = null;
     cachedRealBurndownURL = null;
 }
@@ -829,7 +831,6 @@ export async function renderSettingsModal(options) {
     // Fetch tags and chart data only if we have project access
     let tagsHTML = "";
     let realBurndownData = [];
-    const realBurndownURLChanged = cachedRealBurndownURL !== realBurndownURL;
     if (hasProjectAccess) {
         try {
             tagsHTML = await loadTagSettingsContent(tagsURL);
@@ -838,20 +839,27 @@ export async function renderSettingsModal(options) {
             if (activeTab === "charts") {
                 // Fetch sprints for burndown navigation
                 const slug = getSlug();
-                if (slug && (cachedSprintsForCharts === null || realBurndownURLChanged)) {
+                if (!slug) {
+                    cachedSprintsForCharts = null;
+                    cachedSprintsForChartsSlug = null;
+                }
+                if (slug && (cachedSprintsForCharts === null || cachedSprintsForChartsSlug !== slug)) {
                     try {
                         const sprintsRes = await apiFetch(`/api/board/${slug}/sprints`);
                         const rawSprints = normalizeSprints(sprintsRes);
                         cachedSprintsForCharts = [...rawSprints].sort((a, b) => a.plannedStartAt - b.plannedStartAt);
+                        cachedSprintsForChartsSlug = slug;
                         // Auto-select sprint: active > last closed > first planned
                         burndownSprintIndex = computeDefaultBurndownSprintIndex(cachedSprintsForCharts);
                     }
                     catch {
                         cachedSprintsForCharts = [];
+                        cachedSprintsForChartsSlug = slug;
+                        burndownSprintIndex = 0;
                     }
                 }
                 // When a sprint is selected in board view, use sprint-scoped burndown endpoint
-                const sprints = cachedSprintsForCharts ?? [];
+                const sprints = slug ? (cachedSprintsForCharts ?? []) : [];
                 const burndownSprintIndexClamped = sprints.length > 0 ? Math.min(burndownSprintIndex, sprints.length - 1) : 0;
                 const currentSprintForFetch = sprints.length > 0 ? sprints[burndownSprintIndexClamped] : null;
                 const effectiveBurndownURL = slug && currentSprintForFetch
@@ -893,6 +901,8 @@ export async function renderSettingsModal(options) {
     else {
         // No project access - clear cache
         invalidateTagSettingsCache();
+        cachedSprintsForCharts = null;
+        cachedSprintsForChartsSlug = null;
         cachedRealBurndownData = null;
         cachedRealBurndownURL = null;
     }

--- a/internal/httpapi/web/dist/views/board-realtime.js
+++ b/internal/httpapi/web/dist/views/board-realtime.js
@@ -121,9 +121,11 @@ function getLocalRealtimeGuardRemaining() {
 function getBoardInteractionGuardRemaining() {
     return Math.max(0, boardInteractionGuardMs - (Date.now() - getLastBoardInteractionTimestamp()));
 }
-function isRealtimeRefreshBlocked() {
-    return dragInProgress
-        || boardPointerInteractionActive
+function isRealtimeRefreshBlockedByDrag() {
+    return dragInProgress;
+}
+function isRealtimeRefreshBlockedByNonDragGuard() {
+    return boardPointerInteractionActive
         || todoDialogOpeningInProgress
         || getLocalRealtimeGuardRemaining() > 0
         || getBoardInteractionGuardRemaining() > 0;
@@ -148,9 +150,10 @@ function ensureRealtimeForceRefreshTimer() {
     }, maxRefreshDelayMs);
 }
 // Pending realtime refreshes are slug-scoped. They are dropped after
-// navigation, deferred while local interaction guards are active, retried after
-// max(realtimeRefetchDebounceMs, guardRemaining), and force-flushed after
-// maxRefreshDelayMs so the board eventually reloads.
+// navigation, deferred while drag/local interaction guards are active, retried
+// after max(realtimeRefetchDebounceMs, guardRemaining), and force-flushed after
+// maxRefreshDelayMs only for non-drag guards so active drags can never be
+// interrupted by a board rerender.
 function flushPendingRealtimeRefresh(force = false) {
     const slug = pendingRealtimeRefreshSlug;
     if (!slug) {
@@ -163,7 +166,13 @@ function flushPendingRealtimeRefresh(force = false) {
         clearPendingRealtimeRefresh();
         return;
     }
-    if (!force && isRealtimeRefreshBlocked()) {
+    if (isRealtimeRefreshBlockedByDrag()) {
+        debugLog("flushPendingRealtimeRefresh deferred because drag is active", slug);
+        clearRealtimeForceRefreshTimer();
+        scheduleRealtimeRefreshAttempt(getRealtimeRefreshDelay());
+        return;
+    }
+    if (!force && isRealtimeRefreshBlockedByNonDragGuard()) {
         debugLog("flushPendingRealtimeRefresh deferred because interaction guard active", slug);
         scheduleRealtimeRefreshAttempt(getRealtimeRefreshDelay());
         ensureRealtimeForceRefreshTimer();
@@ -200,7 +209,9 @@ function refetchBoardFromRealtime(slug) {
     pendingRealtimeRefreshSlug = slug;
     debugLog("refetchBoardFromRealtime queued invalidateBoard", slug);
     scheduleRealtimeRefreshAttempt(getRealtimeRefreshDelay());
-    ensureRealtimeForceRefreshTimer();
+    if (!isRealtimeRefreshBlockedByDrag()) {
+        ensureRealtimeForceRefreshTimer();
+    }
 }
 export function connectBoardEvents(slug) {
     if (boardEventsSlug === slug && (boardAnonSseManager !== null || boardRealtimeBound)) {
@@ -389,4 +400,30 @@ export function setInitialBoardLoadInFlight(slug) {
 export function markBoardLoadSucceeded(slug) {
     lastBoardLoadTimestamp = Date.now();
     lastSuccessfulBoardLoadSlug = slug;
+}
+export function __queuePendingRealtimeRefreshForTest(slug) {
+    refetchBoardFromRealtime(slug);
+}
+export function __flushPendingRealtimeRefreshForTest(force = false) {
+    flushPendingRealtimeRefresh(force);
+}
+export function __setTodoDialogOpeningInProgressForTest(active) {
+    todoDialogOpeningInProgress = active;
+}
+export function __getPendingRealtimeRefreshSlugForTest() {
+    return pendingRealtimeRefreshSlug;
+}
+export function __getRealtimeRefreshDebounceMsForTest() {
+    return realtimeRefetchDebounceMs;
+}
+export function __getMaxRefreshDelayMsForTest() {
+    return maxRefreshDelayMs;
+}
+export function __resetRealtimeRefreshStateForTest() {
+    clearPendingRealtimeRefresh();
+    clearBoardPointerReleaseTimer();
+    boardPointerInteractionActive = false;
+    todoDialogOpeningInProgress = false;
+    boardEventsSlug = null;
+    boardRealtimeBound = false;
 }

--- a/internal/httpapi/web/modules/charts/burndown.test.ts
+++ b/internal/httpapi/web/modules/charts/burndown.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { destroyBurndownChart, mountBurndownChart, renderRealBurndownChart } from './burndown.js';
+
+type BurndownSprint = {
+  name: string;
+  plannedStartAt: number;
+  plannedEndAt: number;
+};
+
+type UPlotCall = {
+  opts: any;
+  data: any;
+  targ: HTMLElement;
+};
+
+const uplotCalls: UPlotCall[] = [];
+
+function installFakeUPlot(): void {
+  (window as Window & { uPlot?: any }).uPlot = function FakeUPlot(this: any, opts: any, data: any, targ: HTMLElement) {
+    uplotCalls.push({ opts, data, targ });
+    this.destroy = vi.fn();
+    this.setSize = vi.fn();
+  };
+}
+
+function mountMarkup(
+  data: any[],
+  sprint: BurndownSprint,
+  dataIsSprintScoped = true
+): HTMLElement {
+  document.body.innerHTML = renderRealBurndownChart(data, sprint, { canPrev: false, canNext: false }, dataIsSprintScoped);
+  const mount = document.getElementById('burndown-uplot-mount');
+  if (!(mount instanceof HTMLElement)) {
+    throw new Error('missing burndown mount');
+  }
+  return mount;
+}
+
+describe('charts/burndown', () => {
+  beforeEach(() => {
+    uplotCalls.length = 0;
+    installFakeUPlot();
+    vi.stubGlobal('requestAnimationFrame', ((cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    }) as typeof requestAnimationFrame);
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    document.documentElement.style.setProperty('--border', '#d9d9d9');
+    document.documentElement.style.setProperty('--text', '#111111');
+    document.documentElement.style.setProperty('--muted', '#666666');
+    document.documentElement.style.setProperty('--accent', '#0066cc');
+  });
+
+  afterEach(() => {
+    destroyBurndownChart();
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete (window as Window & { uPlot?: any }).uPlot;
+  });
+
+  it('shows an explicit fallback instead of mounting a one-sample sprint burndown chart', () => {
+    const sprint: BurndownSprint = {
+      name: 'Sprint 1',
+      plannedStartAt: Date.parse('2026-04-13T12:00:00Z'),
+      plannedEndAt: Date.parse('2026-04-20T12:00:00Z'),
+    };
+    const data = [
+      { date: '2026-04-13T00:00:00Z', remainingWork: 5, initialScope: 5 },
+    ];
+
+    const mount = mountMarkup(data, sprint);
+    mountBurndownChart(mount, data, sprint, true);
+
+    expect(uplotCalls).toHaveLength(0);
+    expect(mount.textContent ?? '').toContain('Not enough burndown history yet');
+  });
+
+  it('shows the same one-sample fallback when sprint start is already at UTC midnight', () => {
+    const sprint: BurndownSprint = {
+      name: 'Sprint 1',
+      plannedStartAt: Date.parse('2026-04-13T00:00:00Z'),
+      plannedEndAt: Date.parse('2026-04-20T00:00:00Z'),
+    };
+    const data = [
+      { date: '2026-04-13T00:00:00Z', remainingWork: 5, initialScope: 5 },
+    ];
+
+    const mount = mountMarkup(data, sprint);
+    mountBurndownChart(mount, data, sprint, true);
+
+    expect(uplotCalls).toHaveLength(0);
+    expect(mount.textContent ?? '').toContain('Not enough burndown history yet');
+  });
+
+  it('uses UTC day-boundary X slots for multi-day sprint burndown data', () => {
+    const sprint: BurndownSprint = {
+      name: 'Sprint 1',
+      plannedStartAt: Date.parse('2026-04-13T12:00:00Z'),
+      plannedEndAt: Date.parse('2026-04-20T12:00:00Z'),
+    };
+    const data = [
+      { date: '2026-04-13T00:00:00Z', remainingWork: 8, initialScope: 8 },
+      { date: '2026-04-14T00:00:00Z', remainingWork: 5, initialScope: 8 },
+      { date: '2026-04-15T00:00:00Z', remainingWork: 2, initialScope: 8 },
+    ];
+
+    const mount = mountMarkup(data, sprint);
+    mountBurndownChart(mount, data, sprint, true);
+
+    expect(uplotCalls).toHaveLength(1);
+    const xValues = uplotCalls[0].data[0] as number[];
+    expect(xValues.every((sec) => sec % 86400 === 0)).toBe(true);
+    expect(xValues[xValues.length - 1]).toBe(Date.parse('2026-04-21T00:00:00Z') / 1000);
+    expect(uplotCalls[0].data[1].filter((value: number | null) => value != null)).toEqual([8, 5, 2]);
+    expect(uplotCalls[0].data[2][uplotCalls[0].data[2].length - 1]).toBe(0);
+    expect(document.querySelector('.burndown-chart__subtitle')?.textContent ?? '').toContain('Apr 13 - Apr 20');
+    expect(uplotCalls[0].opts.axes[0].values(null, [xValues[0], xValues[xValues.length - 1]])).toEqual(['Apr 13', 'Apr 21']);
+  });
+
+  it('preserves render-created fallback markup when there is no meaningful plot', () => {
+    const sprint: BurndownSprint = {
+      name: 'Sprint 1',
+      plannedStartAt: Date.parse('2026-04-13T12:00:00Z'),
+      plannedEndAt: Date.parse('2026-04-20T12:00:00Z'),
+    };
+    const data = [
+      { date: '2026-04-13T00:00:00Z', initialScope: 5 },
+    ];
+
+    const mount = mountMarkup(data, sprint);
+    expect(mount.textContent ?? '').toContain('No usable burndown data available.');
+
+    mountBurndownChart(mount, data, sprint, true);
+
+    expect(uplotCalls).toHaveLength(0);
+    expect(mount.textContent ?? '').toContain('No usable burndown data available.');
+  });
+
+  it('treats zero remaining values as valid visible samples in a multi-point series', () => {
+    const sprint: BurndownSprint = {
+      name: 'Sprint 1',
+      plannedStartAt: Date.parse('2026-04-13T12:00:00Z'),
+      plannedEndAt: Date.parse('2026-04-20T12:00:00Z'),
+    };
+    const data = [
+      { date: '2026-04-13T00:00:00Z', remainingWork: 3, initialScope: 3 },
+      { date: '2026-04-14T00:00:00Z', remainingWork: 1, initialScope: 3 },
+      { date: '2026-04-15T00:00:00Z', remainingWork: 0, initialScope: 3 },
+    ];
+
+    const mount = mountMarkup(data, sprint);
+    mountBurndownChart(mount, data, sprint, true);
+
+    expect(uplotCalls).toHaveLength(1);
+    expect(uplotCalls[0].data[1].filter((value: number | null) => value != null)).toEqual([3, 1, 0]);
+  });
+});

--- a/internal/httpapi/web/modules/charts/burndown.ts
+++ b/internal/httpapi/web/modules/charts/burndown.ts
@@ -41,13 +41,46 @@ function toTimestampMs(value: string | number): number | null {
 }
 
 function formatShortDate(tsMs: number): string {
-  return new Date(tsMs).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return new Date(tsMs).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+function startOfUtcDay(tsMs: number): number {
+  const d = new Date(tsMs);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}
+
+function resolveSprintChartBoundsMs(
+  currentSprint?: BurndownSprintFilter | null
+): { startMs: number; endMs: number; displayEndMs: number } | null {
+  if (!currentSprint) {
+    return null;
+  }
+
+  const sprintStartMs = toTimestampMs(currentSprint.plannedStartAt);
+  const sprintEndMs = toTimestampMs(currentSprint.plannedEndAt);
+  if (sprintStartMs == null || sprintEndMs == null || sprintEndMs < sprintStartMs) {
+    return null;
+  }
+
+  const startMs = startOfUtcDay(sprintStartMs);
+  const endMs = startOfUtcDay(sprintEndMs) + MS_PER_DAY;
+  const safeEndMs = endMs > startMs ? endMs : startMs + MS_PER_DAY;
+
+  return {
+    startMs,
+    endMs: safeEndMs,
+    displayEndMs: safeEndMs - 1,
+  };
 }
 
 function resolveTimeDomainMs(
   chartData: RealBurndownPoint[],
   currentSprint?: BurndownSprintFilter | null
-): { startMs: number; endMs: number; durationMs: number } | null {
+): { startMs: number; endMs: number; durationMs: number; displayEndMs: number } | null {
   const firstDataMs = toTimestampMs(chartData[0]?.date ?? '');
   const lastDataMs = toTimestampMs(chartData[chartData.length - 1]?.date ?? '');
   if (firstDataMs == null || lastDataMs == null) {
@@ -56,24 +89,25 @@ function resolveTimeDomainMs(
 
   let startMs = firstDataMs;
   let endMs = lastDataMs;
+  let displayEndMs = endMs;
 
-  if (currentSprint) {
-    const sprintStartMs = toTimestampMs(currentSprint.plannedStartAt);
-    const sprintEndMs = toTimestampMs(currentSprint.plannedEndAt);
-    if (sprintStartMs != null && sprintEndMs != null && sprintEndMs >= sprintStartMs) {
-      startMs = sprintStartMs;
-      endMs = sprintEndMs;
-    }
+  const sprintBounds = resolveSprintChartBoundsMs(currentSprint);
+  if (sprintBounds) {
+    startMs = sprintBounds.startMs;
+    endMs = sprintBounds.endMs;
+    displayEndMs = sprintBounds.displayEndMs;
   }
 
   if (endMs <= startMs) {
     endMs = startMs + MS_PER_DAY;
+    displayEndMs = endMs - 1;
   }
 
   return {
     startMs,
     endMs,
     durationMs: Math.max(endMs - startMs, 1),
+    displayEndMs,
   };
 }
 
@@ -89,17 +123,65 @@ function prepareChartData(
 
   // Skip date filter when data is already sprint-scoped (from backend sprint endpoint)
   if (currentSprint && !dataIsSprintScoped) {
-    const startMs = toTimestampMs(currentSprint.plannedStartAt);
-    const endMs = toTimestampMs(currentSprint.plannedEndAt);
-    if (startMs != null && endMs != null) {
+    const sprintBounds = resolveSprintChartBoundsMs(currentSprint);
+    if (sprintBounds) {
       chartData = chartData.filter((p) => {
         const t = toTimestampMs(p.date)!;
-        return t >= startMs && t <= endMs;
+        return t >= sprintBounds.startMs && t < sprintBounds.endMs;
       });
     }
   }
 
   return chartData;
+}
+
+function resolveUsePoints(
+  chartData: RealBurndownPoint[],
+  initialScopePoints: number | null
+): boolean {
+  const hasAnyPoints = chartData.some((p) => toNumeric(p.remainingPoints) != null);
+  return hasAnyPoints && initialScopePoints != null;
+}
+
+function countVisibleRealSamples(
+  chartData: RealBurndownPoint[],
+  usePoints: boolean
+): number {
+  let count = 0;
+  for (const point of chartData) {
+    const value = usePoints ? toNumeric(point.remainingPoints) : toNumeric(point.remainingWork);
+    if (value != null) {
+      count++;
+    }
+  }
+  return count;
+}
+
+function resolveFallbackMessage(
+  data: RealBurndownPoint[],
+  chartData: RealBurndownPoint[]
+): string | null {
+  if (!Array.isArray(data) || data.length === 0) {
+    return 'No data available. Create some todos to see the burndown chart.';
+  }
+  if (chartData.length === 0) {
+    return 'No data for this sprint. Create some todos during the sprint to see the burndown chart.';
+  }
+
+  const initialScopePoints =
+    toNumeric(chartData[0]?.initialScopePoints) != null
+      ? (toNumeric(chartData[0]?.initialScopePoints) as number)
+      : null;
+  const usePoints = resolveUsePoints(chartData, initialScopePoints);
+  const visibleRealSamples = countVisibleRealSamples(chartData, usePoints);
+
+  if (visibleRealSamples === 0) {
+    return 'No usable burndown data available.';
+  }
+  if (visibleRealSamples === 1) {
+    return 'Not enough burndown history yet. Check back after more sprint progress is recorded.';
+  }
+  return null;
 }
 
 /** Renders the chart wrapper HTML (header, nav, mount div). Does not draw the chart. */
@@ -110,29 +192,18 @@ export function renderRealBurndownChart(
   dataIsSprintScoped?: boolean
 ): string {
   const chartData = Array.isArray(data) && data.length > 0 ? prepareChartData(data, currentSprint, dataIsSprintScoped) : [];
-  const validPoints = chartData.filter((p) => toNumeric(p.remainingPoints) != null);
-  const validWork = chartData.filter((p) => toNumeric(p.remainingWork) != null);
-  const hasDataToPlot = validPoints.length > 0 || validWork.length > 0;
   const domain = chartData.length > 0 ? resolveTimeDomainMs(chartData, currentSprint) : null;
+  const noDataMessage = resolveFallbackMessage(data, chartData);
 
   let dateRangeSubtitle: string;
   if (domain) {
     dateRangeSubtitle = currentSprint
-      ? `${currentSprint.name} | ${formatShortDate(domain.startMs)} - ${formatShortDate(domain.endMs)}`
+      ? `${currentSprint.name} | ${formatShortDate(domain.startMs)} - ${formatShortDate(domain.displayEndMs)}`
       : `${formatShortDate(domain.startMs)} - ${formatShortDate(domain.endMs)}`;
   } else if (currentSprint) {
     dateRangeSubtitle = `${currentSprint.name} | No data`;
   } else {
     dateRangeSubtitle = 'No data available';
-  }
-
-  let noDataMessage: string | null = null;
-  if (!Array.isArray(data) || data.length === 0) {
-    noDataMessage = 'No data available. Create some todos to see the burndown chart.';
-  } else if (chartData.length === 0) {
-    noDataMessage = 'No data for this sprint. Create some todos during the sprint to see the burndown chart.';
-  } else if (!hasDataToPlot) {
-    noDataMessage = 'No usable burndown data available.';
   }
 
   const subtitleWithNav =
@@ -211,10 +282,9 @@ function buildUplotData(
 
   const { startMs, endMs, durationMs } = domain;
   const startSec = Math.floor(startMs / 1000);
-  const endSec = Math.ceil(endMs / 1000);
+  const endSec = Math.floor(endMs / 1000);
 
-  const hasAnyPoints = chartData.some((p) => toNumeric(p.remainingPoints) != null);
-  const usePoints = hasAnyPoints && initialScopePoints != null;
+  const usePoints = resolveUsePoints(chartData, initialScopePoints);
   const totalScope =
     usePoints && initialScopePoints != null ? initialScopePoints : initialScope;
 
@@ -319,6 +389,14 @@ export function mountBurndownChart(
   const chartData = prepareChartData(data, currentSprint, dataIsSprintScoped);
   if (chartData.length === 0) {
     return; // renderRealBurndownChart already put a message in the container
+  }
+
+  const fallbackMessage = resolveFallbackMessage(data, chartData);
+  if (fallbackMessage) {
+    if (!container.querySelector('.burndown-chart__no-data')) {
+      container.innerHTML = `<div class="burndown-chart__no-data muted">${fallbackMessage}</div>`;
+    }
+    return;
   }
 
   const border = getThemeColor('--border');
@@ -453,7 +531,11 @@ export function mountBurndownChart(
         values: (_u: any, vals: number[]) =>
           vals.map((v) => {
             const d = new Date(v * 1000); // scale values are in seconds
-            return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+            return d.toLocaleDateString('en-US', {
+              month: 'short',
+              day: 'numeric',
+              timeZone: 'UTC',
+            });
           }),
       },
       {

--- a/internal/httpapi/web/modules/dialogs/settings-charts.test.ts
+++ b/internal/httpapi/web/modules/dialogs/settings-charts.test.ts
@@ -1,0 +1,232 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  apiFetchMock,
+  fetchProjectMembersMock,
+  loadTagSettingsContentMock,
+  mountBurndownChartMock,
+  destroyBurndownChartMock,
+} = vi.hoisted(() => ({
+  apiFetchMock: vi.fn(),
+  fetchProjectMembersMock: vi.fn(),
+  loadTagSettingsContentMock: vi.fn().mockResolvedValue(''),
+  mountBurndownChartMock: vi.fn(),
+  destroyBurndownChartMock: vi.fn(),
+}));
+
+vi.mock('../api.js', () => ({
+  apiFetch: apiFetchMock,
+}));
+
+vi.mock('../members-cache.js', () => ({
+  fetchProjectMembers: fetchProjectMembersMock,
+}));
+
+vi.mock('../utils.js', () => ({
+  escapeHTML: (s: string) =>
+    String(s)
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#039;'),
+  showToast: vi.fn(),
+  getAppVersion: () => 'test-version',
+  showConfirmDialog: vi.fn(),
+  confirmDelete: vi.fn(),
+  isAnonymousBoard: () => false,
+  renderUserAvatar: () => '',
+  processImageFile: vi.fn(),
+  processWallpaperFileForUpload: vi.fn(),
+  renderAvatarContent: () => '',
+  sanitizeHexColor: (color?: string | null, fallback?: string | null) => color ?? fallback ?? null,
+}));
+
+vi.mock('../theme.js', () => ({
+  getStoredTheme: () => 'system',
+  handleThemeChange: vi.fn(),
+  THEME_SYSTEM: 'system',
+  THEME_DARK: 'dark',
+  THEME_LIGHT: 'light',
+}));
+
+vi.mock('../wallpaper.js', () => ({
+  getStoredWallpaperState: () => ({ mode: 'off' }),
+  setWallpaperOff: vi.fn(),
+  setWallpaperColor: vi.fn(),
+  uploadWallpaperImage: vi.fn(),
+}));
+
+vi.mock('../charts/burndown.js', () => ({
+  renderRealBurndownChart: (
+    _data: any[],
+    currentSprint?: { id?: number; name?: string } | null,
+    sprintNav?: { canPrev: boolean; canNext: boolean }
+  ) => `
+    <div class="burndown-chart" data-current-sprint-id="${currentSprint?.id ?? ''}">
+      <button id="burndown-prev" ${!sprintNav?.canPrev ? 'disabled' : ''} type="button">Prev</button>
+      <div id="burndown-current-sprint">${currentSprint?.name ?? 'No sprint'}</div>
+      <button id="burndown-next" ${!sprintNav?.canNext ? 'disabled' : ''} type="button">Next</button>
+      <div id="burndown-uplot-mount"></div>
+    </div>
+  `,
+  destroyBurndownChart: destroyBurndownChartMock,
+  mountBurndownChart: mountBurndownChartMock,
+}));
+
+vi.mock('../events.js', () => ({
+  emit: vi.fn(),
+}));
+
+vi.mock('../sprints.js', () => ({
+  normalizeSprints: (value: { sprints?: any[] } | null | undefined) => value?.sprints ?? [],
+}));
+
+vi.mock('../core/keybindings.js', () => ({
+  KEY_ACTION_LIST: [],
+  chordFromKeyboardEvent: vi.fn(),
+  formatChordForDisplay: () => '',
+  getResolvedChordForAction: () => '',
+  isTypingInTextField: () => false,
+  reloadKeybindingsFromStorage: vi.fn(),
+  saveKeybindingOverride: vi.fn(),
+  setKeybindingsCaptureListening: vi.fn(),
+}));
+
+vi.mock('../core/assignmentNotify.js', () => ({
+  requestDesktopNotificationPermission: vi.fn(),
+  getDesktopNotificationStatusDescription: () => '',
+}));
+
+vi.mock('../core/push.js', () => ({
+  isPushSubscribed: vi.fn(),
+  subscribeToPush: vi.fn(),
+  unsubscribeFromPush: vi.fn(),
+}));
+
+vi.mock('../core/voiceflow-preferences.js', () => ({
+  getVoiceFlowEnabledPreference: () => false,
+  setVoiceFlowEnabledPreference: vi.fn(),
+}));
+
+vi.mock('./settings-workflow.js', () => ({
+  bindWorkflowTabInteractions: vi.fn(),
+  clearWorkflowDraftState: vi.fn(),
+  invalidateWorkflowLaneCountsCache: vi.fn(),
+  isWorkflowDraftDirty: () => false,
+  loadWorkflowTabContent: () => '',
+  resetWorkflowDraftToBaseline: vi.fn(),
+}));
+
+vi.mock('./settings-tags.js', () => ({
+  bindTagTabInteractions: vi.fn(),
+  invalidateTagsCache: vi.fn(),
+  loadTagSettingsContent: loadTagSettingsContentMock,
+}));
+
+vi.mock('./settings-sprints.js', () => ({
+  bindSprintsTabInteractions: vi.fn(),
+  renderSprintsTabContent: vi.fn().mockResolvedValue(''),
+}));
+
+function installBaseDOM(): void {
+  document.body.innerHTML = `
+    <dialog id="settingsDialog">
+      <div class="dialog__title"></div>
+      <div class="dialog__content"></div>
+    </dialog>
+    <button id="closeSettingsBtn" type="button"></button>
+  `;
+}
+
+async function flushPromises(count = 8): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await Promise.resolve();
+  }
+}
+
+async function loadSettingsModule() {
+  const mod = await import('./settings.js');
+  return mod;
+}
+
+async function loadStateMutations() {
+  const mod = await import('../state/mutations.js');
+  return mod;
+}
+
+describe('settings-charts', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    installBaseDOM();
+    window.history.replaceState({}, '', '/alpha');
+    apiFetchMock.mockReset();
+    fetchProjectMembersMock.mockReset();
+    fetchProjectMembersMock.mockResolvedValue([]);
+    loadTagSettingsContentMock.mockClear();
+    mountBurndownChartMock.mockClear();
+    destroyBurndownChartMock.mockClear();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    }));
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('preserves the selected sprint and fetches that sprint burndown URL after next navigation', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/board/alpha/sprints') {
+        return {
+          sprints: [
+            { id: 1, name: 'Sprint 1', state: 'CLOSED', plannedStartAt: 1000, plannedEndAt: 2000 },
+            { id: 2, name: 'Sprint 2', state: 'ACTIVE', plannedStartAt: 3000, plannedEndAt: 4000 },
+            { id: 3, name: 'Sprint 3', state: 'PLANNED', plannedStartAt: 5000, plannedEndAt: 6000 },
+          ],
+        };
+      }
+      if (url === '/api/board/alpha/sprints/2/burndown') {
+        return [{ date: '2026-04-13T00:00:00Z', remainingWork: 5, initialScope: 5 }];
+      }
+      if (url === '/api/board/alpha/sprints/3/burndown') {
+        return [{ date: '2026-04-20T00:00:00Z', remainingWork: 4, initialScope: 4 }];
+      }
+      throw new Error(`unexpected apiFetch url: ${url}`);
+    });
+
+    const settings = await loadSettingsModule();
+    const state = await loadStateMutations();
+    state.setAuthStatusAvailable(true);
+    state.setSlug('alpha');
+    state.setUser(null);
+    state.setBoard(null);
+    state.setProjects(null);
+    state.setProjectId(null);
+    state.setSettingsProjectId(null);
+    state.setSettingsActiveTab('charts');
+    state.setBoardMembers([]);
+
+    await settings.renderSettingsModal();
+    expect((document.getElementById('burndown-current-sprint')?.textContent ?? '').trim()).toBe('Sprint 2');
+
+    const nextBtn = document.getElementById('burndown-next');
+    if (!(nextBtn instanceof HTMLButtonElement)) {
+      throw new Error('missing next button');
+    }
+    nextBtn.click();
+    await flushPromises();
+
+    expect((document.getElementById('burndown-current-sprint')?.textContent ?? '').trim()).toBe('Sprint 3');
+
+    const burndownUrls = apiFetchMock.mock.calls
+      .map((args) => args[0])
+      .filter((url): url is string => typeof url === 'string' && url.endsWith('/burndown'));
+    expect(burndownUrls[burndownUrls.length - 1]).toBe('/api/board/alpha/sprints/3/burndown');
+  });
+});

--- a/internal/httpapi/web/modules/dialogs/settings.ts
+++ b/internal/httpapi/web/modules/dialogs/settings.ts
@@ -124,6 +124,7 @@ let burndownSprintIndex = 0;
 let cachedRealBurndownData: any[] | null = null;
 let cachedRealBurndownURL: string | null = null;
 let cachedSprintsForCharts: { id: number; name: string; plannedStartAt: number; plannedEndAt: number; state?: string }[] | null = null;
+let cachedSprintsForChartsSlug: string | null = null;
 
 /** Update all user-avatar elements outside the settings dialog (e.g. topbar) after avatar change. */
 function refreshAvatarsOutsideSettings(): void {
@@ -201,6 +202,7 @@ function computeDefaultBurndownSprintIndex(
 
 function invalidateSprintsForChartsCache(): void {
   cachedSprintsForCharts = null;
+  cachedSprintsForChartsSlug = null;
   cachedRealBurndownData = null;
   cachedRealBurndownURL = null;
 }
@@ -948,8 +950,6 @@ export async function renderSettingsModal(options?: { skipProfileRefetch?: boole
   let tagsHTML = "";
   let realBurndownData: any[] = [];
   
-  const realBurndownURLChanged = cachedRealBurndownURL !== realBurndownURL;
-  
   if (hasProjectAccess) {
     try {
       tagsHTML = await loadTagSettingsContent(tagsURL!);
@@ -959,19 +959,26 @@ export async function renderSettingsModal(options?: { skipProfileRefetch?: boole
       if (activeTab === "charts") {
         // Fetch sprints for burndown navigation
         const slug = getSlug();
-        if (slug && (cachedSprintsForCharts === null || realBurndownURLChanged)) {
+        if (!slug) {
+          cachedSprintsForCharts = null;
+          cachedSprintsForChartsSlug = null;
+        }
+        if (slug && (cachedSprintsForCharts === null || cachedSprintsForChartsSlug !== slug)) {
           try {
             const sprintsRes = await apiFetch<{ sprints?: { id: number; name: string; plannedStartAt: number; plannedEndAt: number; state?: string }[] } | null>(`/api/board/${slug}/sprints`);
             const rawSprints = normalizeSprints(sprintsRes);
             cachedSprintsForCharts = [...rawSprints].sort((a, b) => a.plannedStartAt - b.plannedStartAt);
+            cachedSprintsForChartsSlug = slug;
             // Auto-select sprint: active > last closed > first planned
             burndownSprintIndex = computeDefaultBurndownSprintIndex(cachedSprintsForCharts);
           } catch {
             cachedSprintsForCharts = [];
+            cachedSprintsForChartsSlug = slug;
+            burndownSprintIndex = 0;
           }
         }
         // When a sprint is selected in board view, use sprint-scoped burndown endpoint
-        const sprints = cachedSprintsForCharts ?? [];
+        const sprints = slug ? (cachedSprintsForCharts ?? []) : [];
         const burndownSprintIndexClamped = sprints.length > 0 ? Math.min(burndownSprintIndex, sprints.length - 1) : 0;
         const currentSprintForFetch = sprints.length > 0 ? sprints[burndownSprintIndexClamped] : null;
         const effectiveBurndownURL =
@@ -1008,6 +1015,8 @@ export async function renderSettingsModal(options?: { skipProfileRefetch?: boole
   } else {
     // No project access - clear cache
     invalidateTagSettingsCache();
+    cachedSprintsForCharts = null;
+    cachedSprintsForChartsSlug = null;
     cachedRealBurndownData = null;
     cachedRealBurndownURL = null;
   }

--- a/internal/httpapi/web/modules/views/board-realtime.test.ts
+++ b/internal/httpapi/web/modules/views/board-realtime.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  invalidateBoardMock,
+  dragState,
+  selectorState,
+  guardState,
+} = vi.hoisted(() => ({
+  invalidateBoardMock: vi.fn().mockResolvedValue(undefined),
+  dragState: { value: false },
+  selectorState: {
+    slug: "alpha",
+    tag: "bug",
+    search: "login",
+    sprintId: "7",
+    authStatusAvailable: false,
+    user: null as { id: number } | null,
+    projectId: null as number | null,
+  },
+  guardState: {
+    lastBoardInteractionTimestamp: 0,
+    lastLocalMutationTimestamp: 0,
+    bulkUpdating: false,
+  },
+}));
+
+vi.mock("../utils.js", () => ({
+  showToast: vi.fn(),
+}));
+
+vi.mock("../state/selectors.js", () => ({
+  getAuthStatusAvailable: () => selectorState.authStatusAvailable,
+  getProjectId: () => selectorState.projectId,
+  getSlug: () => selectorState.slug,
+  getTag: () => selectorState.tag,
+  getSearch: () => selectorState.search,
+  getSprintIdFromUrl: () => selectorState.sprintId,
+  getUser: () => selectorState.user,
+}));
+
+vi.mock("../members-cache.js", () => ({
+  invalidateMembersCache: vi.fn(),
+}));
+
+vi.mock("../events.js", () => ({
+  on: vi.fn(),
+  off: vi.fn(),
+  emit: vi.fn(),
+}));
+
+vi.mock("../realtime/guard.js", () => ({
+  getLastBoardInteractionTimestamp: () => guardState.lastBoardInteractionTimestamp,
+  getLastLocalMutationTimestamp: () => guardState.lastLocalMutationTimestamp,
+  recordBoardInteraction: vi.fn(() => {
+    guardState.lastBoardInteractionTimestamp = Date.now();
+  }),
+  isBulkUpdating: () => guardState.bulkUpdating,
+}));
+
+vi.mock("../core/assignmentNotify.js", () => ({
+  playAssignmentSound: vi.fn(),
+  showAssignmentDesktopNotification: vi.fn(),
+}));
+
+vi.mock("../core/sse-client.js", () => ({
+  SseConnectionManager: class {
+    open(): void {}
+    stop(): void {}
+    restartRequested(): void {}
+  },
+}));
+
+vi.mock("../core/realtime.js", () => ({
+  registerAnonymousSseRestart: vi.fn(),
+}));
+
+vi.mock("../orchestration/board-refresh.js", () => ({
+  invalidateBoard: invalidateBoardMock,
+}));
+
+vi.mock("../features/drag-drop.js", () => ({
+  get dragInProgress() {
+    return dragState.value;
+  },
+}));
+
+vi.mock("./board-selection.js", () => ({
+  clearTodoMultiSelection: vi.fn(),
+  updateBulkEditBar: vi.fn(),
+}));
+
+async function loadBoardRealtimeModule() {
+  const mod = await import("./board-realtime.js");
+  mod.__resetRealtimeRefreshStateForTest();
+  return mod;
+}
+
+describe("board-realtime drag refresh guards", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-26T12:00:00Z"));
+    vi.resetModules();
+    invalidateBoardMock.mockReset();
+    invalidateBoardMock.mockResolvedValue(undefined);
+    dragState.value = false;
+    selectorState.slug = "alpha";
+    selectorState.tag = "bug";
+    selectorState.search = "login";
+    selectorState.sprintId = "7";
+    selectorState.authStatusAvailable = false;
+    selectorState.user = null;
+    selectorState.projectId = null;
+    guardState.lastBoardInteractionTimestamp = 0;
+    guardState.lastLocalMutationTimestamp = 0;
+    guardState.bulkUpdating = false;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("does not call invalidateBoard during drag even after the max delay or a forced flush", async () => {
+    const mod = await loadBoardRealtimeModule();
+    dragState.value = true;
+
+    mod.__queuePendingRealtimeRefreshForTest("alpha");
+    vi.advanceTimersByTime(mod.__getMaxRefreshDelayMsForTest() + 500);
+    mod.__flushPendingRealtimeRefreshForTest(true);
+
+    expect(invalidateBoardMock).not.toHaveBeenCalled();
+    expect(mod.__getPendingRealtimeRefreshSlugForTest()).toBe("alpha");
+  });
+
+  it("flushes a queued refresh exactly once after drag ends", async () => {
+    const mod = await loadBoardRealtimeModule();
+    dragState.value = true;
+
+    mod.__queuePendingRealtimeRefreshForTest("alpha");
+    vi.advanceTimersByTime(mod.__getMaxRefreshDelayMsForTest() + 500);
+    expect(invalidateBoardMock).not.toHaveBeenCalled();
+
+    dragState.value = false;
+    vi.advanceTimersByTime(mod.__getRealtimeRefreshDebounceMsForTest() + 5);
+
+    expect(invalidateBoardMock).toHaveBeenCalledTimes(1);
+    expect(invalidateBoardMock).toHaveBeenCalledWith("alpha", "bug", "login", "7");
+    expect(mod.__getPendingRealtimeRefreshSlugForTest()).toBeNull();
+
+    vi.advanceTimersByTime(mod.__getMaxRefreshDelayMsForTest());
+    expect(invalidateBoardMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces multiple queued refreshes during drag into one post-drag invalidate", async () => {
+    const mod = await loadBoardRealtimeModule();
+    dragState.value = true;
+
+    mod.__queuePendingRealtimeRefreshForTest("alpha");
+    mod.__queuePendingRealtimeRefreshForTest("alpha");
+    mod.__queuePendingRealtimeRefreshForTest("alpha");
+    vi.advanceTimersByTime(mod.__getMaxRefreshDelayMsForTest() + 500);
+    expect(invalidateBoardMock).not.toHaveBeenCalled();
+
+    dragState.value = false;
+    vi.advanceTimersByTime(mod.__getRealtimeRefreshDebounceMsForTest() + 5);
+
+    expect(invalidateBoardMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the queued refresh behind the board interaction guard immediately after drag completion", async () => {
+    const mod = await loadBoardRealtimeModule();
+    dragState.value = true;
+
+    mod.__queuePendingRealtimeRefreshForTest("alpha");
+
+    dragState.value = false;
+    guardState.lastBoardInteractionTimestamp = Date.now();
+    mod.__flushPendingRealtimeRefreshForTest();
+
+    expect(invalidateBoardMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(mod.__getRealtimeRefreshDebounceMsForTest() - 1);
+    expect(invalidateBoardMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2);
+    expect(invalidateBoardMock).toHaveBeenCalledTimes(1);
+    expect(invalidateBoardMock).toHaveBeenCalledWith("alpha", "bug", "login", "7");
+  });
+
+  it("preserves the old force-flush behavior for non-drag guards", async () => {
+    const mod = await loadBoardRealtimeModule();
+    mod.__setTodoDialogOpeningInProgressForTest(true);
+
+    mod.__queuePendingRealtimeRefreshForTest("alpha");
+    vi.advanceTimersByTime(mod.__getMaxRefreshDelayMsForTest() - 10);
+    expect(invalidateBoardMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(20);
+    expect(invalidateBoardMock).toHaveBeenCalledTimes(1);
+    expect(invalidateBoardMock).toHaveBeenCalledWith("alpha", "bug", "login", "7");
+  });
+});

--- a/internal/httpapi/web/modules/views/board-realtime.ts
+++ b/internal/httpapi/web/modules/views/board-realtime.ts
@@ -157,9 +157,12 @@ function getBoardInteractionGuardRemaining(): number {
   return Math.max(0, boardInteractionGuardMs - (Date.now() - getLastBoardInteractionTimestamp()));
 }
 
-function isRealtimeRefreshBlocked(): boolean {
-  return dragInProgress
-    || boardPointerInteractionActive
+function isRealtimeRefreshBlockedByDrag(): boolean {
+  return dragInProgress;
+}
+
+function isRealtimeRefreshBlockedByNonDragGuard(): boolean {
+  return boardPointerInteractionActive
     || todoDialogOpeningInProgress
     || getLocalRealtimeGuardRemaining() > 0
     || getBoardInteractionGuardRemaining() > 0;
@@ -187,9 +190,10 @@ function ensureRealtimeForceRefreshTimer(): void {
 }
 
 // Pending realtime refreshes are slug-scoped. They are dropped after
-// navigation, deferred while local interaction guards are active, retried after
-// max(realtimeRefetchDebounceMs, guardRemaining), and force-flushed after
-// maxRefreshDelayMs so the board eventually reloads.
+// navigation, deferred while drag/local interaction guards are active, retried
+// after max(realtimeRefetchDebounceMs, guardRemaining), and force-flushed after
+// maxRefreshDelayMs only for non-drag guards so active drags can never be
+// interrupted by a board rerender.
 function flushPendingRealtimeRefresh(force = false): void {
   const slug = pendingRealtimeRefreshSlug;
   if (!slug) {
@@ -204,7 +208,14 @@ function flushPendingRealtimeRefresh(force = false): void {
     return;
   }
 
-  if (!force && isRealtimeRefreshBlocked()) {
+  if (isRealtimeRefreshBlockedByDrag()) {
+    debugLog("flushPendingRealtimeRefresh deferred because drag is active", slug);
+    clearRealtimeForceRefreshTimer();
+    scheduleRealtimeRefreshAttempt(getRealtimeRefreshDelay());
+    return;
+  }
+
+  if (!force && isRealtimeRefreshBlockedByNonDragGuard()) {
     debugLog("flushPendingRealtimeRefresh deferred because interaction guard active", slug);
     scheduleRealtimeRefreshAttempt(getRealtimeRefreshDelay());
     ensureRealtimeForceRefreshTimer();
@@ -242,7 +253,9 @@ function refetchBoardFromRealtime(slug: string): void {
   pendingRealtimeRefreshSlug = slug;
   debugLog("refetchBoardFromRealtime queued invalidateBoard", slug);
   scheduleRealtimeRefreshAttempt(getRealtimeRefreshDelay());
-  ensureRealtimeForceRefreshTimer();
+  if (!isRealtimeRefreshBlockedByDrag()) {
+    ensureRealtimeForceRefreshTimer();
+  }
 }
 
 export function connectBoardEvents(slug: string): void {
@@ -431,4 +444,37 @@ export function setInitialBoardLoadInFlight(slug: string | null): void {
 export function markBoardLoadSucceeded(slug: string): void {
   lastBoardLoadTimestamp = Date.now();
   lastSuccessfulBoardLoadSlug = slug;
+}
+
+export function __queuePendingRealtimeRefreshForTest(slug: string): void {
+  refetchBoardFromRealtime(slug);
+}
+
+export function __flushPendingRealtimeRefreshForTest(force = false): void {
+  flushPendingRealtimeRefresh(force);
+}
+
+export function __setTodoDialogOpeningInProgressForTest(active: boolean): void {
+  todoDialogOpeningInProgress = active;
+}
+
+export function __getPendingRealtimeRefreshSlugForTest(): string | null {
+  return pendingRealtimeRefreshSlug;
+}
+
+export function __getRealtimeRefreshDebounceMsForTest(): number {
+  return realtimeRefetchDebounceMs;
+}
+
+export function __getMaxRefreshDelayMsForTest(): number {
+  return maxRefreshDelayMs;
+}
+
+export function __resetRealtimeRefreshStateForTest(): void {
+  clearPendingRealtimeRefresh();
+  clearBoardPointerReleaseTimer();
+  boardPointerInteractionActive = false;
+  todoDialogOpeningInProgress = false;
+  boardEventsSlug = null;
+  boardRealtimeBound = false;
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.16.0"
+const Version = "3.16.1"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
Fixed the following items:

- **Real burndown chart (sprint domain)** - Sprint charts use UTC day boundaries for the time axis and subtitle range, filter sprint points with half-open day intervals, and show clear fallback copy when data is empty, sprint-scoped but unusable, or only a single sample (instead of mounting a misleading one-point chart).

- **Settings → Charts burndown** - Sprint list cache invalidates when the active board slug changes, so burndown navigation and sprint-scoped fetches stay aligned after switching projects.

- **Board realtime refresh during drag** - SSE-driven board reloads no longer schedule a forced refresh while a card drag is active, and drag-in-progress always defers (never force-flushes) pending refreshes, fixing intermittent freezes when moving notes between lanes.
