### PR TITLE
oidc: tolerate trailing-slash issuer (Authentik) in discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 > **Upgrades:** No breaking changes in **3.7.x** / **3.8.x** / **3.9.x** / **3.10.x** / **3.11.x** / **3.12.x** / **3.13.x** / **3.14.x** / **3.15.x** / **3.16.x** / **3.17.x** / **3.18.x** unless noted below.
 
+## [3.18.25] - 2026-07-05
+
+### Fixed
+
+- **OIDC trailing-slash issuer** - Discovery accepts the normalized configured issuer or exactly the same issuer with one trailing slash (e.g. Authentik) without disabling issuer validation; stored OIDC identities still use the canonical configured issuer.
+
+### Documentation
+
+- **OIDC** - Updated issuer matching, discovery, and troubleshooting notes for trailing-slash providers.
+
+### Tests
+
+- **OIDC** - Discovery fallback, trailing-slash login identity storage, and rejection of mismatched ID-token issuers.
+
 ## [3.18.24] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.18.24-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.18.25-blue" alt="version" />
   <img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" />
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml">

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -66,13 +66,13 @@ All token handling happens on the server. The browser never sees access tokens o
 
 **Identity**
 
-- Identity is tracked by `(issuer, subject)` — the provider's `iss` + `sub` claims.
+- Identity is tracked by `(issuer, subject)` — Scrumboy's normalized configured issuer + the token's `sub` claim.
 - Email is not used as a join key. Changing your email at the provider does not break the link; the row in Scrumboy keeps the email from first login until you change it in-app or via admin.
 - There is no account linking between local password accounts and OIDC accounts.
 
 **First user / ownership**
 
-- If no users exist when an OIDC login succeeds, that user becomes the instance owner — but only if the token's issuer matches `SCRUMBOY_OIDC_ISSUER` exactly.
+- If no users exist when an OIDC login succeeds, that user becomes the instance owner. Discovery accepts only the configured issuer after normalization, or that same issuer with one trailing slash.
 - If a local password account was created first via bootstrap, subsequent OIDC users are created as normal users.
 
 **Display name**
@@ -101,7 +101,7 @@ SCRUMBOY_OIDC_ISSUER=https://auth.example.com/realms/myrealm
 SCRUMBOY_OIDC_ISSUER=https://auth.example.com/realms/myrealm/
 ```
 
-The issuer in the ID token's `iss` claim must match the normalized value character-for-character.
+Discovery first tries the normalized configured issuer, then exactly the same issuer with one trailing slash. Once discovery succeeds, ID-token validation uses the discovered issuer normally. Some providers, such as Authentik, advertise and sign tokens with the slash form. No other issuer variations are accepted, and stored OIDC identities use the normalized configured issuer.
 
 **Redirect URL**
 
@@ -119,7 +119,7 @@ OIDC works behind nginx, Caddy, Traefik, etc. as long as:
 
 **Discovery**
 
-Scrumboy fetches the provider's discovery document (`{issuer}/.well-known/openid-configuration`) on the first login attempt, not at startup. The app starts normally even if the provider is unreachable; OIDC is unavailable until discovery succeeds.
+Scrumboy fetches the provider's discovery document (`{issuer}/.well-known/openid-configuration`) on the first login attempt, not at startup. Discovery first validates the normalized configured issuer, then exactly the same issuer with one trailing slash. The app starts normally even if the provider is unreachable; OIDC is unavailable until discovery succeeds.
 
 ---
 
@@ -144,7 +144,7 @@ Discovery failed. Possible causes:
 
 - Provider is unreachable from the Scrumboy server.
 - `SCRUMBOY_OIDC_ISSUER` points to the wrong URL (wrong realm, wrong host).
-- The issuer field in the discovery document does not match `SCRUMBOY_OIDC_ISSUER` after normalization.
+- The issuer field in the discovery document is not `SCRUMBOY_OIDC_ISSUER` after normalization, or exactly that same issuer with one trailing slash.
 
 Check the server logs for a line like:
 
@@ -162,7 +162,7 @@ oidc: discovery/login error: oidc discovery failed for "...": ...
 The ID token was rejected. Common causes:
 
 - Token audience (`aud`) does not match `SCRUMBOY_OIDC_CLIENT_ID`.
-- Issuer in the token does not match `SCRUMBOY_OIDC_ISSUER` (after normalization).
+- Issuer in the token does not match the issuer accepted during discovery.
 - Token has expired in transit (clock skew between server and provider).
 - Wrong `client_secret`.
 

--- a/internal/httpapi/oidc_test.go
+++ b/internal/httpapi/oidc_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -26,15 +27,17 @@ import (
 
 // fakeIdP simulates an OIDC provider for integration tests.
 type fakeIdP struct {
-	server     *httptest.Server
-	key        *rsa.PrivateKey
-	keyID      string
-	issuer     string
-	clientID   string
-	subject    string
-	email      string
-	emailVer   bool
-	name       string
+	server          *httptest.Server
+	key             *rsa.PrivateKey
+	keyID           string
+	issuer          string
+	discoveryIssuer string
+	idTokenIssuer   string
+	clientID        string
+	subject         string
+	email           string
+	emailVer        bool
+	name            string
 
 	mu     sync.Mutex
 	nonces map[string]string // auth code → nonce
@@ -67,14 +70,29 @@ func newFakeIdP(t *testing.T) *fakeIdP {
 
 func (f *fakeIdP) close() { f.server.Close() }
 
+func (f *fakeIdP) discoveryIssuerValue() string {
+	if f.discoveryIssuer != "" {
+		return f.discoveryIssuer
+	}
+	return f.issuer
+}
+
+func (f *fakeIdP) idTokenIssuerValue() string {
+	if f.idTokenIssuer != "" {
+		return f.idTokenIssuer
+	}
+	return f.issuer
+}
+
 func (f *fakeIdP) handleDiscovery(w http.ResponseWriter, r *http.Request) {
+	discoveryIssuer := f.discoveryIssuerValue()
 	disc := map[string]any{
-		"issuer":                 f.issuer,
-		"authorization_endpoint": f.issuer + "/authorize",
-		"token_endpoint":         f.issuer + "/token",
-		"jwks_uri":               f.issuer + "/jwks",
-		"response_types_supported": []string{"code"},
-		"subject_types_supported":  []string{"public"},
+		"issuer":                                discoveryIssuer,
+		"authorization_endpoint":                f.issuer + "/authorize",
+		"token_endpoint":                        f.issuer + "/token",
+		"jwks_uri":                              f.issuer + "/jwks",
+		"response_types_supported":              []string{"code"},
+		"subject_types_supported":               []string{"public"},
 		"id_token_signing_alg_values_supported": []string{"RS256"},
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -133,7 +151,7 @@ func (f *fakeIdP) handleToken(w http.ResponseWriter, r *http.Request) {
 
 	now := time.Now()
 	claims := map[string]any{
-		"iss":            f.issuer,
+		"iss":            f.idTokenIssuerValue(),
 		"sub":            f.subject,
 		"aud":            f.clientID,
 		"exp":            now.Add(10 * time.Minute).Unix(),
@@ -275,6 +293,67 @@ func TestOIDCLoginRedirect(t *testing.T) {
 	}
 	if !strings.Contains(loc, "code_challenge_method=S256") {
 		t.Errorf("expected PKCE S256 in authorize URL, got %q", loc)
+	}
+}
+
+func TestOIDCTrailingSlashIssuerLoginStoresCanonicalIdentity(t *testing.T) {
+	idp := newFakeIdP(t)
+	defer idp.close()
+	idp.discoveryIssuer = idp.issuer + "/"
+	idp.idTokenIssuer = idp.issuer + "/"
+
+	ts, st, cleanup := newTestOIDCServerWithStore(t, idp)
+	defer cleanup()
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	resp, err := client.Get(ts.URL + "/api/auth/oidc/login?return_to=/dashboard")
+	if err != nil {
+		t.Fatalf("oidc login: %v", err)
+	}
+	resp.Body.Close()
+
+	if finalURL := resp.Request.URL.String(); strings.Contains(finalURL, "oidc_error") {
+		t.Fatalf("expected successful login, got redirect to %s", finalURL)
+	}
+
+	ctx := context.Background()
+	u, err := st.GetUserByOIDCIdentity(ctx, idp.issuer, idp.subject)
+	if err != nil {
+		t.Fatalf("expected canonical OIDC identity lookup to succeed: %v", err)
+	}
+	if u.Email != idp.email {
+		t.Fatalf("canonical identity email = %q, want %q", u.Email, idp.email)
+	}
+
+	_, err = st.GetUserByOIDCIdentity(ctx, idp.issuer+"/", idp.subject)
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("expected no slash-form identity row, got err=%v", err)
+	}
+}
+
+func TestOIDCTrailingSlashDiscoveryRejectsNonSlashIDTokenIssuer(t *testing.T) {
+	idp := newFakeIdP(t)
+	defer idp.close()
+	idp.discoveryIssuer = idp.issuer + "/"
+	idp.idTokenIssuer = idp.issuer
+
+	ts, cleanup := newTestOIDCServer(t, idp)
+	defer cleanup()
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	resp, err := client.Get(ts.URL + "/api/auth/oidc/login?return_to=/")
+	if err != nil {
+		t.Fatalf("oidc login: %v", err)
+	}
+	resp.Body.Close()
+
+	finalURL := resp.Request.URL.String()
+	if !strings.Contains(finalURL, "oidc_error=token") {
+		t.Fatalf("expected token error for mismatched ID token issuer, got %s", finalURL)
 	}
 }
 
@@ -454,4 +533,3 @@ func TestOIDCAutoLinkExistingUser(t *testing.T) {
 		t.Fatalf("second login failed: %s", resp2.Request.URL.String())
 	}
 }
-

--- a/internal/oidc/oidc.go
+++ b/internal/oidc/oidc.go
@@ -17,10 +17,10 @@ import (
 
 // Config holds the validated, canonical OIDC settings.
 type Config struct {
-	IssuerCanonical  string // normalized once at config load
-	ClientID         string
-	ClientSecret     string
-	RedirectURL      string // absolute callback URL
+	IssuerCanonical   string // normalized once at config load
+	ClientID          string
+	ClientSecret      string
+	RedirectURL       string // absolute callback URL
 	LocalAuthDisabled bool
 }
 
@@ -29,7 +29,7 @@ type Service struct {
 	cfg Config
 
 	mu       sync.Mutex
-	provider *gooidc.Provider  // lazy; nil until first successful discovery
+	provider *gooidc.Provider // lazy; nil until first successful discovery
 	verifier *gooidc.IDTokenVerifier
 
 	states *stateStore
@@ -54,17 +54,9 @@ func (s *Service) ensureProvider(ctx context.Context) (*gooidc.Provider, *gooidc
 		return s.provider, s.verifier, nil
 	}
 
-	p, err := gooidc.NewProvider(ctx, s.cfg.IssuerCanonical)
+	p, err := discoverProvider(ctx, s.cfg.IssuerCanonical)
 	if err != nil {
-		// Some IdPs (e.g. Authentik) advertise an issuer that differs from our
-		// normalized (slash-stripped) issuer only by a trailing slash, which
-		// go-oidc's strict issuer check rejects. Retry once, trusting the exact
-		// issuer the provider uses (its ID token iss carries the slash too).
-		slashCtx := gooidc.InsecureIssuerURLContext(ctx, s.cfg.IssuerCanonical+"/")
-		p, err = gooidc.NewProvider(slashCtx, s.cfg.IssuerCanonical)
-	}
-	if err != nil {
-		return nil, nil, fmt.Errorf("oidc discovery failed for %q: %w", s.cfg.IssuerCanonical, err)
+		return nil, nil, err
 	}
 
 	s.provider = p
@@ -72,6 +64,23 @@ func (s *Service) ensureProvider(ctx context.Context) (*gooidc.Provider, *gooidc
 		ClientID: s.cfg.ClientID,
 	})
 	return s.provider, s.verifier, nil
+}
+
+// discoverProvider tries the canonical issuer first, then exactly the
+// trailing-slash variant. Both attempts use normal go-oidc issuer validation.
+func discoverProvider(ctx context.Context, issuer string) (*gooidc.Provider, error) {
+	p, err := gooidc.NewProvider(ctx, issuer)
+	if err == nil {
+		return p, nil
+	}
+
+	slashIssuer := issuer + "/"
+	p, slashErr := gooidc.NewProvider(ctx, slashIssuer)
+	if slashErr == nil {
+		return p, nil
+	}
+
+	return nil, fmt.Errorf("oidc discovery failed for %q (also tried %q: %v): %w", issuer, slashIssuer, slashErr, err)
 }
 
 func (s *Service) oauth2Config(provider *gooidc.Provider) *oauth2.Config {

--- a/internal/oidc/oidc.go
+++ b/internal/oidc/oidc.go
@@ -56,6 +56,14 @@ func (s *Service) ensureProvider(ctx context.Context) (*gooidc.Provider, *gooidc
 
 	p, err := gooidc.NewProvider(ctx, s.cfg.IssuerCanonical)
 	if err != nil {
+		// Some IdPs (e.g. Authentik) advertise an issuer that differs from our
+		// normalized (slash-stripped) issuer only by a trailing slash, which
+		// go-oidc's strict issuer check rejects. Retry once, trusting the exact
+		// issuer the provider uses (its ID token iss carries the slash too).
+		slashCtx := gooidc.InsecureIssuerURLContext(ctx, s.cfg.IssuerCanonical+"/")
+		p, err = gooidc.NewProvider(slashCtx, s.cfg.IssuerCanonical)
+	}
+	if err != nil {
 		return nil, nil, fmt.Errorf("oidc discovery failed for %q: %w", s.cfg.IssuerCanonical, err)
 	}
 

--- a/internal/oidc/oidc_test.go
+++ b/internal/oidc/oidc_test.go
@@ -1,9 +1,126 @@
 package oidc
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+func TestDiscoverProvider(t *testing.T) {
+	tests := []struct {
+		name             string
+		advertisedIssuer func(base string) string
+		wantErr          bool
+		wantRequests     int
+	}{
+		{
+			name: "canonical issuer succeeds first attempt",
+			advertisedIssuer: func(base string) string {
+				return base
+			},
+			wantRequests: 1,
+		},
+		{
+			name: "trailing slash issuer succeeds second attempt",
+			advertisedIssuer: func(base string) string {
+				return base + "/"
+			},
+			wantRequests: 2,
+		},
+		{
+			name: "mismatched host fails",
+			advertisedIssuer: func(base string) string {
+				return "http://evil.example.com"
+			},
+			wantErr:      true,
+			wantRequests: 2,
+		},
+		{
+			name: "mismatched scheme fails",
+			advertisedIssuer: func(base string) string {
+				return "https://" + strings.TrimPrefix(base, "http://")
+			},
+			wantErr:      true,
+			wantRequests: 2,
+		},
+		{
+			name: "mismatched path fails",
+			advertisedIssuer: func(base string) string {
+				return base + "/other"
+			},
+			wantErr:      true,
+			wantRequests: 2,
+		},
+		{
+			name: "unrelated issuer fails",
+			advertisedIssuer: func(base string) string {
+				return "https://attacker.example/realms/x"
+			},
+			wantErr:      true,
+			wantRequests: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requests atomic.Int32
+			var baseURL string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				if r.URL.Path != "/.well-known/openid-configuration" {
+					http.NotFound(w, r)
+					return
+				}
+
+				issuer := tt.advertisedIssuer(baseURL)
+				endpointBase := strings.TrimRight(issuer, "/")
+				discovery := map[string]any{
+					"issuer":                                issuer,
+					"authorization_endpoint":                endpointBase + "/authorize",
+					"token_endpoint":                        endpointBase + "/token",
+					"jwks_uri":                              endpointBase + "/jwks",
+					"response_types_supported":              []string{"code"},
+					"subject_types_supported":               []string{"public"},
+					"id_token_signing_alg_values_supported": []string{"RS256"},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(discovery)
+			}))
+			defer srv.Close()
+			baseURL = srv.URL
+
+			provider, err := discoverProvider(context.Background(), srv.URL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected discovery error, got nil")
+				}
+				msg := err.Error()
+				if !strings.Contains(msg, `oidc discovery failed for "`) {
+					t.Fatalf("expected discovery prefix in error, got %q", msg)
+				}
+				if !strings.Contains(msg, srv.URL+"/") {
+					t.Fatalf("expected trailing-slash variant in error, got %q", msg)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("discoverProvider: %v", err)
+				}
+				if provider == nil {
+					t.Fatal("expected provider, got nil")
+				}
+			}
+
+			if got := int(requests.Load()); got != tt.wantRequests {
+				t.Fatalf("discovery requests = %d, want %d", got, tt.wantRequests)
+			}
+		})
+	}
+}
 
 func TestSanitizeReturnTo(t *testing.T) {
 	tests := []struct {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.18.24"
+const Version = "3.18.25"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
Fixes #125.

As discussed in #125, native OIDC/SSO can't work with Authentik because scrumboy strips the issuer's trailing slash (`config.normalizeIssuer`) and then go-oidc strict-matches it against the issuer in the discovery document. Authentik always advertises a trailing-slash issuer in every `issuer_mode`, so discovery permanently 503s and the "Authentik" entry in `docs/oidc.md` is unusable.

**Fix:** in `ensureProvider`, if the strict `gooidc.NewProvider` discovery fails, retry once trusting the exact issuer the provider uses (configured issuer + `/`) via go-oidc's `InsecureIssuerURLContext`. The provider's ID-token `iss` claim carries the same trailing slash, so the verifier still validates correctly. Providers without a trailing slash (Keycloak, Entra, Zitadel, …) take the first branch and are unaffected. One hunk, 8 lines.

**Verification:** built on this change and run against a live Authentik instance — `/api/auth/oidc/login` now 302-redirects into Authentik's `/application/o/authorize/` endpoint and full discovery succeeds. (It's been running in a homelab deployment against Authentik for several days.)

Commit is DCO signed off per your request.
