### PR TITLE
updated architectural diagrams to converge with recent substantial i18n updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > **Upgrades:** No breaking changes in **3.7.x** / **3.8.x** / **3.9.x** / **3.10.x** / **3.11.x** / **3.12.x** / **3.13.x** / **3.14.x** / **3.15.x** / **3.16.x** / **3.17.x** / **3.18.x** unless noted below.
 
+## [3.18.12] - 2026-06-18
+
+### Documentation
+
+- **Architecture diagrams** - Brought `docs/diagrams/` up to date through 3.18.x (i18n catalogs, locale picker, API error localization, encryption-key startup, field tooltips, pre-auth locale picker); viewer header date set to June 18th 2026.
+
 ## [3.18.11] - 2026-06-18
 
 ### Added
@@ -19,7 +25,7 @@
 ### Added
 
 - **Hindi UI** - Full frontend catalog (`hi`) with India flag in the public locale picker.
-
+    
 ### Changed
 
 - **Locale flag SVGs** - Optimized all vendored flags under `internal/httpapi/web/assets/flags/` with SVGO (`--multipass --final-newline`); normalized UTF-16/BOM encodings on `cn.svg`, `kr.svg`, `tr.svg`, `pk.svg`, and `th.svg` so the assets parse cleanly. Total flag payload ~12% smaller with unchanged visuals.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > **Upgrades:** No breaking changes in **3.7.x** / **3.8.x** / **3.9.x** / **3.10.x** / **3.11.x** / **3.12.x** / **3.13.x** / **3.14.x** / **3.15.x** / **3.16.x** / **3.17.x** / **3.18.x** unless noted below.
 
+## [3.18.11] - 2026-06-18
+
+### Added
+
+- **Italian UI** - Full frontend catalog (`it`) with Italy flag in the public locale picker.
+
 ## [3.18.10] - 2026-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.18.11-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.18.12-blue" alt="version" />
   <a href="LICENSE">
     <img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" />
   </a>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.18.10-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.18.11-blue" alt="version" />
   <a href="LICENSE">
     <img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" />
   </a>
@@ -188,7 +188,7 @@ Simplicity of a light Kanban, with the power of structured systems: Roles, sprin
 
 - PWA: Excellent UX for mobile users.
 
-- Multi-language UI: English, Deutsch, Français, Português (Brasil), Español (Latinoamérica), العربية, Русский, 日本語, Türkçe, 한국어, 简体中文, Bahasa Indonesia, Tiếng Việt, ไทย, اردو, and हिन्दी. The app can infer language from the browser or you can switch it in `Settings -> Language`. The pseudo-locale is reserved for localhost/dev QA.
+- Multi-language UI: English, 简体中文, हिन्दी, Español (Latinoamérica), العربية, Français, Português (Brasil), Bahasa Indonesia, اردو, Русский, Deutsch, 日本語, Tiếng Việt, Türkçe, 한국어, Italiano, and ไทย. The app can infer language from the browser or you can switch it in `Settings -> Language`.
 
 - Anonymous shareable boards can be created in both Full & Anonymous deployments.
 

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -47,4 +47,4 @@ The viewer ports Scrumboy's semantic edge coloring (`mermaid-semantic-edges.js` 
 | [scrumboy_voiceflow.md](scrumboy_voiceflow.md) | Speech commands; UI localized, grammar English-centric |
 | [scrumboy_wall_canvas.md](scrumboy_wall_canvas.md) | Scrumbaby wall canvas |
 | [scrumboy_backup_import.md](scrumboy_backup_import.md) | Backup JSON and Trello import |
-| [scrumboy_frontend_spa.md](scrumboy_frontend_spa.md) | SPA router, state, locale runtime |
+| [scrumboy_frontend_spa.md](scrumboy_frontend_spa.md) | SPA router, state, i18n catalogs, locale picker, API error localization |

--- a/docs/diagrams/index.html
+++ b/docs/diagrams/index.html
@@ -496,7 +496,7 @@
 </head>
 <body>
   <header>
-    <h1>Scrumboy architecture (as of: June 7th 2026)</h1>
+    <h1>Scrumboy architecture (as of June 18th 2026)</h1>
     <p>Go monolith + embedded SPA + SQLite - sourced from <code>docs/diagrams/*.md</code></p>
   </header>
 
@@ -598,7 +598,7 @@
       frontend: {
         label: "Frontend",
         docs: [
-          { file: "scrumboy_frontend_spa.md", title: "Frontend SPA", desc: "Router state locale runtime" },
+          { file: "scrumboy_frontend_spa.md", title: "Frontend SPA", desc: "Router state i18n locale picker API errors" },
         ],
       },
     };

--- a/docs/diagrams/scrumboy_auth_permissions.md
+++ b/docs/diagrams/scrumboy_auth_permissions.md
@@ -37,5 +37,7 @@ flowchart LR
 - **Full mode:** sessions, users, API tokens, admin routes
 - **Anonymous mode:** `requestContext` ignores cookies; temp boards have no owner until claimed
 - **2FA:** requires `SCRUMBOY_ENCRYPTION_KEY` when any user has TOTP enabled
+- **Pre-auth locale picker:** auth shell (sign-in, bootstrap, 2FA, password reset) exposes the shared public locale listbox in the topbar; copy comes from the i18n bootstrap catalog until the full locale JSON loads.
+- **Post-login redirect:** bootstrap, login, and 2FA completion redirect via sanitized `next` from auth state (strips stale OIDC query noise).
 
 See `docs/roles_and_permissions.md` for role matrix detail.

--- a/docs/diagrams/scrumboy_board_kanban.md
+++ b/docs/diagrams/scrumboy_board_kanban.md
@@ -54,4 +54,4 @@ flowchart LR
 
 Projects may add lanes (up to store limit), rename labels, recolor columns, reorder them, and choose which lane counts as done. Todos reference lanes by `column_key`, not a fixed enum.
 
-Lane colors and sprint chips use `styles.css` CSS variables. Sprints filter board scope via `sprintId` query param; tags and search filters apply client-side in `board-filters.ts`.
+Lane colors and sprint chips use `styles.css` CSS variables. Sprints filter board scope via `sprintId` query param; tags and search filters apply client-side in `board-filters.ts`. Agile field labels and native `title` hover hints (`field-tooltips.ts`) localize with the active locale.

--- a/docs/diagrams/scrumboy_bootstrap.md
+++ b/docs/diagrams/scrumboy_bootstrap.md
@@ -7,6 +7,7 @@ flowchart LR
   Env[config.FromEnv]
   DB[db.Open SQLite]
   Mig[migrate.Apply]
+  Key[ResolveStartupEncryptionKey]
   Store[store.New]
   Color[BackfillDominantColors]
   OIDC[oidc.New optional]
@@ -15,10 +16,12 @@ flowchart LR
   Srv[httpapi.NewServer]
   Listen[http.Server Listen TLS optional]
 
-  Env --> DB --> Mig --> Store --> Color
+  Env --> DB --> Mig --> Key --> Store --> Color
   Color --> OIDC
   OIDC --> MCP --> Agora --> Srv --> Listen
 ```
+
+`ResolveStartupEncryptionKey` runs after migrations and before `store.New`. If encrypted auth/security data already exists, an invalid or missing `SCRUMBOY_ENCRYPTION_KEY` fails startup. On a fresh database with no encrypted data, an invalid key is logged and ignored (2FA setup and password-reset encryption stay disabled until a valid key is configured).
 
 ## Background work
 

--- a/docs/diagrams/scrumboy_deployment_ops.md
+++ b/docs/diagrams/scrumboy_deployment_ops.md
@@ -80,7 +80,7 @@ flowchart TB
 
 - **File backup:** stop the process (or ensure no concurrent writes), copy `app.db` and any `-wal` / `-shm` files together.
 - **JSON backup:** scoped export via API; import supports replace, merge, or copy-as-new (see `scrumboy_backup_import.md`).
-- **2FA:** back up `SCRUMBOY_ENCRYPTION_KEY` with the database; rotating it breaks stored TOTP secrets.
+- **2FA:** back up `SCRUMBOY_ENCRYPTION_KEY` with the database; rotating it breaks stored TOTP secrets. Once encrypted auth/security data exists, startup requires the original valid key. On a fresh install with no encrypted data yet, an invalid key is ignored with a warning (2FA and password-reset encryption stay off until a valid key is set).
 - **Upgrade:** replace the binary or image, keep the data volume, restart; pending migrations apply automatically in `main.go`.
 
 ## Operational limits

--- a/docs/diagrams/scrumboy_frontend_spa.md
+++ b/docs/diagrams/scrumboy_frontend_spa.md
@@ -10,9 +10,12 @@ flowchart TB
   Views[views projects board dashboard auth notfound]
   Dialogs[dialogs todo settings wall bulk-edit]
   Core[core sse push notifications theme]
-  I18n[modules/i18n runtime]
-  Catalogs[locale catalogs en de fr pt pseudo]
-  LocaleChange[I18N_LOCALE_CHANGED and hydrateI18n]
+  I18n[i18n runtime index.ts]
+  Picker[locale-select.ts listbox]
+  Tips[field-tooltips.ts]
+  Cat[locale catalogs and flag SVGs]
+  Events[I18N_LOCALE_CHANGED hydrateI18n]
+  ApiErr[apiErrorMessage details.reason]
 
   App --> Router
   App --> Core
@@ -21,19 +24,49 @@ flowchart TB
   Router --> Views
   Views --> Dialogs
   Views --> I18n
+  Views --> Tips
   Dialogs --> I18n
-  I18n --> Catalogs
-  I18n --> LocaleChange
-  LocaleChange --> Views
-  LocaleChange --> Dialogs
+  Dialogs --> Tips
+  I18n --> Cat
+  I18n --> Picker
+  I18n --> Events
+  I18n --> ApiErr
+  Events --> Views
+  Events --> Dialogs
+  Picker --> Cat
 ```
 
 ## Locale flow
 
-- `modules/i18n/index.ts` owns locale detection, catalog loading, `t(...)`, `hydrateI18n(...)`, `I18N_LOCALE_CHANGED`, and shared date/number formatting helpers.
-- The SPA ships public locale catalogs for `en`, `de`, `fr`, and `pt`, plus `pseudo` for localhost/test QA only.
-- On startup the app uses the saved preference when present; otherwise it normalizes the browser language. `Settings -> Language` exposes only the public locales.
-- Locale changes hydrate static DOM in place and trigger targeted re-renders for state-derived copy in views and dialogs that keep local state open.
+```mermaid
+sequenceDiagram
+  participant App as app.js
+  participant I18n as initI18n
+  participant Boot as BOOTSTRAP_EN_CATALOG
+  participant JSON as dist/i18n/locales
+  participant DOM as document
+
+  App->>I18n: detect saved or browser locale
+  Note over Boot: auth and errors keys embedded before fetch
+  I18n->>JSON: fetch en then active locale catalog
+  JSON-->>I18n: cached MessageCatalog
+  I18n->>DOM: lang dir translate=no
+  I18n->>DOM: I18N_LOCALE_CHANGED on setLocale
+```
+
+- `modules/i18n/index.ts` owns locale detection, catalog loading, `t(...)`, `hydrateI18n(...)`, `I18N_LOCALE_CHANGED`, RTL `dir` for `ar` and `ur`, and shared date/number formatting helpers.
+- **Public locales** (picker order by speaker count): `en`, `zh`, `hi`, `es`, `ar`, `fr`, `pt`, `id`, `ur`, `ru`, `de`, `ja`, `vi`, `tr`, `ko`, `it`, `th`. **`pseudo`** is supported for localhost/test QA only (not in the public picker).
+- Catalogs live in `modules/i18n/locales/*.json`, ship as `dist/i18n/locales/*.json`, and are verified for key parity by `scripts/verify-i18n-locales.mjs` during the web build.
+- `BOOTSTRAP_EN_CATALOG` embeds all `auth.*` and `errors.*` keys so sign-in, bootstrap, 2FA, and password-reset copy is available before the full catalog fetch completes.
+- **Language picker:** `locale-select.ts` renders a shared accessible listbox (keyboard navigation, click-outside close) with vendored 3x2 SVG flags from `assets/flags/`. Used on the auth topbar and in Settings → Customization.
+- On startup the app uses the saved `scrumboy.locale` preference when present; otherwise it normalizes the browser language.
+- Locale changes hydrate static `data-i18n-*` DOM in place and trigger targeted re-renders for state-derived copy in views and dialogs that stay open; listeners must detach on dialog close.
+- **`index.html`** marks the shell `translate="no"` so browser translation does not double-translate Scrumboy's own i18n UI.
+
+## API error localization
+
+- Backend validation failures may include stable `error.details.reason` (snake_case). `apiErrorMessage()` maps known reasons to catalog keys; `apiErrorMessageOrRaw()` keeps raw backend text for dynamic import/backup diagnostics.
+- Field hover hints (`field-tooltips.ts`) resolve tooltip copy through `t(...)` at render time.
 
 ## Client routes
 

--- a/docs/diagrams/scrumboy_http_routing.md
+++ b/docs/diagrams/scrumboy_http_routing.md
@@ -33,3 +33,7 @@ flowchart TD
 - `/anon` anonymous temporary board creation (anonymous mode)
 
 API lives under `/api/*` only; everything else falls through to embedded `web/dist` assets or slug canonicalization.
+
+## Localized validation errors (SPA)
+
+Handlers use `writeValidationError(w, message, reason, details)` with stable snake_case `details.reason` when the failure class is known. The SPA maps recognized reasons through `apiErrorMessage()` / catalog keys; unknown or dynamic store messages keep the English `error.message` (or raw text via `apiErrorMessageOrRaw()` on import/backup paths). HTTP status codes and payload shape are unchanged.

--- a/docs/diagrams/scrumboy_overview.md
+++ b/docs/diagrams/scrumboy_overview.md
@@ -43,7 +43,7 @@ Core path: browser to HTTP to store to SQLite, with SSE for live board updates. 
 | `cmd/scrumboy` | Process entry, TLS, hourly maintenance |
 | `internal/httpapi` | HTTP routing, SSE hub, SPA embed, webhooks, push |
 | `internal/store` | Domain logic and authorization |
-| `internal/httpapi/web` | TypeScript SPA compiled to `dist/` |
+| `internal/httpapi/web` | TypeScript SPA compiled to `dist/`; i18n catalogs, locale runtime, vendored flag assets |
 | `internal/migrate` | Versioned SQL migrations |
 | `internal/mcp` | Optional MCP HTTP and JSON-RPC tools |
 | `internal/agora` | Optional Agoragentic adapter over MCP |

--- a/docs/diagrams/scrumboy_voiceflow.md
+++ b/docs/diagrams/scrumboy_voiceflow.md
@@ -22,7 +22,7 @@ flowchart LR
 
 ## Locale boundary
 
-- Board chrome and `Settings -> Customization -> VoiceFlow` copy follow the app locale.
+- Board chrome, `Settings -> Customization -> VoiceFlow` copy, and runtime status/error toasts follow the app locale.
 - Parser vocabulary, built-in status aliases, spoken `yes` / `no` confirmations, and spoken disambiguation words currently stay English-centric.
 - `Safe-Mode` is the safer choice in a non-English UI because the command grammar does not switch with the app locale yet.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.18.10"
+const Version = "3.18.11"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.18.11"
+const Version = "3.18.12"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
This documentation update reflects completed changes to the localization framework, initialization sequence, and architecture diagrams across the `scrumboy` codebase.

Frontend documentation updates detail the 17 public locales, pseudo-localization, `locale-select.ts` component, flag SVGs, initialization diagrams, RTL support, and the build verifier. It synchronizes documentation for localized field tooltips, voiceflow runtime toasts, pre-auth locale picking, sanitized redirects, and error localization via `details.reason`. Core architecture and deployment documentation adds details for the `ResolveStartupEncryptionKey` step, defining system behavior differences between fresh installs and existing encrypted data. Finally, the root README, `index.html` frontend diagram descriptions, and the system overview web package specifications have been updated to reflect this infrastructure.