### PR TITLE
Fix/i18n rtl layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > **Upgrades:** No breaking changes in **3.7.x** / **3.8.x** / **3.9.x** / **3.10.x** / **3.11.x** / **3.12.x** / **3.13.x** / **3.14.x** / **3.15.x** / **3.16.x** / **3.17.x** / **3.18.x** unless noted below.
 
+## [3.18.4] - 2026-06-17
+
+### Fixed
+
+- **Arabic Settings modal on mobile** - Settings dialog shell is explicitly viewport-centered on narrow RTL viewports so it stays fully visible; modal content remains RTL.
+
 ## [3.18.3] - 2026-06-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.18.3-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.18.4-blue" alt="version" />
   <a href="LICENSE">
     <img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" />
   </a>

--- a/internal/httpapi/web/styles.css
+++ b/internal/httpapi/web/styles.css
@@ -1586,6 +1586,27 @@ html[data-wallpaper-active] #settingsDialog.dialog {
   }
 }
 
+/* RTL mobile: explicitly viewport-center the Settings shell to avoid off-screen horizontal drift. */
+@media (max-width: 767px) {
+  [dir="rtl"] #settingsDialog.dialog {
+    left: 0;
+    right: 0;
+    margin-left: auto;
+    margin-right: auto;
+    transform: translateY(-50%);
+    width: min(720px, calc(100vw - 24px));
+    max-width: calc(100vw - 24px);
+    box-sizing: border-box;
+  }
+}
+
+@media (max-width: 620px) {
+  [dir="rtl"] #settingsDialog.dialog {
+    width: calc(100vw - 16px);
+    max-width: calc(100vw - 16px);
+  }
+}
+
 .dialog[open] {
   display: flex;
   flex-direction: column;

--- a/internal/httpapi/web_assets_test.go
+++ b/internal/httpapi/web_assets_test.go
@@ -112,6 +112,40 @@ func TestWebStyles_CardDoingAliasForWorkflowKey(t *testing.T) {
 	}
 }
 
+func TestWebStyles_SettingsDialog_RtlMobileCentering(t *testing.T) {
+	css, err := embeddedWeb.ReadFile("web/styles.css")
+	if err != nil {
+		t.Fatalf("read embedded styles.css: %v", err)
+	}
+	s := string(css)
+	if !strings.Contains(s, `[dir="rtl"] #settingsDialog.dialog`) {
+		t.Fatalf("expected RTL mobile Settings dialog centering selector")
+	}
+	re := regexp.MustCompile(`(?s)@media \(max-width: 767px\)\s*\{\s*\[dir="rtl"\] #settingsDialog\.dialog\s*\{[^}]+\}`)
+	if !re.Match(css) {
+		t.Fatalf("expected @media (max-width: 767px) block for RTL Settings dialog centering")
+	}
+	block := re.FindString(s)
+	for _, needle := range []string{
+		"margin-left: auto",
+		"margin-right: auto",
+		"transform: translateY(-50%)",
+		"max-width: calc(100vw - 24px)",
+	} {
+		if !strings.Contains(block, needle) {
+			t.Fatalf("expected RTL Settings mobile centering block to contain %q", needle)
+		}
+	}
+	re620 := regexp.MustCompile(`(?s)@media \(max-width: 620px\)\s*\{\s*\[dir="rtl"\] #settingsDialog\.dialog\s*\{[^}]+\}`)
+	if !re620.Match(css) {
+		t.Fatalf("expected @media (max-width: 620px) block for RTL Settings dialog width")
+	}
+	block620 := re620.FindString(s)
+	if !strings.Contains(block620, "max-width: calc(100vw - 16px)") {
+		t.Fatalf("expected narrow-mobile RTL Settings block to cap width at calc(100vw - 16px)")
+	}
+}
+
 func TestWebBoard_MobileTabLegacyResolutionAndSync(t *testing.T) {
 	boardTs, err := embeddedWeb.ReadFile("web/modules/views/board.ts")
 	if err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.18.3"
+const Version = "3.18.4"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
i18n: Fixed centering for right-to-left languages such as Arabic.