### PR TITLE
localized OG metadata

### DIFF
--- a/internal/httpapi/web/dist/i18n/locales/bn.json
+++ b/internal/httpapi/web/dist/i18n/locales/bn.json
@@ -10,7 +10,7 @@
   "common.save": "সংরক্ষণ",
   "common.value": "মান",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy-এ দ্রুত সহযোগিতার জন্য self-hosted প্রোজেক্ট বোর্ড বা একদম ঝটপট anonymous বোর্ড পাবেন।",
+  "landing.meta.description": "Scrumboy দ্রুত সহযোগিতার জন্য নিজের সার্ভারে চালানো যায় এমন প্রোজেক্ট বোর্ড বা তাৎক্ষণিক অজ্ঞাতনামা বোর্ড প্রদান করে।",
   "landing.nav.brandAriaLabel": "Scrumboy হোম",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "ঝামেলা ছাড়া",

--- a/internal/httpapi/web/dist/i18n/locales/de.json
+++ b/internal/httpapi/web/dist/i18n/locales/de.json
@@ -10,7 +10,7 @@
   "common.save": "Speichern",
   "common.value": "Wert",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy bietet selbst gehostete Projektboards oder sofortige anonyme Boards für schnelle Zusammenarbeit.",
+  "landing.meta.description": "Scrumboy bietet selbst gehostete Projektboards oder sofort verfügbare anonyme Boards für schnelle Zusammenarbeit.",
   "landing.nav.brandAriaLabel": "Scrumboy-Startseite",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "ohne",

--- a/internal/httpapi/web/dist/i18n/locales/es.json
+++ b/internal/httpapi/web/dist/i18n/locales/es.json
@@ -10,7 +10,7 @@
   "common.save": "Guardar",
   "common.value": "Valor",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy te da tableros de proyecto autohospedados o tableros anónimos instantáneos para colaborar rápido.",
+  "landing.meta.description": "Scrumboy te ofrece tableros de proyecto autohospedados o tableros anónimos instantáneos para colaborar rápidamente.",
   "landing.nav.brandAriaLabel": "Inicio de Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "sin",

--- a/internal/httpapi/web/dist/i18n/locales/fa.json
+++ b/internal/httpapi/web/dist/i18n/locales/fa.json
@@ -10,7 +10,7 @@
   "common.save": "ذخیره",
   "common.value": "مقدار",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy برای همکاری سریع، بردهای پروژه‌ی self-hosted یا بردهای anonymous فوری در اختیارتان می‌گذارد.",
+  "landing.meta.description": "Scrumboy برای همکاری سریع، بردهای پروژه با میزبانی شخصی یا بردهای ناشناس فوری در اختیارتان می‌گذارد.",
   "landing.nav.brandAriaLabel": "صفحهٔ اصلی Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "بدون",

--- a/internal/httpapi/web/dist/i18n/locales/hi.json
+++ b/internal/httpapi/web/dist/i18n/locales/hi.json
@@ -10,7 +10,7 @@
   "common.save": "सहेजें",
   "common.value": "मान",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy तेज़ सहयोग के लिए self-hosted प्रोजेक्ट बोर्ड या तुरंत बनने वाले anonymous बोर्ड देता है।",
+  "landing.meta.description": "Scrumboy तेज़ सहयोग के लिए अपने सर्वर पर चलने वाले प्रोजेक्ट बोर्ड या तुरंत बनाए जाने वाले गुमनाम बोर्ड उपलब्ध कराता है।",
   "landing.nav.brandAriaLabel": "Scrumboy होम",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "बिना झंझट",

--- a/internal/httpapi/web/dist/i18n/locales/id.json
+++ b/internal/httpapi/web/dist/i18n/locales/id.json
@@ -10,7 +10,7 @@
   "common.save": "Simpan",
   "common.value": "Nilai",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy memberi Anda papan proyek self-hosted atau papan anonim instan untuk kolaborasi cepat.",
+  "landing.meta.description": "Scrumboy menyediakan papan proyek yang di-host sendiri atau papan anonim instan untuk kolaborasi cepat.",
   "landing.nav.brandAriaLabel": "Beranda Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "tanpa",

--- a/internal/httpapi/web/dist/i18n/locales/it.json
+++ b/internal/httpapi/web/dist/i18n/locales/it.json
@@ -10,7 +10,7 @@
   "common.save": "Salva",
   "common.value": "Valore",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy offre board di progetto self-hosted o board anonime immediate per collaborare rapidamente.",
+  "landing.meta.description": "Scrumboy offre bacheche di progetto self-hosted o bacheche anonime istantanee per collaborare rapidamente.",
   "landing.nav.brandAriaLabel": "Home di Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "senza complicazioni",

--- a/internal/httpapi/web/dist/i18n/locales/ms.json
+++ b/internal/httpapi/web/dist/i18n/locales/ms.json
@@ -10,7 +10,7 @@
   "common.save": "Simpan",
   "common.value": "Nilai",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy memberi anda papan projek self-hosted atau papan tanpa nama serta-merta untuk kerjasama pantas.",
+  "landing.meta.description": "Scrumboy menyediakan papan projek yang dihos sendiri atau papan tanpa nama serta-merta untuk kerjasama pantas.",
   "landing.nav.brandAriaLabel": "Laman utama Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "tanpa",

--- a/internal/httpapi/web/dist/i18n/locales/pl.json
+++ b/internal/httpapi/web/dist/i18n/locales/pl.json
@@ -10,7 +10,7 @@
   "common.save": "Zapisz",
   "common.value": "Wartość",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy daje ci self-hosted tablice projektów albo anonimowe tablice od ręki — do szybkiej współpracy.",
+  "landing.meta.description": "Scrumboy oferuje samodzielnie hostowane tablice projektów lub natychmiastowe anonimowe tablice do szybkiej współpracy.",
   "landing.nav.brandAriaLabel": "Strona główna Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "bez",

--- a/internal/httpapi/web/dist/i18n/locales/ru.json
+++ b/internal/httpapi/web/dist/i18n/locales/ru.json
@@ -10,7 +10,7 @@
   "common.save": "Сохранить",
   "common.value": "Значение",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy дает самостоятельные проектные доски или мгновенные анонимные доски для быстрой совместной работы.",
+  "landing.meta.description": "Scrumboy предлагает самостоятельно размещаемые проектные доски или мгновенные анонимные доски для быстрой совместной работы.",
   "landing.nav.brandAriaLabel": "Главная Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "без",

--- a/internal/httpapi/web/dist/i18n/locales/sw.json
+++ b/internal/httpapi/web/dist/i18n/locales/sw.json
@@ -10,7 +10,7 @@
   "common.save": "Hifadhi",
   "common.value": "Thamani",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy hukupa bodi za miradi za self-hosted au bodi za anonymous za papo hapo kwa ushirikiano wa haraka.",
+  "landing.meta.description": "Scrumboy hukupa bodi za miradi zinazojihifadhi mwenyewe au bodi za siri zinazoundwa papo hapo kwa ushirikiano wa haraka.",
   "landing.nav.brandAriaLabel": "Nyumbani Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "bila",

--- a/internal/httpapi/web/dist/i18n/locales/tr.json
+++ b/internal/httpapi/web/dist/i18n/locales/tr.json
@@ -10,7 +10,7 @@
   "common.save": "Kaydet",
   "common.value": "Değer",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy, hızlı iş birliği için self-hosted proje panoları veya anında anonim panolar sunar.",
+  "landing.meta.description": "Scrumboy, hızlı iş birliği için kendi sunucunuzda barındırabileceğiniz proje panoları veya anında oluşturulan anonim panolar sunar.",
   "landing.nav.brandAriaLabel": "Scrumboy ana sayfası",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "zahmetsiz",

--- a/internal/httpapi/web/dist/i18n/locales/uk.json
+++ b/internal/httpapi/web/dist/i18n/locales/uk.json
@@ -10,7 +10,7 @@
   "common.save": "Зберегти",
   "common.value": "Значення",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy дає self-hosted проєктні дошки або миттєві анонімні дошки для швидкої співпраці.",
+  "landing.meta.description": "Scrumboy надає проєктні дошки для власного хостингу або миттєві анонімні дошки для швидкої співпраці.",
   "landing.nav.brandAriaLabel": "Головна Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "без",

--- a/internal/httpapi/web/dist/i18n/locales/ur.json
+++ b/internal/httpapi/web/dist/i18n/locales/ur.json
@@ -10,7 +10,7 @@
   "common.save": "محفوظ کریں",
   "common.value": "قدر",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy تیز تعاون کے لیے self-hosted پروجیکٹ بورڈز یا فوری anonymous بورڈز فراہم کرتا ہے۔",
+  "landing.meta.description": "Scrumboy تیز تعاون کے لیے اپنے سرور پر چلنے والے پروجیکٹ بورڈز یا فوری گمنام بورڈز فراہم کرتا ہے۔",
   "landing.nav.brandAriaLabel": "Scrumboy ہوم",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "آسان اور",

--- a/internal/httpapi/web/landing.locales/ar.html
+++ b/internal/httpapi/web/landing.locales/ar.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy يوفّر لوحات مشاريع ذاتية الاستضافة، أو لوحات فورية بدون حساب للتعاون السريع.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/ar/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy يوفّر لوحات مشاريع ذاتية الاستضافة، أو لوحات فورية بدون حساب للتعاون السريع." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy يوفّر لوحات مشاريع ذاتية الاستضافة، أو لوحات فورية بدون حساب للتعاون السريع." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/bn.html
+++ b/internal/httpapi/web/landing.locales/bn.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy দ্রুত সহযোগিতার জন্য নিজের সার্ভারে চালানো যায় এমন প্রোজেক্ট বোর্ড বা তাৎক্ষণিক অজ্ঞাতনামা বোর্ড প্রদান করে।">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/bn/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy দ্রুত সহযোগিতার জন্য নিজের সার্ভারে চালানো যায় এমন প্রোজেক্ট বোর্ড বা তাৎক্ষণিক অজ্ঞাতনামা বোর্ড প্রদান করে।" />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy দ্রুত সহযোগিতার জন্য নিজের সার্ভারে চালানো যায় এমন প্রোজেক্ট বোর্ড বা তাৎক্ষণিক অজ্ঞাতনামা বোর্ড প্রদান করে।" />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/de.html
+++ b/internal/httpapi/web/landing.locales/de.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy bietet selbst gehostete Projektboards oder sofort verfügbare anonyme Boards für schnelle Zusammenarbeit.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/de/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy bietet selbst gehostete Projektboards oder sofort verfügbare anonyme Boards für schnelle Zusammenarbeit." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy bietet selbst gehostete Projektboards oder sofort verfügbare anonyme Boards für schnelle Zusammenarbeit." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/es.html
+++ b/internal/httpapi/web/landing.locales/es.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy te ofrece tableros de proyecto autohospedados o tableros anónimos instantáneos para colaborar rápidamente.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/es/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy te ofrece tableros de proyecto autohospedados o tableros anónimos instantáneos para colaborar rápidamente." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy te ofrece tableros de proyecto autohospedados o tableros anónimos instantáneos para colaborar rápidamente." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/fa.html
+++ b/internal/httpapi/web/landing.locales/fa.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy برای همکاری سریع، بردهای پروژه با میزبانی شخصی یا بردهای ناشناس فوری در اختیارتان می‌گذارد.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/fa/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy برای همکاری سریع، بردهای پروژه با میزبانی شخصی یا بردهای ناشناس فوری در اختیارتان می‌گذارد." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy برای همکاری سریع، بردهای پروژه با میزبانی شخصی یا بردهای ناشناس فوری در اختیارتان می‌گذارد." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/fr.html
+++ b/internal/httpapi/web/landing.locales/fr.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy propose des tableaux de projet auto-hébergés ou des tableaux anonymes instantanés pour collaborer rapidement.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/fr/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy propose des tableaux de projet auto-hébergés ou des tableaux anonymes instantanés pour collaborer rapidement." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy propose des tableaux de projet auto-hébergés ou des tableaux anonymes instantanés pour collaborer rapidement." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/hi.html
+++ b/internal/httpapi/web/landing.locales/hi.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy तेज़ सहयोग के लिए अपने सर्वर पर चलने वाले प्रोजेक्ट बोर्ड या तुरंत बनाए जाने वाले गुमनाम बोर्ड उपलब्ध कराता है।">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/hi/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy तेज़ सहयोग के लिए अपने सर्वर पर चलने वाले प्रोजेक्ट बोर्ड या तुरंत बनाए जाने वाले गुमनाम बोर्ड उपलब्ध कराता है।" />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy तेज़ सहयोग के लिए अपने सर्वर पर चलने वाले प्रोजेक्ट बोर्ड या तुरंत बनाए जाने वाले गुमनाम बोर्ड उपलब्ध कराता है।" />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/id.html
+++ b/internal/httpapi/web/landing.locales/id.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy menyediakan papan proyek yang di-host sendiri atau papan anonim instan untuk kolaborasi cepat.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/id/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy menyediakan papan proyek yang di-host sendiri atau papan anonim instan untuk kolaborasi cepat." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy menyediakan papan proyek yang di-host sendiri atau papan anonim instan untuk kolaborasi cepat." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/it.html
+++ b/internal/httpapi/web/landing.locales/it.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy offre bacheche di progetto self-hosted o bacheche anonime istantanee per collaborare rapidamente.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/it/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy offre bacheche di progetto self-hosted o bacheche anonime istantanee per collaborare rapidamente." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy offre bacheche di progetto self-hosted o bacheche anonime istantanee per collaborare rapidamente." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/ja.html
+++ b/internal/httpapi/web/landing.locales/ja.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy は、セルフホスト型のプロジェクトボードと、すばやい共同作業向けの即席匿名ボードを提供します。">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/ja/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy は、セルフホスト型のプロジェクトボードと、すばやい共同作業向けの即席匿名ボードを提供します。" />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy は、セルフホスト型のプロジェクトボードと、すばやい共同作業向けの即席匿名ボードを提供します。" />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/ko.html
+++ b/internal/httpapi/web/landing.locales/ko.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy는 빠른 협업을 위한 셀프 호스팅 프로젝트 보드와 즉시 만들 수 있는 익명 보드를 제공합니다.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/ko/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy는 빠른 협업을 위한 셀프 호스팅 프로젝트 보드와 즉시 만들 수 있는 익명 보드를 제공합니다." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy는 빠른 협업을 위한 셀프 호스팅 프로젝트 보드와 즉시 만들 수 있는 익명 보드를 제공합니다." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/ms.html
+++ b/internal/httpapi/web/landing.locales/ms.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy menyediakan papan projek yang dihos sendiri atau papan tanpa nama serta-merta untuk kerjasama pantas.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/ms/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy menyediakan papan projek yang dihos sendiri atau papan tanpa nama serta-merta untuk kerjasama pantas." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy menyediakan papan projek yang dihos sendiri atau papan tanpa nama serta-merta untuk kerjasama pantas." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/pl.html
+++ b/internal/httpapi/web/landing.locales/pl.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy oferuje samodzielnie hostowane tablice projektów lub natychmiastowe anonimowe tablice do szybkiej współpracy.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/pl/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy oferuje samodzielnie hostowane tablice projektów lub natychmiastowe anonimowe tablice do szybkiej współpracy." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy oferuje samodzielnie hostowane tablice projektów lub natychmiastowe anonimowe tablice do szybkiej współpracy." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/pt.html
+++ b/internal/httpapi/web/landing.locales/pt.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="O Scrumboy oferece quadros de projeto auto-hospedados ou quadros anônimos instantâneos para colaboração rápida.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/pt/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="O Scrumboy oferece quadros de projeto auto-hospedados ou quadros anônimos instantâneos para colaboração rápida." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="O Scrumboy oferece quadros de projeto auto-hospedados ou quadros anônimos instantâneos para colaboração rápida." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/ru.html
+++ b/internal/httpapi/web/landing.locales/ru.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy предлагает самостоятельно размещаемые проектные доски или мгновенные анонимные доски для быстрой совместной работы.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/ru/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy предлагает самостоятельно размещаемые проектные доски или мгновенные анонимные доски для быстрой совместной работы." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy предлагает самостоятельно размещаемые проектные доски или мгновенные анонимные доски для быстрой совместной работы." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/sw.html
+++ b/internal/httpapi/web/landing.locales/sw.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy hukupa bodi za miradi zinazojihifadhi mwenyewe au bodi za siri zinazoundwa papo hapo kwa ushirikiano wa haraka.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/sw/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy hukupa bodi za miradi zinazojihifadhi mwenyewe au bodi za siri zinazoundwa papo hapo kwa ushirikiano wa haraka." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy hukupa bodi za miradi zinazojihifadhi mwenyewe au bodi za siri zinazoundwa papo hapo kwa ushirikiano wa haraka." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/th.html
+++ b/internal/httpapi/web/landing.locales/th.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy ให้บอร์ดโปรเจกต์แบบ self-hosted หรือบอร์ดไม่ระบุตัวตนที่สร้างได้ทันทีสำหรับการทำงานร่วมกันอย่างรวดเร็ว">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/th/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy ให้บอร์ดโปรเจกต์แบบ self-hosted หรือบอร์ดไม่ระบุตัวตนที่สร้างได้ทันทีสำหรับการทำงานร่วมกันอย่างรวดเร็ว" />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy ให้บอร์ดโปรเจกต์แบบ self-hosted หรือบอร์ดไม่ระบุตัวตนที่สร้างได้ทันทีสำหรับการทำงานร่วมกันอย่างรวดเร็ว" />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/tr.html
+++ b/internal/httpapi/web/landing.locales/tr.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy, hızlı iş birliği için kendi sunucunuzda barındırabileceğiniz proje panoları veya anında oluşturulan anonim panolar sunar.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/tr/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy, hızlı iş birliği için kendi sunucunuzda barındırabileceğiniz proje panoları veya anında oluşturulan anonim panolar sunar." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy, hızlı iş birliği için kendi sunucunuzda barındırabileceğiniz proje panoları veya anında oluşturulan anonim panolar sunar." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/uk.html
+++ b/internal/httpapi/web/landing.locales/uk.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy надає проєктні дошки для власного хостингу або миттєві анонімні дошки для швидкої співпраці.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/uk/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy надає проєктні дошки для власного хостингу або миттєві анонімні дошки для швидкої співпраці." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="pl_PL" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy надає проєктні дошки для власного хостингу або миттєві анонімні дошки для швидкої співпраці." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/ur.html
+++ b/internal/httpapi/web/landing.locales/ur.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy تیز تعاون کے لیے اپنے سرور پر چلنے والے پروجیکٹ بورڈز یا فوری گمنام بورڈز فراہم کرتا ہے۔">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/ur/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy تیز تعاون کے لیے اپنے سرور پر چلنے والے پروجیکٹ بورڈز یا فوری گمنام بورڈز فراہم کرتا ہے۔" />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy تیز تعاون کے لیے اپنے سرور پر چلنے والے پروجیکٹ بورڈز یا فوری گمنام بورڈز فراہم کرتا ہے۔" />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/vi.html
+++ b/internal/httpapi/web/landing.locales/vi.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy cung cấp bảng dự án tự lưu trữ hoặc bảng ẩn danh tức thì để cộng tác nhanh.">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/vi/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy cung cấp bảng dự án tự lưu trữ hoặc bảng ẩn danh tức thì để cộng tác nhanh." />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy cung cấp bảng dự án tự lưu trữ hoặc bảng ẩn danh tức thì để cộng tác nhanh." />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/landing.locales/zh.html
+++ b/internal/httpapi/web/landing.locales/zh.html
@@ -8,7 +8,7 @@
   <meta name="color-scheme" content="dark">
   <meta name="theme-color" content="#0f1218">
   <title>Scrumboy</title>
-  <meta name="description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration.">
+  <meta name="description" content="Scrumboy 提供自托管项目看板，或可即时创建的匿名看板，用于快速协作。">
   <meta name="robots" content="noindex,follow">
   <meta name="app-version" content="{{VERSION}}" />
   <link rel="preload" as="image" href="/scrumboylanding.png" fetchpriority="high">
@@ -17,7 +17,7 @@
   <meta property="og:site_name" content="Scrumboy" />
   <meta property="og:url" content="https://scrumboy.com/zh/" />
   <meta property="og:title" content="Scrumboy" />
-  <meta property="og:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta property="og:description" content="Scrumboy 提供自托管项目看板，或可即时创建的匿名看板，用于快速协作。" />
   <meta property="og:image" content="https://scrumboy.com/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -47,7 +47,7 @@
   <meta property="og:locale:alternate" content="uk_UA" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Scrumboy" />
-  <meta name="twitter:description" content="Scrumboy gives you self-hosted project boards or instant anonymous boards for quick collaboration." />
+  <meta name="twitter:description" content="Scrumboy 提供自托管项目看板，或可即时创建的匿名看板，用于快速协作。" />
   <meta name="twitter:image" content="https://scrumboy.com/og-image.png" />
   <style>
     :root {

--- a/internal/httpapi/web/modules/i18n/locales/bn.json
+++ b/internal/httpapi/web/modules/i18n/locales/bn.json
@@ -10,7 +10,7 @@
   "common.save": "সংরক্ষণ",
   "common.value": "মান",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy-এ দ্রুত সহযোগিতার জন্য self-hosted প্রোজেক্ট বোর্ড বা একদম ঝটপট anonymous বোর্ড পাবেন।",
+  "landing.meta.description": "Scrumboy দ্রুত সহযোগিতার জন্য নিজের সার্ভারে চালানো যায় এমন প্রোজেক্ট বোর্ড বা তাৎক্ষণিক অজ্ঞাতনামা বোর্ড প্রদান করে।",
   "landing.nav.brandAriaLabel": "Scrumboy হোম",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "ঝামেলা ছাড়া",

--- a/internal/httpapi/web/modules/i18n/locales/de.json
+++ b/internal/httpapi/web/modules/i18n/locales/de.json
@@ -10,7 +10,7 @@
   "common.save": "Speichern",
   "common.value": "Wert",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy bietet selbst gehostete Projektboards oder sofortige anonyme Boards für schnelle Zusammenarbeit.",
+  "landing.meta.description": "Scrumboy bietet selbst gehostete Projektboards oder sofort verfügbare anonyme Boards für schnelle Zusammenarbeit.",
   "landing.nav.brandAriaLabel": "Scrumboy-Startseite",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "ohne",

--- a/internal/httpapi/web/modules/i18n/locales/es.json
+++ b/internal/httpapi/web/modules/i18n/locales/es.json
@@ -10,7 +10,7 @@
   "common.save": "Guardar",
   "common.value": "Valor",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy te da tableros de proyecto autohospedados o tableros anónimos instantáneos para colaborar rápido.",
+  "landing.meta.description": "Scrumboy te ofrece tableros de proyecto autohospedados o tableros anónimos instantáneos para colaborar rápidamente.",
   "landing.nav.brandAriaLabel": "Inicio de Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "sin",

--- a/internal/httpapi/web/modules/i18n/locales/fa.json
+++ b/internal/httpapi/web/modules/i18n/locales/fa.json
@@ -10,7 +10,7 @@
   "common.save": "ذخیره",
   "common.value": "مقدار",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy برای همکاری سریع، بردهای پروژه‌ی self-hosted یا بردهای anonymous فوری در اختیارتان می‌گذارد.",
+  "landing.meta.description": "Scrumboy برای همکاری سریع، بردهای پروژه با میزبانی شخصی یا بردهای ناشناس فوری در اختیارتان می‌گذارد.",
   "landing.nav.brandAriaLabel": "صفحهٔ اصلی Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "بدون",

--- a/internal/httpapi/web/modules/i18n/locales/hi.json
+++ b/internal/httpapi/web/modules/i18n/locales/hi.json
@@ -10,7 +10,7 @@
   "common.save": "सहेजें",
   "common.value": "मान",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy तेज़ सहयोग के लिए self-hosted प्रोजेक्ट बोर्ड या तुरंत बनने वाले anonymous बोर्ड देता है।",
+  "landing.meta.description": "Scrumboy तेज़ सहयोग के लिए अपने सर्वर पर चलने वाले प्रोजेक्ट बोर्ड या तुरंत बनाए जाने वाले गुमनाम बोर्ड उपलब्ध कराता है।",
   "landing.nav.brandAriaLabel": "Scrumboy होम",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "बिना झंझट",

--- a/internal/httpapi/web/modules/i18n/locales/id.json
+++ b/internal/httpapi/web/modules/i18n/locales/id.json
@@ -10,7 +10,7 @@
   "common.save": "Simpan",
   "common.value": "Nilai",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy memberi Anda papan proyek self-hosted atau papan anonim instan untuk kolaborasi cepat.",
+  "landing.meta.description": "Scrumboy menyediakan papan proyek yang di-host sendiri atau papan anonim instan untuk kolaborasi cepat.",
   "landing.nav.brandAriaLabel": "Beranda Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "tanpa",

--- a/internal/httpapi/web/modules/i18n/locales/it.json
+++ b/internal/httpapi/web/modules/i18n/locales/it.json
@@ -10,7 +10,7 @@
   "common.save": "Salva",
   "common.value": "Valore",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy offre board di progetto self-hosted o board anonime immediate per collaborare rapidamente.",
+  "landing.meta.description": "Scrumboy offre bacheche di progetto self-hosted o bacheche anonime istantanee per collaborare rapidamente.",
   "landing.nav.brandAriaLabel": "Home di Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "senza complicazioni",

--- a/internal/httpapi/web/modules/i18n/locales/ms.json
+++ b/internal/httpapi/web/modules/i18n/locales/ms.json
@@ -10,7 +10,7 @@
   "common.save": "Simpan",
   "common.value": "Nilai",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy memberi anda papan projek self-hosted atau papan tanpa nama serta-merta untuk kerjasama pantas.",
+  "landing.meta.description": "Scrumboy menyediakan papan projek yang dihos sendiri atau papan tanpa nama serta-merta untuk kerjasama pantas.",
   "landing.nav.brandAriaLabel": "Laman utama Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "tanpa",

--- a/internal/httpapi/web/modules/i18n/locales/pl.json
+++ b/internal/httpapi/web/modules/i18n/locales/pl.json
@@ -10,7 +10,7 @@
   "common.save": "Zapisz",
   "common.value": "Wartość",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy daje ci self-hosted tablice projektów albo anonimowe tablice od ręki — do szybkiej współpracy.",
+  "landing.meta.description": "Scrumboy oferuje samodzielnie hostowane tablice projektów lub natychmiastowe anonimowe tablice do szybkiej współpracy.",
   "landing.nav.brandAriaLabel": "Strona główna Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "bez",

--- a/internal/httpapi/web/modules/i18n/locales/ru.json
+++ b/internal/httpapi/web/modules/i18n/locales/ru.json
@@ -10,7 +10,7 @@
   "common.save": "Сохранить",
   "common.value": "Значение",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy дает самостоятельные проектные доски или мгновенные анонимные доски для быстрой совместной работы.",
+  "landing.meta.description": "Scrumboy предлагает самостоятельно размещаемые проектные доски или мгновенные анонимные доски для быстрой совместной работы.",
   "landing.nav.brandAriaLabel": "Главная Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "без",

--- a/internal/httpapi/web/modules/i18n/locales/sw.json
+++ b/internal/httpapi/web/modules/i18n/locales/sw.json
@@ -10,7 +10,7 @@
   "common.save": "Hifadhi",
   "common.value": "Thamani",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy hukupa bodi za miradi za self-hosted au bodi za anonymous za papo hapo kwa ushirikiano wa haraka.",
+  "landing.meta.description": "Scrumboy hukupa bodi za miradi zinazojihifadhi mwenyewe au bodi za siri zinazoundwa papo hapo kwa ushirikiano wa haraka.",
   "landing.nav.brandAriaLabel": "Nyumbani Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "bila",

--- a/internal/httpapi/web/modules/i18n/locales/tr.json
+++ b/internal/httpapi/web/modules/i18n/locales/tr.json
@@ -10,7 +10,7 @@
   "common.save": "Kaydet",
   "common.value": "Değer",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy, hızlı iş birliği için self-hosted proje panoları veya anında anonim panolar sunar.",
+  "landing.meta.description": "Scrumboy, hızlı iş birliği için kendi sunucunuzda barındırabileceğiniz proje panoları veya anında oluşturulan anonim panolar sunar.",
   "landing.nav.brandAriaLabel": "Scrumboy ana sayfası",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "zahmetsiz",

--- a/internal/httpapi/web/modules/i18n/locales/uk.json
+++ b/internal/httpapi/web/modules/i18n/locales/uk.json
@@ -10,7 +10,7 @@
   "common.save": "Зберегти",
   "common.value": "Значення",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy дає self-hosted проєктні дошки або миттєві анонімні дошки для швидкої співпраці.",
+  "landing.meta.description": "Scrumboy надає проєктні дошки для власного хостингу або миттєві анонімні дошки для швидкої співпраці.",
   "landing.nav.brandAriaLabel": "Головна Scrumboy",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "без",

--- a/internal/httpapi/web/modules/i18n/locales/ur.json
+++ b/internal/httpapi/web/modules/i18n/locales/ur.json
@@ -10,7 +10,7 @@
   "common.save": "محفوظ کریں",
   "common.value": "قدر",
   "landing.meta.title": "Scrumboy",
-  "landing.meta.description": "Scrumboy تیز تعاون کے لیے self-hosted پروجیکٹ بورڈز یا فوری anonymous بورڈز فراہم کرتا ہے۔",
+  "landing.meta.description": "Scrumboy تیز تعاون کے لیے اپنے سرور پر چلنے والے پروجیکٹ بورڈز یا فوری گمنام بورڈز فراہم کرتا ہے۔",
   "landing.nav.brandAriaLabel": "Scrumboy ہوم",
   "landing.hero.title.line1Accent": "Kanban Boards",
   "landing.hero.title.line1Rest": "آسان اور",

--- a/internal/httpapi/web/scripts/generate-landing.mjs
+++ b/internal/httpapi/web/scripts/generate-landing.mjs
@@ -248,6 +248,10 @@ function landingDisplayCatalog(locale, localeCatalog, englishCatalog, keys) {
   }
 
   if (locale !== "en") {
+    const metaDescription = localeCatalog["landing.meta.description"];
+    if (typeof metaDescription === "string") {
+      catalog["landing.meta.description"] = metaDescription;
+    }
     const multilingualText = localeCatalog[MULTILINGUAL_TEXT_KEY]?.trim();
     if (multilingualText) {
       catalog[MULTILINGUAL_TEXT_KEY] = multilingualText;


### PR DESCRIPTION
Previously, the OG preview text showed English for all locales. Now it should show localized translations for the specific landing pages.