### PR TITLE
Audit/test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go:
+    name: Go tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Test Go
+        run: go test ./... -count=1 -timeout=5m
+
+  frontend:
+    name: Frontend tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: internal/httpapi/web/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: internal/httpapi/web
+        run: npm ci
+
+      - name: Test frontend
+        working-directory: internal/httpapi/web
+        run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 > **Upgrades:** No breaking changes in **3.7.x** / **3.8.x** / **3.9.x** / **3.10.x** / **3.11.x** / **3.12.x** / **3.13.x** / **3.14.x** / **3.15.x** / **3.16.x** / **3.17.x** / **3.18.x** unless noted below.
 
+## [3.18.24] - 2026-07-01
+
+### Added
+
+- **CI workflow** - GitHub Actions (`.github/workflows/ci.yml`) runs Go (`go test ./...`) and frontend (`npm test`) on every push and pull request to `main`, with parallel jobs and `workflow_dispatch` for manual runs.
+
+### Tests
+
+- **Maintenance CLI tools** - Coverage for `dbquery`, `slugfix`, `tagcheck`, and `tagrecover` (report formatting, error paths, and legacy slug/tag recovery); core logic extracted into testable `run()` helpers.
+- **Auth** - Password validation rules and password-reset token generate/parse/verify flows.
+- **Database layer** - `db.Open` directory creation, SQLite pragmas, connection pool limits, and migration runner idempotency with current-schema landmark checks.
+- **Event bus** - Fan-out publish delivery order, context propagation, and missing-ID/timestamp defaults.
+- **HTTP API** - Auth rate limiter per-IP and per-email windows, stale-entry cleanup, and email normalization.
+- **Project color** - Dominant-color extraction from avatar data URLs (invalid input, PNG channels, clamping).
+
+### Documentation
+
+- **README** - Tests status shield linked to the CI workflow on `main`.
+
 ## [3.18.23] - 2026-06-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.18.23-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.18.24-blue" alt="version" />
   <img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" />
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
+  <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/markrai/scrumboy/ci.yml?branch=main&label=tests" alt="tests" />
+  </a>
 </p>
 
 #### Self-hosted project management & issue-tracking solution + instant shareable & customizable boards + realtime collaboration, automation, API access and MCP-compatible client support

--- a/cmd/dbquery/main.go
+++ b/cmd/dbquery/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"io"
 	"log"
 	"os"
 
@@ -29,27 +31,31 @@ func main() {
 	defer sqlDB.Close()
 
 	query := os.Args[1]
-	ctx := context.Background()
+	if err := run(context.Background(), sqlDB, query, os.Stdout); err != nil {
+		log.Fatalf("%v", err)
+	}
+}
 
+func run(ctx context.Context, sqlDB *sql.DB, query string, out io.Writer) error {
 	rows, err := sqlDB.QueryContext(ctx, query)
 	if err != nil {
-		log.Fatalf("query: %v", err)
+		return fmt.Errorf("query: %w", err)
 	}
 	defer rows.Close()
 
 	cols, err := rows.Columns()
 	if err != nil {
-		log.Fatalf("columns: %v", err)
+		return fmt.Errorf("columns: %w", err)
 	}
 
 	// Print header
 	for i, col := range cols {
 		if i > 0 {
-			fmt.Print(" | ")
+			fmt.Fprint(out, " | ")
 		}
-		fmt.Print(col)
+		fmt.Fprint(out, col)
 	}
-	fmt.Println()
+	fmt.Fprintln(out)
 
 	// Print rows
 	values := make([]interface{}, len(cols))
@@ -60,21 +66,22 @@ func main() {
 
 	for rows.Next() {
 		if err := rows.Scan(valuePtrs...); err != nil {
-			log.Fatalf("scan: %v", err)
+			return fmt.Errorf("scan: %w", err)
 		}
 		for i, val := range values {
 			if i > 0 {
-				fmt.Print(" | ")
+				fmt.Fprint(out, " | ")
 			}
 			if val == nil {
-				fmt.Print("NULL")
+				fmt.Fprint(out, "NULL")
 			} else {
-				fmt.Print(val)
+				fmt.Fprint(out, val)
 			}
 		}
-		fmt.Println()
+		fmt.Fprintln(out)
 	}
 	if err := rows.Err(); err != nil {
-		log.Fatalf("rows: %v", err)
+		return fmt.Errorf("rows: %w", err)
 	}
+	return nil
 }

--- a/cmd/dbquery/main_test.go
+++ b/cmd/dbquery/main_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"scrumboy/internal/db"
+)
+
+func TestRunPrintsHeadersAndRows(t *testing.T) {
+	sqlDB := openTestDB(t)
+	execSQL(t, sqlDB, `CREATE TABLE tasks(name TEXT NOT NULL, priority INTEGER NOT NULL)`)
+	execSQL(t, sqlDB, `INSERT INTO tasks(name, priority) VALUES (?, ?)`, "second", 2)
+	execSQL(t, sqlDB, `INSERT INTO tasks(name, priority) VALUES (?, ?)`, "first", 1)
+
+	var buf bytes.Buffer
+	err := run(context.Background(), sqlDB, `SELECT name, priority FROM tasks ORDER BY priority`, &buf)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := buf.String()
+
+	assertContains(t, got, "name | priority")
+	assertContains(t, got, "first | 1")
+	assertContains(t, got, "second | 2")
+	if strings.Index(got, "first | 1") > strings.Index(got, "second | 2") {
+		t.Fatalf("rows were not printed in query order\noutput:\n%s", got)
+	}
+}
+
+func TestRunPrintsNULLValues(t *testing.T) {
+	sqlDB := openTestDB(t)
+	execSQL(t, sqlDB, `CREATE TABLE tasks(name TEXT NOT NULL, note TEXT)`)
+	execSQL(t, sqlDB, `INSERT INTO tasks(name, note) VALUES (?, ?)`, "first", nil)
+
+	var buf bytes.Buffer
+	err := run(context.Background(), sqlDB, `SELECT name, note FROM tasks ORDER BY name`, &buf)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	assertContains(t, buf.String(), "first | NULL")
+}
+
+func TestRunSupportsExpressionQueries(t *testing.T) {
+	sqlDB := openTestDB(t)
+
+	var buf bytes.Buffer
+	err := run(context.Background(), sqlDB, `SELECT 1 AS one, 'two' AS two`, &buf)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := buf.String()
+
+	assertContains(t, got, "one | two")
+	assertContains(t, got, "1 | two")
+}
+
+func TestRunReturnsQueryError(t *testing.T) {
+	sqlDB := openTestDB(t)
+
+	var buf bytes.Buffer
+	err := run(context.Background(), sqlDB, `SELECT * FROM missing_table`, &buf)
+	if err == nil {
+		t.Fatal("run returned nil error")
+	}
+	if !strings.Contains(err.Error(), "query") {
+		t.Fatalf("error = %q, want substring %q", err.Error(), "query")
+	}
+}
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "data", "app.db"), db.Options{
+		BusyTimeout: 5000,
+		JournalMode: "WAL",
+		Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return sqlDB
+}
+
+func execSQL(t *testing.T, sqlDB *sql.DB, stmt string, args ...any) {
+	t.Helper()
+	if _, err := sqlDB.ExecContext(context.Background(), stmt, args...); err != nil {
+		t.Fatalf("exec %q: %v", stmt, err)
+	}
+}
+
+func assertContains(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Fatalf("output missing %q\noutput:\n%s", want, got)
+	}
+}

--- a/cmd/slugfix/main.go
+++ b/cmd/slugfix/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -29,15 +31,21 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
+	if err := run(ctx, sqlDB, logger); err != nil {
+		logger.Fatal(err)
+	}
+}
+
+func run(ctx context.Context, sqlDB *sql.DB, logger *log.Logger) error {
 	if err := migrate.Apply(ctx, sqlDB); err != nil {
-		logger.Fatalf("migrate: %v", err)
+		return fmt.Errorf("migrate: %w", err)
 	}
 
 	st := store.New(sqlDB, nil)
 	n, err := st.RewriteDurableProjectSlugs(ctx)
 	if err != nil {
-		logger.Fatalf("rewrite slugs: %v", err)
+		return fmt.Errorf("rewrite slugs: %w", err)
 	}
 	logger.Printf("rewrote %d durable project slug(s)", n)
+	return nil
 }
-

--- a/cmd/slugfix/main_test.go
+++ b/cmd/slugfix/main_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"log"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"scrumboy/internal/db"
+	"scrumboy/internal/migrate"
+	"scrumboy/internal/store"
+)
+
+func TestRunAppliesMigrationsAndLogsRewriteCount(t *testing.T) {
+	sqlDB := openTestDB(t)
+	var buf bytes.Buffer
+
+	if err := run(context.Background(), sqlDB, newTestLogger(&buf)); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	assertContains(t, buf.String(), "rewrote 0 durable project slug(s)")
+	if got := schemaMigrationCount(t, sqlDB); got == 0 {
+		t.Fatal("schema_migrations count = 0, want at least 1")
+	}
+}
+
+func TestRunRewritesLegacyDurableProjectSlugs(t *testing.T) {
+	sqlDB := openTestDB(t)
+	ctx := context.Background()
+	if err := migrate.Apply(ctx, sqlDB); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	st := store.New(sqlDB, nil)
+	p1, err := st.CreateProject(ctx, "VO2 Max Coach")
+	if err != nil {
+		t.Fatalf("CreateProject #1: %v", err)
+	}
+	p2, err := st.CreateProject(ctx, "VO2 Max Coach")
+	if err != nil {
+		t.Fatalf("CreateProject #2: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx, `UPDATE projects SET slug = ? WHERE id = ?`, "deadbeef", p1.ID); err != nil {
+		t.Fatalf("set legacy slug p1: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx, `UPDATE projects SET slug = ? WHERE id = ?`, "cafebabe", p2.ID); err != nil {
+		t.Fatalf("set legacy slug p2: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := run(ctx, sqlDB, newTestLogger(&buf)); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	assertContains(t, buf.String(), "rewrote 2 durable project slug(s)")
+	p1r, err := st.GetProject(ctx, p1.ID)
+	if err != nil {
+		t.Fatalf("GetProject p1: %v", err)
+	}
+	p2r, err := st.GetProject(ctx, p2.ID)
+	if err != nil {
+		t.Fatalf("GetProject p2: %v", err)
+	}
+	if p1r.Slug != "vo2-max-coach" {
+		t.Fatalf("p1 slug = %q, want %q", p1r.Slug, "vo2-max-coach")
+	}
+	if p2r.Slug != "vo2-max-coach-2" {
+		t.Fatalf("p2 slug = %q, want %q", p2r.Slug, "vo2-max-coach-2")
+	}
+}
+
+func TestRunReturnsMigrateErrorForCanceledContext(t *testing.T) {
+	sqlDB := openTestDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var buf bytes.Buffer
+	err := run(ctx, sqlDB, newTestLogger(&buf))
+	if err == nil {
+		t.Fatal("run returned nil error")
+	}
+	if !strings.Contains(err.Error(), "migrate") {
+		t.Fatalf("error = %q, want substring %q", err.Error(), "migrate")
+	}
+}
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "data", "app.db"), db.Options{
+		BusyTimeout: 5000,
+		JournalMode: "WAL",
+		Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return sqlDB
+}
+
+func newTestLogger(buf *bytes.Buffer) *log.Logger {
+	return log.New(buf, "", 0)
+}
+
+func schemaMigrationCount(t *testing.T, sqlDB *sql.DB) int {
+	t.Helper()
+	var count int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
+		t.Fatalf("count schema_migrations: %v", err)
+	}
+	return count
+}
+
+func assertContains(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Fatalf("output missing %q\noutput:\n%s", want, got)
+	}
+}

--- a/cmd/tagcheck/main.go
+++ b/cmd/tagcheck/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"log"
 	"os"
 
@@ -31,49 +32,56 @@ func main() {
 	}
 	defer sqlDB.Close()
 
-	ctx := context.Background()
+	if err := run(context.Background(), sqlDB, os.Stdout); err != nil {
+		log.Fatal(err)
+	}
+}
 
+func run(ctx context.Context, sqlDB *sql.DB, out io.Writer) error {
 	// Check total tags
 	var totalTags int
 	if err := sqlDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM tags`).Scan(&totalTags); err != nil {
-		log.Fatalf("count tags: %v", err)
+		return fmt.Errorf("count tags: %w", err)
 	}
-	fmt.Printf("Total tags in database: %d\n\n", totalTags)
+	fmt.Fprintf(out, "Total tags in database: %d\n\n", totalTags)
 
 	// Check tags by scope
 	rows, err := sqlDB.QueryContext(ctx, `SELECT scope, COUNT(*) as count FROM tags GROUP BY scope`)
 	if err != nil {
-		log.Fatalf("query scope: %v", err)
+		return fmt.Errorf("query scope: %w", err)
 	}
-	defer rows.Close()
-	fmt.Println("Tags by scope:")
+	fmt.Fprintln(out, "Tags by scope:")
 	for rows.Next() {
 		var scope sql.NullString
 		var count int
 		if err := rows.Scan(&scope, &count); err != nil {
-			log.Fatalf("scan: %v", err)
+			_ = rows.Close()
+			return fmt.Errorf("scan: %w", err)
 		}
 		if scope.Valid {
-			fmt.Printf("  scope='%s': %d tags\n", scope.String, count)
+			fmt.Fprintf(out, "  scope='%s': %d tags\n", scope.String, count)
 		} else {
-			fmt.Printf("  scope=NULL: %d tags\n", count)
+			fmt.Fprintf(out, "  scope=NULL: %d tags\n", count)
 		}
 	}
-	fmt.Println()
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close scope rows: %w", err)
+	}
+	fmt.Fprintln(out)
 
 	// Check GLOBAL tags
 	var globalTags int
 	if err := sqlDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM tags WHERE scope = 'GLOBAL' AND project_id IS NULL`).Scan(&globalTags); err != nil {
-		log.Fatalf("count global: %v", err)
+		return fmt.Errorf("count global: %w", err)
 	}
-	fmt.Printf("GLOBAL tags (scope='GLOBAL' AND project_id IS NULL): %d\n\n", globalTags)
+	fmt.Fprintf(out, "GLOBAL tags (scope='GLOBAL' AND project_id IS NULL): %d\n\n", globalTags)
 
 	// Check todo_tags relationships
 	var totalTodoTags int
 	if err := sqlDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM todo_tags`).Scan(&totalTodoTags); err != nil {
-		log.Fatalf("count todo_tags: %v", err)
+		return fmt.Errorf("count todo_tags: %w", err)
 	}
-	fmt.Printf("Total todo_tags relationships: %d\n", totalTodoTags)
+	fmt.Fprintf(out, "Total todo_tags relationships: %d\n", totalTodoTags)
 
 	// Check orphaned todo_tags
 	var orphaned int
@@ -82,9 +90,9 @@ func main() {
 		LEFT JOIN tags t ON t.id = tt.tag_id 
 		WHERE t.id IS NULL
 	`).Scan(&orphaned); err != nil {
-		log.Fatalf("count orphaned: %v", err)
+		return fmt.Errorf("count orphaned: %w", err)
 	}
-	fmt.Printf("Orphaned todo_tags (referencing non-existent tags): %d\n\n", orphaned)
+	fmt.Fprintf(out, "Orphaned todo_tags (referencing non-existent tags): %d\n\n", orphaned)
 
 	// Check tags with todo relationships
 	var tagsWithTodos int
@@ -93,12 +101,12 @@ func main() {
 		FROM tags t 
 		INNER JOIN todo_tags tt ON t.id = tt.tag_id
 	`).Scan(&tagsWithTodos); err != nil {
-		log.Fatalf("count tags with todos: %v", err)
+		return fmt.Errorf("count tags with todos: %w", err)
 	}
-	fmt.Printf("Tags that are actually used by todos: %d\n\n", tagsWithTodos)
+	fmt.Fprintf(out, "Tags that are actually used by todos: %d\n\n", tagsWithTodos)
 
 	// Show some sample tags
-	fmt.Println("\nSample tags (first 10):")
+	fmt.Fprintln(out, "\nSample tags (first 10):")
 	rows, err = sqlDB.QueryContext(ctx, `
 		SELECT t.id, t.name, t.scope, t.project_id, COUNT(tt.todo_id) as todo_count 
 		FROM tags t 
@@ -108,9 +116,8 @@ func main() {
 		LIMIT 10
 	`)
 	if err != nil {
-		log.Fatalf("query sample: %v", err)
+		return fmt.Errorf("query sample: %w", err)
 	}
-	defer rows.Close()
 	for rows.Next() {
 		var id int64
 		var name string
@@ -118,7 +125,8 @@ func main() {
 		var projectID sql.NullInt64
 		var todoCount int
 		if err := rows.Scan(&id, &name, &scope, &projectID, &todoCount); err != nil {
-			log.Fatalf("scan sample: %v", err)
+			_ = rows.Close()
+			return fmt.Errorf("scan sample: %w", err)
 		}
 		scopeStr := "NULL"
 		if scope.Valid {
@@ -128,7 +136,10 @@ func main() {
 		if projectID.Valid {
 			projStr = fmt.Sprintf("%d", projectID.Int64)
 		}
-		fmt.Printf("  id=%d name='%s' scope=%s project_id=%s todo_count=%d\n", id, name, scopeStr, projStr, todoCount)
+		fmt.Fprintf(out, "  id=%d name='%s' scope=%s project_id=%s todo_count=%d\n", id, name, scopeStr, projStr, todoCount)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close sample rows: %w", err)
 	}
 
 	// Check if there are tags that should be GLOBAL but aren't
@@ -139,10 +150,11 @@ func main() {
 		WHERE (scope IS NULL OR scope != 'GLOBAL' OR project_id IS NOT NULL)
 		AND id IN (SELECT DISTINCT tag_id FROM todo_tags)
 	`).Scan(&wrongScope); err != nil {
-		log.Fatalf("count wrong scope: %v", err)
+		return fmt.Errorf("count wrong scope: %w", err)
 	}
 	if wrongScope > 0 {
-		fmt.Printf("\n⚠️  WARNING: %d tags used by todos have wrong scope (not GLOBAL with project_id=NULL)\n", wrongScope)
-		fmt.Println("   These tags exist but won't show up in full mode queries!")
+		fmt.Fprintf(out, "\n⚠️  WARNING: %d tags used by todos have wrong scope (not GLOBAL with project_id=NULL)\n", wrongScope)
+		fmt.Fprintln(out, "   These tags exist but won't show up in full mode queries!")
 	}
+	return nil
 }

--- a/cmd/tagcheck/main_test.go
+++ b/cmd/tagcheck/main_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"scrumboy/internal/db"
+)
+
+func TestRunReportsTagSummaryAndSamples(t *testing.T) {
+	sqlDB := openTestDB(t)
+	createTagCheckSchema(t, sqlDB)
+
+	execSQL(t, sqlDB, `INSERT INTO tags(id, name, scope, project_id) VALUES (?, ?, ?, ?)`, 1, "feature", "GLOBAL", nil)
+	execSQL(t, sqlDB, `INSERT INTO tags(id, name, scope, project_id) VALUES (?, ?, ?, ?)`, 2, "bug", nil, nil)
+	execSQL(t, sqlDB, `INSERT INTO tags(id, name, scope, project_id) VALUES (?, ?, ?, ?)`, 3, "techdebt", "PROJECT", 42)
+	execSQL(t, sqlDB, `INSERT INTO tags(id, name, scope, project_id) VALUES (?, ?, ?, ?)`, 4, "unused", "GLOBAL", nil)
+	execSQL(t, sqlDB, `INSERT INTO todo_tags(todo_id, tag_id) VALUES (?, ?)`, 100, 1)
+	execSQL(t, sqlDB, `INSERT INTO todo_tags(todo_id, tag_id) VALUES (?, ?)`, 101, 2)
+	execSQL(t, sqlDB, `INSERT INTO todo_tags(todo_id, tag_id) VALUES (?, ?)`, 102, 3)
+	execSQL(t, sqlDB, `INSERT INTO todo_tags(todo_id, tag_id) VALUES (?, ?)`, 103, 999)
+
+	var buf bytes.Buffer
+	if err := run(context.Background(), sqlDB, &buf); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := buf.String()
+
+	assertContains(t, got, "Total tags in database: 4")
+	assertContains(t, got, "Tags by scope:")
+	assertContains(t, got, "  scope='GLOBAL': 2 tags")
+	assertContains(t, got, "  scope=NULL: 1 tags")
+	assertContains(t, got, "  scope='PROJECT': 1 tags")
+	assertContains(t, got, "GLOBAL tags (scope='GLOBAL' AND project_id IS NULL): 2")
+	assertContains(t, got, "Total todo_tags relationships: 4")
+	assertContains(t, got, "Orphaned todo_tags (referencing non-existent tags): 1")
+	assertContains(t, got, "Tags that are actually used by todos: 3")
+	assertContains(t, got, "Sample tags (first 10):")
+	assertContains(t, got, "  id=1 name='feature' scope=GLOBAL project_id=NULL todo_count=1")
+	assertContains(t, got, "  id=2 name='bug' scope=NULL project_id=NULL todo_count=1")
+	assertContains(t, got, "  id=3 name='techdebt' scope=PROJECT project_id=42 todo_count=1")
+	assertContains(t, got, "  id=4 name='unused' scope=GLOBAL project_id=NULL todo_count=0")
+}
+
+func TestRunWarnsWhenUsedTagsHaveWrongScope(t *testing.T) {
+	sqlDB := openTestDB(t)
+	createTagCheckSchema(t, sqlDB)
+
+	execSQL(t, sqlDB, `INSERT INTO tags(id, name, scope, project_id) VALUES (?, ?, ?, ?)`, 1, "bug", nil, nil)
+	execSQL(t, sqlDB, `INSERT INTO todo_tags(todo_id, tag_id) VALUES (?, ?)`, 100, 1)
+
+	var buf bytes.Buffer
+	if err := run(context.Background(), sqlDB, &buf); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := buf.String()
+
+	assertContains(t, got, "WARNING: 1 tags used by todos have wrong scope")
+	assertContains(t, got, "   These tags exist but won't show up in full mode queries!")
+}
+
+func TestRunOmitsWrongScopeWarningWhenUsedTagsAreGlobal(t *testing.T) {
+	sqlDB := openTestDB(t)
+	createTagCheckSchema(t, sqlDB)
+
+	execSQL(t, sqlDB, `INSERT INTO tags(id, name, scope, project_id) VALUES (?, ?, ?, ?)`, 1, "feature", "GLOBAL", nil)
+	execSQL(t, sqlDB, `INSERT INTO todo_tags(todo_id, tag_id) VALUES (?, ?)`, 100, 1)
+
+	var buf bytes.Buffer
+	if err := run(context.Background(), sqlDB, &buf); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	assertNotContains(t, buf.String(), "WARNING:")
+}
+
+func TestRunReturnsQueryError(t *testing.T) {
+	sqlDB := openTestDB(t)
+
+	var buf bytes.Buffer
+	err := run(context.Background(), sqlDB, &buf)
+	if err == nil {
+		t.Fatal("run returned nil error")
+	}
+	if !strings.Contains(err.Error(), "count tags") {
+		t.Fatalf("error = %q, want substring %q", err.Error(), "count tags")
+	}
+}
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "data", "app.db"), db.Options{
+		BusyTimeout: 5000,
+		JournalMode: "WAL",
+		Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return sqlDB
+}
+
+func createTagCheckSchema(t *testing.T, sqlDB *sql.DB) {
+	t.Helper()
+	execSQL(t, sqlDB, `CREATE TABLE tags(id INTEGER PRIMARY KEY, name TEXT NOT NULL, scope TEXT, project_id INTEGER)`)
+	execSQL(t, sqlDB, `CREATE TABLE todo_tags(todo_id INTEGER NOT NULL, tag_id INTEGER NOT NULL)`)
+}
+
+func execSQL(t *testing.T, sqlDB *sql.DB, stmt string, args ...any) {
+	t.Helper()
+	if _, err := sqlDB.ExecContext(context.Background(), stmt, args...); err != nil {
+		t.Fatalf("exec %q: %v", stmt, err)
+	}
+}
+
+func assertContains(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Fatalf("output missing %q\noutput:\n%s", want, got)
+	}
+}
+
+func assertNotContains(t *testing.T, got, unwanted string) {
+	t.Helper()
+	if strings.Contains(got, unwanted) {
+		t.Fatalf("output unexpectedly contained %q\noutput:\n%s", unwanted, got)
+	}
+}

--- a/cmd/tagrecover/main.go
+++ b/cmd/tagrecover/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"io"
 	"log"
 	"os"
 
@@ -30,14 +32,18 @@ func main() {
 	}
 	defer sqlDB.Close()
 
-	ctx := context.Background()
+	if err := run(context.Background(), sqlDB, os.Stdout); err != nil {
+		log.Fatal(err)
+	}
+}
 
+func run(ctx context.Context, sqlDB *sql.DB, out io.Writer) error {
 	// Check if there are any todos that might have had tags
 	var totalTodos int
 	if err := sqlDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM todos`).Scan(&totalTodos); err != nil {
-		log.Fatalf("count todos: %v", err)
+		return fmt.Errorf("count todos: %w", err)
 	}
-	fmt.Printf("Total todos in database: %d\n", totalTodos)
+	fmt.Fprintf(out, "Total todos in database: %d\n", totalTodos)
 
 	// Check if there are any todos with project_id that match existing tags' old project_ids
 	// (This won't help much since tags are now GLOBAL, but let's see)
@@ -47,31 +53,32 @@ func main() {
 		FROM todos t
 		WHERE EXISTS (SELECT 1 FROM tags WHERE tags.name IN ('feature', 'bug', 'enhancement', 'experimental', 'marketing', 'techdebt', 'integration', 'anonymous-boards'))
 	`).Scan(&todosWithPossibleTags); err != nil {
-		log.Fatalf("count todos with possible tags: %v", err)
+		return fmt.Errorf("count todos with possible tags: %w", err)
 	}
-	fmt.Printf("Projects that might have had these tags: %d\n\n", todosWithPossibleTags)
+	fmt.Fprintf(out, "Projects that might have had these tags: %d\n\n", todosWithPossibleTags)
 
 	// List all available tags
-	fmt.Println("Available tags (these can be re-applied to todos):")
+	fmt.Fprintln(out, "Available tags (these can be re-applied to todos):")
 	rows, err := sqlDB.QueryContext(ctx, `SELECT id, name FROM tags ORDER BY name`)
 	if err != nil {
-		log.Fatalf("query tags: %v", err)
+		return fmt.Errorf("query tags: %w", err)
 	}
 	defer rows.Close()
 	for rows.Next() {
 		var id int64
 		var name string
 		if err := rows.Scan(&id, &name); err != nil {
-			log.Fatalf("scan: %v", err)
+			return fmt.Errorf("scan: %w", err)
 		}
-		fmt.Printf("  - %s (id=%d)\n", name, id)
+		fmt.Fprintf(out, "  - %s (id=%d)\n", name, id)
 	}
 
-	fmt.Println("\n⚠️  RECOVERY STATUS:")
-	fmt.Println("  - Tags preserved: YES (8 tags exist)")
-	fmt.Println("  - Tag-todo relationships: LOST (0 relationships)")
-	fmt.Println("  - Recovery possible: NO (relationships cannot be reconstructed without backup)")
-	fmt.Println("\n  ACTION REQUIRED:")
-	fmt.Println("  You will need to manually re-tag your todos using the tag names listed above.")
-	fmt.Println("  The tags themselves are available and ready to use.")
+	fmt.Fprintln(out, "\n⚠️  RECOVERY STATUS:")
+	fmt.Fprintln(out, "  - Tags preserved: YES (8 tags exist)")
+	fmt.Fprintln(out, "  - Tag-todo relationships: LOST (0 relationships)")
+	fmt.Fprintln(out, "  - Recovery possible: NO (relationships cannot be reconstructed without backup)")
+	fmt.Fprintln(out, "\n  ACTION REQUIRED:")
+	fmt.Fprintln(out, "  You will need to manually re-tag your todos using the tag names listed above.")
+	fmt.Fprintln(out, "  The tags themselves are available and ready to use.")
+	return nil
 }

--- a/cmd/tagrecover/main_test.go
+++ b/cmd/tagrecover/main_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"scrumboy/internal/db"
+)
+
+func TestRunReportsRecoverySummaryAndTags(t *testing.T) {
+	sqlDB := openTestDB(t)
+	createTagRecoverSchema(t, sqlDB)
+
+	execSQL(t, sqlDB, `INSERT INTO todos(project_id) VALUES (?)`, 10)
+	execSQL(t, sqlDB, `INSERT INTO todos(project_id) VALUES (?)`, 20)
+	execSQL(t, sqlDB, `INSERT INTO todos(project_id) VALUES (?)`, 10)
+	execSQL(t, sqlDB, `INSERT INTO tags(id, name) VALUES (?, ?)`, 1, "feature")
+	execSQL(t, sqlDB, `INSERT INTO tags(id, name) VALUES (?, ?)`, 2, "bug")
+	execSQL(t, sqlDB, `INSERT INTO tags(id, name) VALUES (?, ?)`, 3, "zzz")
+
+	var buf bytes.Buffer
+	if err := run(context.Background(), sqlDB, &buf); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := buf.String()
+
+	assertContains(t, got, "Total todos in database: 3")
+	assertContains(t, got, "Projects that might have had these tags: 2")
+	assertContains(t, got, "Available tags (these can be re-applied to todos):")
+	assertInOrder(t, got,
+		"  - bug (id=2)",
+		"  - feature (id=1)",
+		"  - zzz (id=3)",
+	)
+	assertContains(t, got, "⚠️  RECOVERY STATUS:")
+	assertContains(t, got, "  - Tags preserved: YES (8 tags exist)")
+	assertContains(t, got, "  - Tag-todo relationships: LOST (0 relationships)")
+	assertContains(t, got, "  - Recovery possible: NO (relationships cannot be reconstructed without backup)")
+	assertContains(t, got, "  ACTION REQUIRED:")
+	assertContains(t, got, "  You will need to manually re-tag your todos using the tag names listed above.")
+	assertContains(t, got, "  The tags themselves are available and ready to use.")
+}
+
+func TestRunHandlesNoTagsOrTodos(t *testing.T) {
+	sqlDB := openTestDB(t)
+	createTagRecoverSchema(t, sqlDB)
+
+	var buf bytes.Buffer
+	if err := run(context.Background(), sqlDB, &buf); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := buf.String()
+
+	assertContains(t, got, "Total todos in database: 0")
+	assertContains(t, got, "Projects that might have had these tags: 0")
+	assertContains(t, got, "Available tags (these can be re-applied to todos):")
+	assertContains(t, got, "⚠️  RECOVERY STATUS:")
+	assertContains(t, got, "  ACTION REQUIRED:")
+	assertNotContains(t, got, "(id=")
+}
+
+func TestRunReturnsCountTodosError(t *testing.T) {
+	sqlDB := openTestDB(t)
+
+	var buf bytes.Buffer
+	err := run(context.Background(), sqlDB, &buf)
+	if err == nil {
+		t.Fatal("run returned nil error")
+	}
+	if !strings.Contains(err.Error(), "count todos") {
+		t.Fatalf("error = %q, want substring %q", err.Error(), "count todos")
+	}
+}
+
+func TestRunReturnsMissingTagsError(t *testing.T) {
+	sqlDB := openTestDB(t)
+	execSQL(t, sqlDB, `CREATE TABLE todos(project_id INTEGER)`)
+
+	var buf bytes.Buffer
+	err := run(context.Background(), sqlDB, &buf)
+	if err == nil {
+		t.Fatal("run returned nil error")
+	}
+	if !strings.Contains(err.Error(), "count todos with possible tags") {
+		t.Fatalf("error = %q, want substring %q", err.Error(), "count todos with possible tags")
+	}
+}
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "data", "app.db"), db.Options{
+		BusyTimeout: 5000,
+		JournalMode: "WAL",
+		Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return sqlDB
+}
+
+func createTagRecoverSchema(t *testing.T, sqlDB *sql.DB) {
+	t.Helper()
+	execSQL(t, sqlDB, `CREATE TABLE todos(project_id INTEGER)`)
+	execSQL(t, sqlDB, `CREATE TABLE tags(id INTEGER PRIMARY KEY, name TEXT NOT NULL)`)
+}
+
+func execSQL(t *testing.T, sqlDB *sql.DB, stmt string, args ...any) {
+	t.Helper()
+	if _, err := sqlDB.ExecContext(context.Background(), stmt, args...); err != nil {
+		t.Fatalf("exec %q: %v", stmt, err)
+	}
+}
+
+func assertContains(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Fatalf("output missing %q\noutput:\n%s", want, got)
+	}
+}
+
+func assertNotContains(t *testing.T, got, unwanted string) {
+	t.Helper()
+	if strings.Contains(got, unwanted) {
+		t.Fatalf("output unexpectedly contained %q\noutput:\n%s", unwanted, got)
+	}
+}
+
+func assertInOrder(t *testing.T, got string, wants ...string) {
+	t.Helper()
+	last := -1
+	for _, want := range wants {
+		next := strings.Index(got, want)
+		if next == -1 {
+			t.Fatalf("output missing %q\noutput:\n%s", want, got)
+		}
+		if next < last {
+			t.Fatalf("output item %q appeared out of order\noutput:\n%s", want, got)
+		}
+		last = next
+	}
+}

--- a/internal/auth/password_validation_test.go
+++ b/internal/auth/password_validation_test.go
@@ -1,0 +1,42 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+
+	"scrumboy/internal/errs"
+)
+
+func TestValidatePassword(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "empty", input: "", wantErr: true},
+		{name: "whitespace only", input: " \t\n ", wantErr: true},
+		{name: "below minimum", input: "1234567", wantErr: true},
+		{name: "below minimum after trimming", input: " 1234567 ", wantErr: true},
+		{name: "exactly minimum", input: "12345678"},
+		{name: "longer password", input: "password123"},
+		{name: "exactly minimum after trimming", input: " 12345678 "},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePassword(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if !errors.Is(err, errs.ErrValidation) {
+					t.Fatalf("error = %v, want ErrValidation", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidatePassword(%q): %v", tc.input, err)
+			}
+		})
+	}
+}

--- a/internal/auth/tokens/password_reset_test.go
+++ b/internal/auth/tokens/password_reset_test.go
@@ -1,0 +1,233 @@
+package tokens
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func encodeTokenPayload(payload string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(payload))
+}
+
+func mustParseGeneratedToken(t *testing.T, token string) (int64, int64, []byte) {
+	t.Helper()
+
+	userID, timestamp, signature, err := ParsePasswordResetToken(token)
+	if err != nil {
+		t.Fatalf("ParsePasswordResetToken(%q): %v", token, err)
+	}
+	return userID, timestamp, signature
+}
+
+func signPasswordResetToken(secret []byte, userID int64, timestamp int64, passwordHash string) []byte {
+	payload := fmt.Sprintf("%d|%d", userID, timestamp)
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(payload))
+	mac.Write([]byte("|"))
+	mac.Write([]byte(passwordHash))
+	return mac.Sum(nil)
+}
+
+func TestGeneratePasswordResetToken_EmptySecret(t *testing.T) {
+	token, expiresAt, err := GeneratePasswordResetToken(nil, 42, "hash")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "secret required" {
+		t.Fatalf("error = %q, want secret required", err.Error())
+	}
+	if token != "" {
+		t.Fatalf("token = %q, want empty", token)
+	}
+	if !expiresAt.IsZero() {
+		t.Fatalf("expiresAt = %v, want zero", expiresAt)
+	}
+}
+
+func TestGeneratePasswordResetToken_ValidToken(t *testing.T) {
+	secret := []byte("test-secret")
+	passwordHash := "current-password-hash"
+	const userID int64 = 42
+
+	before := time.Now().UTC()
+	token, expiresAt, err := GeneratePasswordResetToken(secret, userID, passwordHash)
+	after := time.Now().UTC()
+	if err != nil {
+		t.Fatalf("GeneratePasswordResetToken: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+
+	minExpires := before.Add(TokenExpiry)
+	maxExpires := after.Add(TokenExpiry)
+	if expiresAt.Before(minExpires) || expiresAt.After(maxExpires) {
+		t.Fatalf("expiresAt = %v, want between %v and %v", expiresAt, minExpires, maxExpires)
+	}
+
+	gotUserID, timestamp, signature := mustParseGeneratedToken(t, token)
+	if gotUserID != userID {
+		t.Fatalf("userID = %d, want %d", gotUserID, userID)
+	}
+	if timestamp == 0 {
+		t.Fatal("timestamp = 0, want nonzero")
+	}
+	if timestamp < before.Add(-time.Second).Unix() || timestamp > after.Add(time.Second).Unix() {
+		t.Fatalf("timestamp = %d, want current between %d and %d", timestamp, before.Add(-time.Second).Unix(), after.Add(time.Second).Unix())
+	}
+	if len(signature) != 32 {
+		t.Fatalf("signature length = %d, want 32", len(signature))
+	}
+}
+
+func TestParsePasswordResetToken_MalformedInputs(t *testing.T) {
+	validSig := strings.Repeat("ab", 32)
+	cases := []struct {
+		name  string
+		token string
+	}{
+		{name: "empty", token: ""},
+		{name: "whitespace", token: " \t\n "},
+		{name: "invalid base64", token: "!not-base64!"},
+		{name: "too few parts", token: encodeTokenPayload("42|123")},
+		{name: "nonnumeric user id", token: encodeTokenPayload("abc|123|" + validSig)},
+		{name: "zero user id", token: encodeTokenPayload("0|123|" + validSig)},
+		{name: "negative user id", token: encodeTokenPayload("-1|123|" + validSig)},
+		{name: "nonnumeric timestamp", token: encodeTokenPayload("42|soon|" + validSig)},
+		{name: "non-hex signature", token: encodeTokenPayload("42|123|" + strings.Repeat("z", 64))},
+		{name: "wrong signature length", token: encodeTokenPayload("42|123|" + hex.EncodeToString([]byte("short")))},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			userID, timestamp, signature, err := ParsePasswordResetToken(tc.token)
+			if err == nil {
+				t.Fatalf("expected error, got userID=%d timestamp=%d signature=%x", userID, timestamp, signature)
+			}
+		})
+	}
+}
+
+func TestVerifyPasswordResetToken_ValidGeneratedToken(t *testing.T) {
+	secret := []byte("test-secret")
+	passwordHash := "current-password-hash"
+	const userID int64 = 42
+
+	token, _, err := GeneratePasswordResetToken(secret, userID, passwordHash)
+	if err != nil {
+		t.Fatalf("GeneratePasswordResetToken: %v", err)
+	}
+	gotUserID, timestamp, signature := mustParseGeneratedToken(t, token)
+
+	if err := VerifyPasswordResetToken(secret, gotUserID, timestamp, signature, passwordHash); err != nil {
+		t.Fatalf("VerifyPasswordResetToken: %v", err)
+	}
+}
+
+func TestVerifyPasswordResetToken_RejectsInvalidInputs(t *testing.T) {
+	secret := []byte("test-secret")
+	passwordHash := "current-password-hash"
+	const userID int64 = 42
+	now := time.Now().UTC().Unix()
+	validSignature := signPasswordResetToken(secret, userID, now, passwordHash)
+
+	mutatedSignature := append([]byte(nil), validSignature...)
+	mutatedSignature[0] ^= 0xff
+
+	expiredTimestamp := time.Now().UTC().Unix() - int64(TokenExpiry.Seconds()) - 60
+	futureTimestamp := time.Now().UTC().Unix() + int64(ClockSkew.Seconds()) + 60
+
+	cases := []struct {
+		name         string
+		secret       []byte
+		userID       int64
+		timestamp    int64
+		signature    []byte
+		passwordHash string
+		wantMessage  string
+	}{
+		{
+			name:         "empty secret",
+			secret:       nil,
+			userID:       userID,
+			timestamp:    now,
+			signature:    validSignature,
+			passwordHash: passwordHash,
+			wantMessage:  "secret required",
+		},
+		{
+			name:         "wrong secret",
+			secret:       []byte("wrong-secret"),
+			userID:       userID,
+			timestamp:    now,
+			signature:    validSignature,
+			passwordHash: passwordHash,
+		},
+		{
+			name:         "wrong password hash",
+			secret:       secret,
+			userID:       userID,
+			timestamp:    now,
+			signature:    validSignature,
+			passwordHash: "old-password-hash",
+		},
+		{
+			name:         "wrong user id",
+			secret:       secret,
+			userID:       userID + 1,
+			timestamp:    now,
+			signature:    validSignature,
+			passwordHash: passwordHash,
+		},
+		{
+			name:         "mutated signature",
+			secret:       secret,
+			userID:       userID,
+			timestamp:    now,
+			signature:    mutatedSignature,
+			passwordHash: passwordHash,
+		},
+		{
+			name:         "expired timestamp",
+			secret:       secret,
+			userID:       userID,
+			timestamp:    expiredTimestamp,
+			signature:    signPasswordResetToken(secret, userID, expiredTimestamp, passwordHash),
+			passwordHash: passwordHash,
+		},
+		{
+			name:         "future timestamp beyond skew",
+			secret:       secret,
+			userID:       userID,
+			timestamp:    futureTimestamp,
+			signature:    signPasswordResetToken(secret, userID, futureTimestamp, passwordHash),
+			passwordHash: passwordHash,
+		},
+		{
+			name:         "non-32-byte signature",
+			secret:       secret,
+			userID:       userID,
+			timestamp:    now,
+			signature:    []byte("short"),
+			passwordHash: passwordHash,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := VerifyPasswordResetToken(tc.secret, tc.userID, tc.timestamp, tc.signature, tc.passwordHash)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if tc.wantMessage != "" && err.Error() != tc.wantMessage {
+				t.Fatalf("error = %q, want %q", err.Error(), tc.wantMessage)
+			}
+		})
+	}
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,0 +1,117 @@
+package db
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func testOptions() Options {
+	return Options{BusyTimeout: 5000, JournalMode: "WAL", Synchronous: "FULL"}
+}
+
+func openTempDB(t *testing.T, opts Options) (*sql.DB, string) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "data", "app.db")
+	sqlDB, err := Open(path, opts)
+	if err != nil {
+		t.Fatalf("Open(%q): %v", path, err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return sqlDB, path
+}
+
+func pragmaInt(t *testing.T, sqlDB *sql.DB, name string) int {
+	t.Helper()
+
+	var got int
+	if err := sqlDB.QueryRow("PRAGMA " + name).Scan(&got); err != nil {
+		t.Fatalf("PRAGMA %s: %v", name, err)
+	}
+	return got
+}
+
+func pragmaString(t *testing.T, sqlDB *sql.DB, name string) string {
+	t.Helper()
+
+	var got string
+	if err := sqlDB.QueryRow("PRAGMA " + name).Scan(&got); err != nil {
+		t.Fatalf("PRAGMA %s: %v", name, err)
+	}
+	return got
+}
+
+func TestOpenCreatesParentDirectoryAndPings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data", "app.db")
+	parent := filepath.Dir(path)
+	if _, err := os.Stat(parent); !os.IsNotExist(err) {
+		t.Fatalf("parent directory exists before Open or stat failed: %v", err)
+	}
+
+	sqlDB, err := Open(path, testOptions())
+	if err != nil {
+		t.Fatalf("Open(%q): %v", path, err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	info, err := os.Stat(parent)
+	if err != nil {
+		t.Fatalf("stat parent directory: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("parent path %q is not a directory", parent)
+	}
+	if err := sqlDB.Ping(); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	var got int
+	if err := sqlDB.QueryRow("SELECT 1").Scan(&got); err != nil {
+		t.Fatalf("SELECT 1: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("SELECT 1 = %d, want 1", got)
+	}
+}
+
+func TestOpenAppliesSQLitePragmas(t *testing.T) {
+	sqlDB, _ := openTempDB(t, testOptions())
+
+	if got := pragmaInt(t, sqlDB, "busy_timeout"); got != 5000 {
+		t.Fatalf("PRAGMA busy_timeout = %d, want 5000", got)
+	}
+	if got := strings.ToLower(pragmaString(t, sqlDB, "journal_mode")); got != "wal" {
+		t.Fatalf("PRAGMA journal_mode = %q, want wal", got)
+	}
+	if got := pragmaInt(t, sqlDB, "synchronous"); got != 2 {
+		t.Fatalf("PRAGMA synchronous = %d, want 2", got)
+	}
+	if got := pragmaInt(t, sqlDB, "foreign_keys"); got != 1 {
+		t.Fatalf("PRAGMA foreign_keys = %d, want 1", got)
+	}
+}
+
+func TestOpenConstrainsConnectionPool(t *testing.T) {
+	sqlDB, _ := openTempDB(t, testOptions())
+
+	if got := sqlDB.Stats().MaxOpenConnections; got != 1 {
+		t.Fatalf("MaxOpenConnections = %d, want 1", got)
+	}
+}
+
+func TestOpenRejectsZeroBusyTimeout(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data", "app.db")
+	sqlDB, err := Open(path, Options{BusyTimeout: 0, JournalMode: "WAL", Synchronous: "FULL"})
+	if sqlDB != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("returned *sql.DB = %v, want nil", sqlDB)
+	}
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "busy_timeout is 0") {
+		t.Fatalf("error = %q, want busy_timeout is 0", err.Error())
+	}
+}

--- a/internal/eventbus/fanout_test.go
+++ b/internal/eventbus/fanout_test.go
@@ -1,0 +1,159 @@
+package eventbus
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type recordedEvent struct {
+	ctx   context.Context
+	event Event
+}
+
+type recordingConsumer struct {
+	calls   []recordedEvent
+	onEvent func(ctx context.Context, e Event)
+}
+
+func (c *recordingConsumer) OnEvent(ctx context.Context, e Event) {
+	c.calls = append(c.calls, recordedEvent{ctx: ctx, event: e})
+	if c.onEvent != nil {
+		c.onEvent(ctx, e)
+	}
+}
+
+func TestFanoutPublishWithNoConsumersSucceeds(t *testing.T) {
+	fanout := NewFanout()
+
+	if err := fanout.Publish(context.Background(), Event{Type: "test.event"}); err != nil {
+		t.Fatalf("Publish returned error: %v", err)
+	}
+}
+
+func TestFanoutPublishPopulatesMissingIDAndTime(t *testing.T) {
+	consumer := &recordingConsumer{}
+	fanout := NewFanout(consumer)
+
+	before := time.Now().UTC().Add(-time.Second)
+	if err := fanout.Publish(context.Background(), Event{
+		Type:      "test.event",
+		ProjectID: 123,
+	}); err != nil {
+		t.Fatalf("Publish returned error: %v", err)
+	}
+	after := time.Now().UTC().Add(time.Second)
+
+	if len(consumer.calls) != 1 {
+		t.Fatalf("consumer calls = %d, want 1", len(consumer.calls))
+	}
+	got := consumer.calls[0].event
+	if got.ID == "" {
+		t.Fatal("generated event ID is empty")
+	}
+	if got.Time.IsZero() {
+		t.Fatal("generated event time is zero")
+	}
+	if got.Time.Location() != time.UTC {
+		t.Fatalf("generated event time location = %v, want UTC", got.Time.Location())
+	}
+	if got.Time.Before(before) || got.Time.After(after) {
+		t.Fatalf("generated event time = %v, want between %v and %v", got.Time, before, after)
+	}
+}
+
+func TestFanoutPublishPreservesExistingIDAndTime(t *testing.T) {
+	consumer := &recordingConsumer{}
+	fanout := NewFanout(consumer)
+	want := Event{
+		ID:        "evt-fixed",
+		Type:      "test.event",
+		Time:      time.Date(2025, time.January, 2, 3, 4, 5, 0, time.UTC),
+		ProjectID: 456,
+		Payload:   []byte(`{"ok":true}`),
+	}
+
+	if err := fanout.Publish(context.Background(), want); err != nil {
+		t.Fatalf("Publish returned error: %v", err)
+	}
+
+	if len(consumer.calls) != 1 {
+		t.Fatalf("consumer calls = %d, want 1", len(consumer.calls))
+	}
+	got := consumer.calls[0].event
+	if got.ID != want.ID {
+		t.Fatalf("event ID = %q, want %q", got.ID, want.ID)
+	}
+	if !got.Time.Equal(want.Time) {
+		t.Fatalf("event time = %v, want %v", got.Time, want.Time)
+	}
+	if got.Type != want.Type {
+		t.Fatalf("event type = %q, want %q", got.Type, want.Type)
+	}
+	if got.ProjectID != want.ProjectID {
+		t.Fatalf("event project ID = %d, want %d", got.ProjectID, want.ProjectID)
+	}
+	if !reflect.DeepEqual(got.Payload, want.Payload) {
+		t.Fatalf("event payload = %s, want %s", got.Payload, want.Payload)
+	}
+}
+
+func TestFanoutPublishDeliversToConsumersInOrder(t *testing.T) {
+	var order []string
+	first := &recordingConsumer{onEvent: func(context.Context, Event) { order = append(order, "first") }}
+	second := &recordingConsumer{onEvent: func(context.Context, Event) { order = append(order, "second") }}
+	third := &recordingConsumer{onEvent: func(context.Context, Event) { order = append(order, "third") }}
+	fanout := NewFanout(first, second, third)
+	want := Event{
+		ID:        "evt-ordered",
+		Type:      "test.event",
+		Time:      time.Date(2025, time.February, 3, 4, 5, 6, 0, time.UTC),
+		ProjectID: 789,
+		Payload:   []byte(`{"ordered":true}`),
+	}
+
+	if err := fanout.Publish(context.Background(), want); err != nil {
+		t.Fatalf("Publish returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(order, []string{"first", "second", "third"}) {
+		t.Fatalf("delivery order = %v, want [first second third]", order)
+	}
+	for name, consumer := range map[string]*recordingConsumer{
+		"first":  first,
+		"second": second,
+		"third":  third,
+	} {
+		if len(consumer.calls) != 1 {
+			t.Fatalf("%s consumer calls = %d, want 1", name, len(consumer.calls))
+		}
+		if !reflect.DeepEqual(consumer.calls[0].event, want) {
+			t.Fatalf("%s consumer event = %+v, want %+v", name, consumer.calls[0].event, want)
+		}
+	}
+}
+
+func TestFanoutPublishPassesContextThrough(t *testing.T) {
+	type contextKey struct{}
+
+	consumer := &recordingConsumer{}
+	fanout := NewFanout(consumer)
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), contextKey{}, "test-value"))
+	cancel()
+
+	if err := fanout.Publish(ctx, Event{ID: "evt-context", Time: time.Now().UTC()}); err != nil {
+		t.Fatalf("Publish returned error: %v", err)
+	}
+
+	if len(consumer.calls) != 1 {
+		t.Fatalf("consumer calls = %d, want 1", len(consumer.calls))
+	}
+	gotCtx := consumer.calls[0].ctx
+	if gotCtx.Value(contextKey{}) != "test-value" {
+		t.Fatalf("context value = %v, want test-value", gotCtx.Value(contextKey{}))
+	}
+	if gotCtx.Err() != context.Canceled {
+		t.Fatalf("context error = %v, want %v", gotCtx.Err(), context.Canceled)
+	}
+}

--- a/internal/httpapi/ratelimit/ratelimit_test.go
+++ b/internal/httpapi/ratelimit/ratelimit_test.go
@@ -1,0 +1,155 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNormalizeEmailTrimsAndLowercases(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "surrounding whitespace", input: "  User@Example.COM  ", want: "user@example.com"},
+		{name: "tabs and newlines", input: "\tUser@Example.COM\n", want: "user@example.com"},
+		{name: "mixed case", input: "MiXeD@Example.COM", want: "mixed@example.com"},
+		{name: "plus address text", input: " User.Name+Tag@Example.COM ", want: "user.name+tag@example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeEmail(tt.input); got != tt.want {
+				t.Fatalf("NormalizeEmail(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAllowWithNoKeysAlwaysSucceeds(t *testing.T) {
+	limiter := New(1, time.Minute)
+
+	for i := 0; i < 5; i++ {
+		if !limiter.Allow("", "") {
+			t.Fatalf("Allow with empty keys returned false on call %d", i+1)
+		}
+	}
+}
+
+func TestAllowHonorsIPLimit(t *testing.T) {
+	limiter := New(2, time.Minute)
+
+	if !limiter.Allow("ip:192.0.2.1", "") {
+		t.Fatal("first request for IP was rejected")
+	}
+	if !limiter.Allow("ip:192.0.2.1", "") {
+		t.Fatal("second request for IP was rejected")
+	}
+	if limiter.Allow("ip:192.0.2.1", "") {
+		t.Fatal("third request for same IP was allowed")
+	}
+	if !limiter.Allow("ip:192.0.2.2", "") {
+		t.Fatal("request for different IP was rejected")
+	}
+}
+
+func TestAllowHonorsEmailLimitAcrossDifferentIPs(t *testing.T) {
+	limiter := New(2, time.Minute)
+	emailKey := "email:" + NormalizeEmail("User+Tag@Example.COM")
+
+	if !limiter.Allow("ip:192.0.2.1", emailKey) {
+		t.Fatal("first request for email was rejected")
+	}
+	if !limiter.Allow("ip:192.0.2.2", emailKey) {
+		t.Fatal("second request for email was rejected")
+	}
+	if limiter.Allow("ip:192.0.2.3", emailKey) {
+		t.Fatal("third request for same email across different IPs was allowed")
+	}
+}
+
+func TestAllowHonorsIPLimitAcrossDifferentEmails(t *testing.T) {
+	limiter := New(2, time.Minute)
+	ipKey := "ip:192.0.2.1"
+
+	if !limiter.Allow(ipKey, "email:"+NormalizeEmail("one@example.com")) {
+		t.Fatal("first request for IP was rejected")
+	}
+	if !limiter.Allow(ipKey, "email:"+NormalizeEmail("two@example.com")) {
+		t.Fatal("second request for IP was rejected")
+	}
+	if limiter.Allow(ipKey, "email:"+NormalizeEmail("three@example.com")) {
+		t.Fatal("third request for same IP across different emails was allowed")
+	}
+}
+
+func TestAllowResetsExpiredWindow(t *testing.T) {
+	window := time.Minute
+	limiter := New(2, window)
+	key := "ip:192.0.2.1"
+
+	if !limiter.Allow(key, "") {
+		t.Fatal("first request was rejected")
+	}
+	if !limiter.Allow(key, "") {
+		t.Fatal("second request was rejected")
+	}
+	if limiter.Allow(key, "") {
+		t.Fatal("third request before window expiry was allowed")
+	}
+
+	limiter.mu.Lock()
+	limiter.entries[key].windowAt = time.Now().Add(-window - time.Second)
+	limiter.mu.Unlock()
+
+	beforeReset := time.Now().Add(-time.Second)
+	if !limiter.Allow(key, "") {
+		t.Fatal("request after window expiry was rejected")
+	}
+	afterReset := time.Now().Add(time.Second)
+
+	limiter.mu.Lock()
+	got := limiter.entries[key]
+	limiter.mu.Unlock()
+	if got == nil {
+		t.Fatal("entry was not recreated after expired window")
+	}
+	if got.count != 1 {
+		t.Fatalf("entry count after reset = %d, want 1", got.count)
+	}
+	if got.windowAt.Before(beforeReset) || got.windowAt.After(afterReset) {
+		t.Fatalf("entry windowAt after reset = %v, want between %v and %v", got.windowAt, beforeReset, afterReset)
+	}
+}
+
+func TestAllowCleansStaleEntries(t *testing.T) {
+	window := time.Minute
+	limiter := New(2, window)
+	now := time.Now()
+	staleKey := "ip:stale"
+	freshKey := "ip:fresh"
+	newKey := "ip:new"
+
+	limiter.mu.Lock()
+	limiter.entries[staleKey] = &entry{count: 1, windowAt: now.Add(-window - time.Second)}
+	limiter.entries[freshKey] = &entry{count: 1, windowAt: now}
+	limiter.lastClean = now.Add(-limiter.cleanup - time.Second)
+	limiter.mu.Unlock()
+
+	if !limiter.Allow(newKey, "") {
+		t.Fatal("request for new key was rejected")
+	}
+
+	limiter.mu.Lock()
+	defer limiter.mu.Unlock()
+	if _, ok := limiter.entries[staleKey]; ok {
+		t.Fatal("stale entry remained after cleanup")
+	}
+	if _, ok := limiter.entries[freshKey]; !ok {
+		t.Fatal("fresh entry was removed during cleanup")
+	}
+	if _, ok := limiter.entries[newKey]; !ok {
+		t.Fatal("new key entry was not created")
+	}
+}

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -1,0 +1,274 @@
+package migrate
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"scrumboy/internal/db"
+)
+
+func openMigratedDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	sqlDB := openRawTestDB(t)
+	if err := Apply(context.Background(), sqlDB); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	return sqlDB
+}
+
+func openRawTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "data", "app.db"), db.Options{
+		BusyTimeout: 5000,
+		JournalMode: "WAL",
+		Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return sqlDB
+}
+
+func embeddedMigrationVersions(t *testing.T) []string {
+	t.Helper()
+
+	entries, err := migrationsFS.ReadDir("migrations")
+	if err != nil {
+		t.Fatalf("ReadDir migrations: %v", err)
+	}
+	var versions []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		versions = append(versions, entry.Name())
+	}
+	sort.Strings(versions)
+	return versions
+}
+
+func appliedMigrationVersions(t *testing.T, sqlDB *sql.DB) []string {
+	t.Helper()
+
+	rows, err := sqlDB.Query(`SELECT version FROM schema_migrations ORDER BY version`)
+	if err != nil {
+		t.Fatalf("query schema_migrations: %v", err)
+	}
+	defer rows.Close()
+
+	var versions []string
+	for rows.Next() {
+		var version string
+		if err := rows.Scan(&version); err != nil {
+			t.Fatalf("scan schema_migrations: %v", err)
+		}
+		versions = append(versions, version)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("schema_migrations rows: %v", err)
+	}
+	return versions
+}
+
+func pragmaInt(t *testing.T, sqlDB *sql.DB, name string) int {
+	t.Helper()
+
+	var got int
+	if err := sqlDB.QueryRow("PRAGMA " + name).Scan(&got); err != nil {
+		t.Fatalf("PRAGMA %s: %v", name, err)
+	}
+	return got
+}
+
+func tableExists(t *testing.T, sqlDB *sql.DB, name string) bool {
+	t.Helper()
+	return sqliteMasterObjectExists(t, sqlDB, "table", name)
+}
+
+func columnExists(t *testing.T, sqlDB *sql.DB, table, column string) bool {
+	t.Helper()
+
+	rows, err := sqlDB.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		t.Fatalf("PRAGMA table_info(%s): %v", table, err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid        int
+			name       string
+			columnType string
+			notNull    int
+			defaultVal sql.NullString
+			pk         int
+		)
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultVal, &pk); err != nil {
+			t.Fatalf("scan table_info(%s): %v", table, err)
+		}
+		if name == column {
+			return true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("table_info(%s) rows: %v", table, err)
+	}
+	return false
+}
+
+func indexExists(t *testing.T, sqlDB *sql.DB, name string) bool {
+	t.Helper()
+	return sqliteMasterObjectExists(t, sqlDB, "index", name)
+}
+
+func triggerExists(t *testing.T, sqlDB *sql.DB, name string) bool {
+	t.Helper()
+	return sqliteMasterObjectExists(t, sqlDB, "trigger", name)
+}
+
+func sqliteMasterObjectExists(t *testing.T, sqlDB *sql.DB, objectType, name string) bool {
+	t.Helper()
+
+	var exists bool
+	if err := sqlDB.QueryRow(`SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = ? AND name = ?)`, objectType, name).Scan(&exists); err != nil {
+		t.Fatalf("query sqlite_master %s %s: %v", objectType, name, err)
+	}
+	return exists
+}
+
+func TestApplyFreshDatabaseRecordsAllEmbeddedMigrations(t *testing.T) {
+	sqlDB := openRawTestDB(t)
+	if err := Apply(context.Background(), sqlDB); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	want := embeddedMigrationVersions(t)
+	got := appliedMigrationVersions(t, sqlDB)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("applied versions = %v, want %v", got, want)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected at least one migration")
+	}
+	if got[0] != "001_init.sql" {
+		t.Fatalf("first migration = %q, want 001_init.sql", got[0])
+	}
+	if len(got) != len(want) {
+		t.Fatalf("applied count = %d, want %d", len(got), len(want))
+	}
+}
+
+func TestApplyIsIdempotent(t *testing.T) {
+	sqlDB := openRawTestDB(t)
+	if err := Apply(context.Background(), sqlDB); err != nil {
+		t.Fatalf("Apply #1: %v", err)
+	}
+	first := appliedMigrationVersions(t, sqlDB)
+
+	if err := Apply(context.Background(), sqlDB); err != nil {
+		t.Fatalf("Apply #2: %v", err)
+	}
+	second := appliedMigrationVersions(t, sqlDB)
+
+	if !reflect.DeepEqual(second, first) {
+		t.Fatalf("second applied versions = %v, want %v", second, first)
+	}
+	var duplicates int
+	if err := sqlDB.QueryRow(`
+SELECT COUNT(*) FROM (
+  SELECT version
+  FROM schema_migrations
+  GROUP BY version
+  HAVING COUNT(*) > 1
+)`).Scan(&duplicates); err != nil {
+		t.Fatalf("query duplicate migrations: %v", err)
+	}
+	if duplicates != 0 {
+		t.Fatalf("duplicate schema_migrations rows = %d, want 0", duplicates)
+	}
+}
+
+func TestApplyCreatesCurrentSchemaLandmarks(t *testing.T) {
+	sqlDB := openMigratedDB(t)
+
+	for _, table := range []string{
+		"projects",
+		"todos",
+		"users",
+		"sessions",
+		"project_members",
+		"project_workflow_columns",
+		"todo_assignee_events",
+		"audit_events",
+		"api_tokens",
+		"user_oidc_identities",
+		"webhooks",
+		"push_subscriptions",
+		"project_walls",
+	} {
+		if !tableExists(t, sqlDB, table) {
+			t.Fatalf("expected table %s to exist", table)
+		}
+	}
+
+	for _, tc := range []struct {
+		table  string
+		column string
+	}{
+		{table: "projects", column: "dominant_color"},
+		{table: "projects", column: "import_metadata"},
+		{table: "todos", column: "column_key"},
+		{table: "todos", column: "done_at"},
+		{table: "todos", column: "import_metadata"},
+		{table: "project_walls", column: "edges"},
+		{table: "users", column: "two_factor_enabled"},
+	} {
+		if !columnExists(t, sqlDB, tc.table, tc.column) {
+			t.Fatalf("expected column %s.%s to exist", tc.table, tc.column)
+		}
+	}
+
+	for _, index := range []string{
+		"idx_projects_slug_production",
+		"idx_todos_project_local_id",
+		"idx_todos_project_column_key_rank_id",
+	} {
+		if !indexExists(t, sqlDB, index) {
+			t.Fatalf("expected index %s to exist", index)
+		}
+	}
+
+	for _, trigger := range []string{
+		"trg_audit_events_no_update",
+		"trg_todo_assignee_events_no_delete",
+	} {
+		if !triggerExists(t, sqlDB, trigger) {
+			t.Fatalf("expected trigger %s to exist", trigger)
+		}
+	}
+}
+
+func TestApplyLeavesForeignKeysEnabled(t *testing.T) {
+	sqlDB := openMigratedDB(t)
+
+	if got := pragmaInt(t, sqlDB, "foreign_keys"); got != 1 {
+		t.Fatalf("PRAGMA foreign_keys = %d, want 1", got)
+	}
+}
+
+func TestApplyWithCanceledContextReturnsError(t *testing.T) {
+	sqlDB := openRawTestDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := Apply(ctx, sqlDB); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/projectcolor/projectcolor_test.go
+++ b/internal/projectcolor/projectcolor_test.go
@@ -1,0 +1,150 @@
+package projectcolor
+
+import (
+	"bytes"
+	"encoding/base64"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
+	"strconv"
+	"testing"
+)
+
+func solidPNGDataURL(t *testing.T, c color.RGBA) string {
+	t.Helper()
+
+	img := image.NewRGBA(image.Rect(0, 0, 16, 16))
+	draw.Draw(img, img.Bounds(), &image.Uniform{C: c}, image.Point{}, draw.Src)
+	return pngDataURL(t, img)
+}
+
+func pngDataURL(t *testing.T, img image.Image) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("png.Encode: %v", err)
+	}
+	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(buf.Bytes())
+}
+
+func parseHexColor(t *testing.T, got string) (r, g, b uint8) {
+	t.Helper()
+	assertHexColor(t, got)
+
+	r64, err := strconv.ParseUint(got[1:3], 16, 8)
+	if err != nil {
+		t.Fatalf("parse red from %q: %v", got, err)
+	}
+	g64, err := strconv.ParseUint(got[3:5], 16, 8)
+	if err != nil {
+		t.Fatalf("parse green from %q: %v", got, err)
+	}
+	b64, err := strconv.ParseUint(got[5:7], 16, 8)
+	if err != nil {
+		t.Fatalf("parse blue from %q: %v", got, err)
+	}
+	return uint8(r64), uint8(g64), uint8(b64)
+}
+
+func assertHexColor(t *testing.T, got string) {
+	t.Helper()
+
+	if len(got) != 7 || got[0] != '#' {
+		t.Fatalf("color = %q, want #RRGGBB", got)
+	}
+	for _, c := range got[1:] {
+		if (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') {
+			continue
+		}
+		t.Fatalf("color = %q, want uppercase #RRGGBB", got)
+	}
+}
+
+func TestExtractFromDataURL_InvalidInputsReturnFallback(t *testing.T) {
+	notImage := base64.StdEncoding.EncodeToString([]byte("not an image"))
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{name: "empty", input: ""},
+		{name: "whitespace", input: " \t\n "},
+		{name: "non data url", input: "https://example.test/image.png"},
+		{name: "data url without comma", input: "data:image/png;base64"},
+		{name: "data url without base64", input: "data:image/png," + notImage},
+		{name: "malformed base64", input: "data:image/png;base64,not-base64!!!"},
+		{name: "base64 non image", input: "data:text/plain;base64," + notImage},
+		{name: "empty base64 image payload", input: "data:image/png;base64,"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ExtractFromDataURL(tc.input); got != fallbackColor {
+				t.Fatalf("ExtractFromDataURL(%q) = %q, want %q", tc.input, got, fallbackColor)
+			}
+		})
+	}
+}
+
+func TestExtractFromDataURL_SolidPNGPreservesDominantChannel(t *testing.T) {
+	cases := []struct {
+		name     string
+		color    color.RGBA
+		dominant string
+	}{
+		{name: "red", color: color.RGBA{R: 255, A: 255}, dominant: "red"},
+		{name: "green", color: color.RGBA{G: 255, A: 255}, dominant: "green"},
+		{name: "blue", color: color.RGBA{B: 255, A: 255}, dominant: "blue"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractFromDataURL(solidPNGDataURL(t, tc.color))
+			if got == fallbackColor {
+				t.Fatalf("ExtractFromDataURL returned fallback color %q", got)
+			}
+			r, g, b := parseHexColor(t, got)
+			switch tc.dominant {
+			case "red":
+				if r <= g || r <= b {
+					t.Fatalf("color %q channels r=%d g=%d b=%d, want red dominant", got, r, g, b)
+				}
+			case "green":
+				if g <= r || g <= b {
+					t.Fatalf("color %q channels r=%d g=%d b=%d, want green dominant", got, r, g, b)
+				}
+			case "blue":
+				if b <= r || b <= g {
+					t.Fatalf("color %q channels r=%d g=%d b=%d, want blue dominant", got, r, g, b)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractFromDataURL_ClampsBlackAndWhite(t *testing.T) {
+	black := ExtractFromDataURL(solidPNGDataURL(t, color.RGBA{A: 255}))
+	if black == "#000000" {
+		t.Fatal("black image returned #000000, want lifted display color")
+	}
+	blackR, blackG, blackB := parseHexColor(t, black)
+	if blackR == 0 && blackG == 0 && blackB == 0 {
+		t.Fatalf("black image channels r=%d g=%d b=%d, want at least one channel above zero", blackR, blackG, blackB)
+	}
+
+	white := ExtractFromDataURL(solidPNGDataURL(t, color.RGBA{R: 255, G: 255, B: 255, A: 255}))
+	if white == "#FFFFFF" {
+		t.Fatal("white image returned #FFFFFF, want clamped display color")
+	}
+	whiteR, whiteG, whiteB := parseHexColor(t, white)
+	if whiteR == 255 && whiteG == 255 && whiteB == 255 {
+		t.Fatalf("white image channels r=%d g=%d b=%d, want at least one channel below 255", whiteR, whiteG, whiteB)
+	}
+}
+
+func TestExtractFromDataURL_TransparentPNGReturnsValidColor(t *testing.T) {
+	img := image.NewRGBA(image.Rect(0, 0, 16, 16))
+	got := ExtractFromDataURL(pngDataURL(t, img))
+	assertHexColor(t, got)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.18.23"
+const Version = "3.18.24"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
Expand automated test coverage across key packages, including authentication, database, event bus, rate limiting, and maintenance CLI tools. Introduce a GitHub Actions CI workflow that runs the Go and frontend test suites on every PR and push to `main`, with a README status badge reflecting the current test status. Direct tests for `internal/errs` and `internal/version` were intentionally omitted, as they are constant/sentinel-only packages already exercised indirectly.
