### PR TITLE
Add OAuth 2.1 authorization server support for MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Invariants (e.g. canonical URL `/{slug}`, no UI links to `/p/{id}`) are enforced
 
 - **Architecture diagrams:** [`docs/diagrams/`](docs/diagrams/) - Mermaid sources and self-contained viewer (`serve-diagrams.bat` or `python serve.py` in that folder, then open `http://127.0.0.1:8775/`)
 - **MCP (HTTP tools + JSON-RPC):** [`docs/mcp.md`](docs/mcp.md) - tool catalog, auth, legacy vs `/mcp/rpc`, examples (agents & automation). See also [`API.md`](API.md) for exhaustive MCP HTTP detail.
+- **OAuth 2.1 for MCP clients:** [`docs/oauth.md`](docs/oauth.md) - discovery, Dynamic Client Registration, PKCE, authorize/token/revoke flow for clients like Claude Code's `--transport http` OAuth connect.
 - **Agent plugin package:** [`plugins/scrumboy-board-operator`](plugins/scrumboy-board-operator) - local/manual plugin metadata, board-operator Skill, and seed eval cases for MCP/Agoragentic agent workflows.
 - **PWA / Web Push (VAPID):** [`docs/pwa.md`](docs/pwa.md) - keys, subscriber contact, post-login auto-subscribe when VAPID is configured, Settings opt-out, tradeoffs.
 - **Roles and permissions:** [`docs/roles_and_permissions.md`](docs/roles_and_permissions.md) - project roles, backend authorization, anonymous boards.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -129,6 +129,8 @@ Behavior is implemented in `internal/mcp/adapter.go` (`resolveRequestAuth`).
 
 **Bootstrap:** When the user table is empty (`CountUsers == 0`), capabilities include `bootstrapAvailable: true` and `auth.authenticatedToolsUsable: false`. Most tools return **`CAPABILITY_UNAVAILABLE`** (*unavailable before bootstrap*) until the first user exists.
 
+**OAuth 2.1 (full mode only):** Scrumboy's MCP endpoint also supports OAuth 2.1 for clients that support automatic discovery and Dynamic Client Registration (e.g. Claude Code's `--transport http` OAuth flow), as an alternative to manually minting a static API token. See **[`docs/oauth.md`](oauth.md)** for the discovery endpoints, authorize/token/revoke flow, and token lifetimes. Static Bearer API tokens (above) remain fully supported and unaffected — an OAuth-issued access token is just another Bearer credential accepted by the same `resolveRequestAuth` boundary.
+
 ## Capabilities
 
 **Legacy (recommended for a quick probe):**

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,0 +1,144 @@
+# OAuth 2.1 for MCP Clients
+
+Updated: 2026-07-13
+
+Scrumboy's MCP endpoint (`/mcp`, `/mcp/rpc`) supports OAuth 2.1 for clients that implement automatic discovery, PKCE, and Dynamic Client Registration (DCR) — for example Claude Code's `claude mcp add --transport http` flow. This is an alternative to manually minting a static API token via `POST /api/me/tokens`; it requires **no configuration** — no environment variables, no manual client registration. The client self-registers and the user approves access through a normal browser consent screen.
+
+Compatible clients: any MCP client that speaks HTTP OAuth discovery (RFC 8414 / RFC 9728), PKCE (RFC 7636, S256 only), and Dynamic Client Registration (RFC 7591). Claude Code is the primary target; any other MCP-over-HTTP client with the same OAuth support works identically.
+
+---
+
+## Quick Start
+
+No setup required. Point an MCP client at your Scrumboy instance's `/mcp` endpoint:
+
+```sh
+claude mcp add --transport http scrumboy https://scrumboy.example.com/mcp
+```
+
+The client will:
+
+1. Fetch `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server` to discover the endpoints below.
+2. `POST /oauth/register` to self-register as a public client (no `client_secret`).
+3. Open a browser to `/oauth/authorize` with a PKCE `code_challenge`.
+4. Prompt you to log in (if not already) and approve access.
+5. Exchange the returned code for an access token at `/oauth/token`.
+
+Static Bearer API tokens (`docs/mcp.md`) remain fully supported and unaffected — this is an additional way to obtain a Bearer credential, not a replacement.
+
+---
+
+## How It Works
+
+1. MCP client discovers endpoints via `GET /.well-known/oauth-authorization-server` and `GET /.well-known/oauth-protected-resource`.
+2. Client registers itself via `POST /oauth/register` (RFC 7591) and receives a `client_id` (no secret — public client).
+3. Client redirects the user's browser to `GET /oauth/authorize` with `response_type=code`, its `client_id`, `redirect_uri`, and a PKCE `code_challenge` (S256).
+4. If the user has no active Scrumboy session, a login form is shown inline. Once logged in, a consent screen ("Approve access for `<client name>`?") is shown.
+5. On approval, Scrumboy redirects back to the client's `redirect_uri` with a single-use authorization code.
+6. Client exchanges the code (plus its `code_verifier`) for an access token and refresh token at `POST /oauth/token`.
+7. Client sends the access token as `Authorization: Bearer <token>` on `/mcp` or `/mcp/rpc` requests, exactly like a static API token.
+
+---
+
+## Requirements & Constraints
+
+**Client type**
+
+- Public clients only (no `client_secret`, `token_endpoint_auth_method: "none"`). This matches how Claude Code and most MCP clients register.
+- One `redirect_uri` per client, fixed at registration time.
+
+**PKCE**
+
+- Required on every authorization request. Only `S256` is accepted; `plain` is rejected.
+
+**Consent**
+
+- Single fixed scope ("read and manage projects, todos, sprints, and tags"); there is no granular per-scope consent screen.
+- The user approving consent must already have (or create, via the normal login form shown inline) a Scrumboy session. Accounts with 2FA enabled must log in at the main app first — the inline login form on the consent page does not handle a 2FA challenge.
+
+**Mode**
+
+- Available only in full mode (`SCRUMBOY_MODE=full`). All `/oauth/*` and `/.well-known/oauth-*` endpoints return `404` in anonymous mode.
+
+**Token lifetimes**
+
+- Authorization codes: 60 seconds, single-use.
+- Access tokens: 1 hour.
+- Refresh tokens: 30 days (matches the existing session TTL), rotated on every use.
+
+---
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/.well-known/oauth-protected-resource` | RFC 9728 — advertises this MCP resource's authorization server. |
+| `GET` | `/.well-known/oauth-authorization-server` | RFC 8414 — advertises the endpoints below. |
+| `POST` | `/oauth/register` | RFC 7591 — self-service client registration. |
+| `GET`/`POST` | `/oauth/authorize` | RFC 6749 §3.1 — login/consent, then issues an authorization code. |
+| `POST` | `/oauth/token` | RFC 6749 §3.2 — exchanges a code or refresh token for an access token. |
+| `POST` | `/oauth/revoke` | RFC 7009 — revokes an access or refresh token. |
+
+`/oauth/*` is deliberately outside `/api/*`: it does not require the `X-Scrumboy: 1` CSRF header that `/api/*` writes require. The consent form at `/oauth/authorize` relies on `SameSite=Lax` session-cookie semantics instead — a cross-site top-level form POST never carries the session cookie, so a forged consent-approval submission cannot succeed.
+
+---
+
+## Example: token exchange
+
+```sh
+curl -X POST https://scrumboy.example.com/oauth/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=authorization_code" \
+  --data-urlencode "code=$CODE" \
+  --data-urlencode "redirect_uri=$REDIRECT_URI" \
+  --data-urlencode "client_id=$CLIENT_ID" \
+  --data-urlencode "code_verifier=$CODE_VERIFIER"
+```
+
+```json
+{
+  "access_token": "...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "..."
+}
+```
+
+Then use it exactly like a static API token:
+
+```sh
+curl -X POST https://scrumboy.example.com/mcp/rpc \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"projects.list","arguments":{}}}'
+```
+
+---
+
+## Error Handling
+
+`/oauth/token` and `/oauth/register` return the flat RFC 6749 §5.2 / RFC 7591 §3.2.2 error shape (not Scrumboy's usual `{"error":{"code":...}}` API envelope):
+
+```json
+{"error": "invalid_grant", "error_description": "the authorization code is invalid, expired, or already used"}
+```
+
+Codes used: **`invalid_request`**, **`invalid_client`**, **`invalid_grant`**, **`unsupported_grant_type`**, **`access_denied`**, **`unsupported_response_type`**, **`invalid_redirect_uri`**, **`invalid_client_metadata`**.
+
+`/oauth/authorize` failures either redirect to the client's `redirect_uri` with `error`/`error_description`/`state` query params (once `redirect_uri` itself is verified against the registered client), or — if `redirect_uri` cannot be verified — render a plain error page instead of redirecting, to avoid an open-redirect.
+
+`/oauth/revoke` always returns `200`, whether or not the presented token existed (RFC 7009 §2.2) — this is intentional and prevents the endpoint from being used to probe for token existence.
+
+---
+
+## Not Implemented
+
+The following are explicitly out of scope in the current version:
+
+- **Confidential clients / client secrets** — public clients (PKCE) only.
+- **Multiple redirect URIs per client** — one per client, fixed at registration.
+- **Granular per-scope consent** — a single fixed scope.
+- **Refresh-token reuse-detection cascade** — a reused (already-rotated-away-from) refresh token is rejected, but reuse does not revoke the rest of that token family.
+- **Admin UI for listing/revoking registered OAuth clients** — inspect or clean up via direct database access if ever needed.
+- **JWT access tokens / JWKS endpoint** — tokens are opaque and validated by direct database lookup, matching how static API tokens already work.
+- **Inline 2FA during the consent-page login form** — accounts with 2FA enabled must log in at the main app first, then reopen the authorization link.

--- a/internal/httpapi/routing_oauth.go
+++ b/internal/httpapi/routing_oauth.go
@@ -1,0 +1,489 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"scrumboy/internal/oauth"
+	"scrumboy/internal/store"
+)
+
+// handleOAuth dispatches the /oauth/* surface (RFC 6749/7591/7636/7009). All
+// of it is deliberately outside /api/*: OAuth clients authenticate via PKCE
+// and client_id, not the X-Scrumboy CSRF header /api/* requires, and the
+// consent form at /oauth/authorize relies on SameSite=Lax cookie semantics
+// (a cross-site top-level POST navigation never carries the session cookie)
+// rather than that header for its own CSRF protection.
+func (s *Server) handleOAuth(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/oauth/register":
+		s.handleOAuthRegister(w, r)
+	case "/oauth/authorize":
+		s.handleOAuthAuthorize(w, r)
+	case "/oauth/token":
+		s.handleOAuthToken(w, r)
+	case "/oauth/revoke":
+		s.handleOAuthRevoke(w, r)
+	default:
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+	}
+}
+
+func (s *Server) oauthIssuer(r *http.Request) string {
+	proto := "http"
+	if isSecureRequest(r) {
+		proto = "https"
+	}
+	return proto + "://" + r.Host
+}
+
+// handleOAuthProtectedResourceMetadata serves RFC 9728 discovery: the two
+// fields Claude Code's MCP OAuth client actually reads.
+func (s *Server) handleOAuthProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) {
+	if s.mode == "anonymous" {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+		return
+	}
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed", nil)
+		return
+	}
+	issuer := s.oauthIssuer(r)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"resource":              issuer + "/mcp",
+		"authorization_servers": []string{issuer},
+	})
+}
+
+// handleOAuthASMetadata serves RFC 8414 authorization server discovery.
+func (s *Server) handleOAuthASMetadata(w http.ResponseWriter, r *http.Request) {
+	if s.mode == "anonymous" {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+		return
+	}
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed", nil)
+		return
+	}
+	issuer := s.oauthIssuer(r)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"issuer":                                     issuer,
+		"authorization_endpoint":                     issuer + "/oauth/authorize",
+		"token_endpoint":                             issuer + "/oauth/token",
+		"registration_endpoint":                      issuer + "/oauth/register",
+		"revocation_endpoint":                        issuer + "/oauth/revoke",
+		"response_types_supported":                   []string{"code"},
+		"grant_types_supported":                      []string{"authorization_code", "refresh_token"},
+		"code_challenge_methods_supported":           []string{"S256"},
+		"token_endpoint_auth_methods_supported":      []string{"none"},
+		"revocation_endpoint_auth_methods_supported": []string{"none"},
+	})
+}
+
+// handleOAuthRegister implements RFC 7591 Dynamic Client Registration.
+// Unauthenticated by design: DCR is inherently self-service.
+func (s *Server) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
+	if s.mode == "anonymous" {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed", nil)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, s.maxBody))
+	if err != nil {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidClientMetadata, "could not read request body")
+		return
+	}
+	var in struct {
+		ClientName   string   `json:"client_name"`
+		RedirectURIs []string `json:"redirect_uris"`
+	}
+	if err := json.Unmarshal(body, &in); err != nil {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidClientMetadata, "invalid JSON body")
+		return
+	}
+	if len(in.RedirectURIs) == 0 || strings.TrimSpace(in.RedirectURIs[0]) == "" {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRedirectURI, "redirect_uris is required")
+		return
+	}
+	redirectURI := strings.TrimSpace(in.RedirectURIs[0])
+	clientName := strings.TrimSpace(in.ClientName)
+
+	clientID, err := oauth.GenerateClientID()
+	if err != nil {
+		writeInternal(w, err)
+		return
+	}
+	if _, err := s.store.CreateOAuthClient(s.requestContext(r), clientID, clientName, redirectURI); err != nil {
+		writeInternal(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"client_id":                  clientID,
+		"client_name":                clientName,
+		"redirect_uris":              []string{redirectURI},
+		"token_endpoint_auth_method": "none",
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+	})
+}
+
+type authorizeParams struct {
+	ResponseType        string
+	ClientID            string
+	RedirectURI         string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	State               string
+}
+
+func parseAuthorizeParams(r *http.Request) authorizeParams {
+	return authorizeParams{
+		ResponseType:        r.FormValue("response_type"),
+		ClientID:            r.FormValue("client_id"),
+		RedirectURI:         r.FormValue("redirect_uri"),
+		CodeChallenge:       r.FormValue("code_challenge"),
+		CodeChallengeMethod: r.FormValue("code_challenge_method"),
+		State:               r.FormValue("state"),
+	}
+}
+
+// handleOAuthAuthorize serves the RFC 6749 §3.1/§4.1.1 authorize endpoint.
+// GET shows a login form (if the caller has no valid session) or a consent
+// form (if logged in); POST is the consent form's approve/deny submission.
+func (s *Server) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
+	if s.mode == "anonymous" {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+		return
+	}
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed", nil)
+		return
+	}
+
+	params := parseAuthorizeParams(r)
+	ctx := s.requestContext(r)
+
+	client, err := s.store.GetOAuthClient(ctx, params.ClientID)
+	if err != nil || params.ClientID == "" {
+		s.renderOAuthErrorPage(w, http.StatusBadRequest, "Unknown client", "This authorization request does not reference a registered OAuth client.")
+		return
+	}
+	if params.RedirectURI == "" || params.RedirectURI != client.RedirectURI {
+		// redirect_uri is unverified or doesn't match the client's registered
+		// URI: never redirect on it (open-redirect risk per RFC 6749 §4.1.2.1),
+		// render a plain error page instead.
+		s.renderOAuthErrorPage(w, http.StatusBadRequest, "Redirect URI mismatch", "The redirect_uri for this request does not match the one registered for this client.")
+		return
+	}
+
+	// From here on redirect_uri is trusted (exact match to the registered
+	// client), so remaining validation failures redirect with error params.
+	if params.ResponseType != "code" {
+		s.redirectOAuthError(w, r, params.RedirectURI, oauth.ErrUnsupportedResponse, "only response_type=code is supported", params.State)
+		return
+	}
+	if params.CodeChallenge == "" || params.CodeChallengeMethod != "S256" {
+		s.redirectOAuthError(w, r, params.RedirectURI, oauth.ErrInvalidRequest, "PKCE (code_challenge with S256) is required", params.State)
+		return
+	}
+
+	if r.Method == http.MethodPost {
+		s.handleOAuthAuthorizeSubmit(w, r, ctx, client, params)
+		return
+	}
+
+	// GET: bootstrap-before-login and login-before-consent gates.
+	n, err := s.store.CountUsers(ctx)
+	if err != nil {
+		writeInternal(w, err)
+		return
+	}
+	if n == 0 {
+		s.renderOAuthErrorPage(w, http.StatusServiceUnavailable, "Set up Scrumboy first", `This Scrumboy instance has no account yet. Complete first-time setup at <a href="/">the main app</a>, then reopen this link.`)
+		return
+	}
+	if _, ok := store.UserIDFromContext(ctx); !ok {
+		s.renderOAuthLoginPage(w, client)
+		return
+	}
+	s.renderOAuthConsentPage(w, client, params)
+}
+
+func (s *Server) handleOAuthAuthorizeSubmit(w http.ResponseWriter, r *http.Request, ctx context.Context, client store.OAuthClient, params authorizeParams) {
+	userID, ok := store.UserIDFromContext(ctx)
+	if !ok {
+		// Session expired between the GET and this POST; send back to the
+		// GET flow, which will show the login form again.
+		s.renderOAuthLoginPage(w, client)
+		return
+	}
+
+	action := r.FormValue("action")
+	if action == "deny" {
+		s.redirectOAuthError(w, r, params.RedirectURI, oauth.ErrAccessDenied, "the user denied the request", params.State)
+		return
+	}
+	if action != "approve" {
+		s.renderOAuthErrorPage(w, http.StatusBadRequest, "Invalid request", "Missing or unrecognized consent action.")
+		return
+	}
+
+	code, err := s.store.CreateOAuthAuthCode(ctx, client.ID, userID, params.RedirectURI, params.CodeChallenge, params.CodeChallengeMethod)
+	if err != nil {
+		writeInternal(w, err)
+		return
+	}
+
+	redirectURL := params.RedirectURI + queryJoiner(params.RedirectURI) + "code=" + url.QueryEscape(code)
+	if params.State != "" {
+		redirectURL += "&state=" + url.QueryEscape(params.State)
+	}
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// handleOAuthToken implements the RFC 6749 §4.1.3/§6 token endpoint for the
+// authorization_code and refresh_token grants.
+func (s *Server) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
+	if s.mode == "anonymous" {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed", nil)
+		return
+	}
+	if s.authRateLimit != nil && !s.authRateLimit.Allow("ip:"+clientIP(r), "") {
+		oauth.WriteJSON(w, http.StatusTooManyRequests, oauth.ErrInvalidRequest, "too many attempts; try again later")
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	ctx := s.requestContext(r)
+
+	switch r.FormValue("grant_type") {
+	case "authorization_code":
+		s.handleOAuthTokenAuthCode(w, r, ctx)
+	case "refresh_token":
+		s.handleOAuthTokenRefresh(w, r, ctx)
+	default:
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrUnsupportedGrantType, "unsupported grant_type")
+	}
+}
+
+func (s *Server) handleOAuthTokenAuthCode(w http.ResponseWriter, r *http.Request, ctx context.Context) {
+	code := r.FormValue("code")
+	redirectURI := r.FormValue("redirect_uri")
+	clientID := r.FormValue("client_id")
+	codeVerifier := r.FormValue("code_verifier")
+
+	if code == "" || redirectURI == "" || clientID == "" || codeVerifier == "" {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "code, redirect_uri, client_id, and code_verifier are required")
+		return
+	}
+
+	ac, err := s.store.ConsumeOAuthAuthCode(ctx, code)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidGrant, "the authorization code is invalid, expired, or already used")
+			return
+		}
+		writeInternal(w, err)
+		return
+	}
+	if ac.ClientID != clientID || ac.RedirectURI != redirectURI {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidGrant, "client_id or redirect_uri does not match the authorization request")
+		return
+	}
+	if !oauth.VerifyPKCE(ac.CodeChallengeMethod, codeVerifier, ac.CodeChallenge) {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidGrant, "code_verifier does not match the original code_challenge")
+		return
+	}
+
+	pair, err := s.store.IssueOAuthTokenPair(ctx, ac.ClientID, ac.UserID)
+	if err != nil {
+		writeInternal(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"access_token":  pair.AccessToken,
+		"token_type":    "Bearer",
+		"expires_in":    pair.ExpiresIn,
+		"refresh_token": pair.RefreshToken,
+	})
+}
+
+func (s *Server) handleOAuthTokenRefresh(w http.ResponseWriter, r *http.Request, ctx context.Context) {
+	refreshToken := r.FormValue("refresh_token")
+	if refreshToken == "" {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "refresh_token is required")
+		return
+	}
+	clientID, userID, err := s.store.ConsumeOAuthRefreshToken(ctx, refreshToken)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidGrant, "the refresh token is invalid, expired, or already used")
+			return
+		}
+		writeInternal(w, err)
+		return
+	}
+	if reqClientID := r.FormValue("client_id"); reqClientID != "" && reqClientID != clientID {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidGrant, "client_id does not match this refresh token")
+		return
+	}
+
+	pair, err := s.store.IssueOAuthTokenPair(ctx, clientID, userID)
+	if err != nil {
+		writeInternal(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"access_token":  pair.AccessToken,
+		"token_type":    "Bearer",
+		"expires_in":    pair.ExpiresIn,
+		"refresh_token": pair.RefreshToken,
+	})
+}
+
+// handleOAuthRevoke implements RFC 7009 token revocation. Per §2.2, it always
+// returns 200 regardless of whether the token existed, so a caller can never
+// use this endpoint to probe for a token's existence.
+func (s *Server) handleOAuthRevoke(w http.ResponseWriter, r *http.Request) {
+	if s.mode == "anonymous" {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed", nil)
+		return
+	}
+	token := r.FormValue("token")
+	hint := r.FormValue("token_type_hint")
+	if token != "" {
+		if err := s.store.RevokeOAuthToken(s.requestContext(r), token, hint); err != nil {
+			s.logger.Printf("oauth: revoke token: %v", err)
+		}
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// redirectOAuthError redirects to the (already-verified) client redirect_uri
+// with RFC 6749 §4.1.2.1 error query params.
+func (s *Server) redirectOAuthError(w http.ResponseWriter, r *http.Request, redirectURI, code, description, state string) {
+	dest := redirectURI + queryJoiner(redirectURI) + "error=" + url.QueryEscape(code) + "&error_description=" + url.QueryEscape(description)
+	if state != "" {
+		dest += "&state=" + url.QueryEscape(state)
+	}
+	http.Redirect(w, r, dest, http.StatusFound)
+}
+
+func queryJoiner(u string) string {
+	if strings.Contains(u, "?") {
+		return "&"
+	}
+	return "?"
+}
+
+const oauthPageStyle = `<style>
+body{font-family:system-ui,-apple-system,sans-serif;background:#0f1115;color:#e6e6e6;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}
+.card{background:#1a1d24;border:1px solid #2a2e37;border-radius:12px;padding:32px;max-width:420px;width:90%}
+h1{font-size:18px;margin:0 0 16px}
+p{font-size:14px;line-height:1.5;color:#b8bcc4}
+input{width:100%;box-sizing:border-box;padding:10px;margin:6px 0;border-radius:6px;border:1px solid #2a2e37;background:#0f1115;color:#e6e6e6}
+button{padding:10px 18px;border-radius:6px;border:none;font-size:14px;cursor:pointer;margin-top:8px}
+.btn-primary{background:#5b8cff;color:#fff}
+.btn-secondary{background:#2a2e37;color:#e6e6e6;margin-left:8px}
+.err{color:#ff6b6b;font-size:13px;margin-top:8px}
+a{color:#5b8cff}
+</style>`
+
+func (s *Server) renderOAuthErrorPage(w http.ResponseWriter, status int, title, body string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	fmt.Fprintf(w, `<!DOCTYPE html><html><head><meta charset="utf-8"><title>%s</title>%s</head><body><div class="card"><h1>%s</h1><p>%s</p></div></body></html>`,
+		html.EscapeString(title), oauthPageStyle, html.EscapeString(title), body)
+}
+
+func (s *Server) renderOAuthLoginPage(w http.ResponseWriter, client store.OAuthClient) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	name := client.ClientName
+	if name == "" {
+		name = "This application"
+	}
+	fmt.Fprintf(w, `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Log in to Scrumboy</title>%s</head><body>
+<div class="card">
+<h1>Log in to connect %s</h1>
+<p>Sign in with your Scrumboy account to continue.</p>
+<div id="err" class="err"></div>
+<input id="email" type="email" placeholder="Email" autocomplete="username">
+<input id="password" type="password" placeholder="Password" autocomplete="current-password">
+<button class="btn-primary" onclick="doLogin()">Log in</button>
+<script>
+function doLogin() {
+  var email = document.getElementById('email').value;
+  var password = document.getElementById('password').value;
+  var err = document.getElementById('err');
+  err.textContent = '';
+  fetch('/api/auth/login', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json', 'X-Scrumboy': '1'},
+    body: JSON.stringify({email: email, password: password})
+  }).then(function(res) {
+    return res.json().then(function(body) { return {status: res.status, body: body}; });
+  }).then(function(r) {
+    if (r.status === 200 && !r.body.requires2fa) {
+      window.location.reload();
+      return;
+    }
+    if (r.body && r.body.requires2fa) {
+      err.textContent = 'This account has 2FA enabled. Please log in at the main app first, then reopen this link.';
+      return;
+    }
+    err.textContent = 'Login failed. Check your email and password.';
+  }).catch(function() {
+    err.textContent = 'Login failed. Please try again.';
+  });
+}
+</script>
+</div></body></html>`, oauthPageStyle, html.EscapeString(name))
+}
+
+func (s *Server) renderOAuthConsentPage(w http.ResponseWriter, client store.OAuthClient, params authorizeParams) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	name := client.ClientName
+	if name == "" {
+		name = "This application"
+	}
+	fmt.Fprintf(w, `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Authorize %s</title>%s</head><body>
+<div class="card">
+<h1>Approve access for %s?</h1>
+<p>%s will be able to read and manage projects, todos, sprints, and tags in this Scrumboy instance on your behalf.</p>
+<form method="POST" action="/oauth/authorize">
+<input type="hidden" name="response_type" value="%s">
+<input type="hidden" name="client_id" value="%s">
+<input type="hidden" name="redirect_uri" value="%s">
+<input type="hidden" name="code_challenge" value="%s">
+<input type="hidden" name="code_challenge_method" value="%s">
+<input type="hidden" name="state" value="%s">
+<button class="btn-primary" type="submit" name="action" value="approve">Approve</button>
+<button class="btn-secondary" type="submit" name="action" value="deny">Deny</button>
+</form>
+</div></body></html>`,
+		html.EscapeString(name), oauthPageStyle, html.EscapeString(name), html.EscapeString(name),
+		html.EscapeString(params.ResponseType), html.EscapeString(params.ClientID), html.EscapeString(params.RedirectURI),
+		html.EscapeString(params.CodeChallenge), html.EscapeString(params.CodeChallengeMethod), html.EscapeString(params.State))
+}

--- a/internal/httpapi/routing_oauth_test.go
+++ b/internal/httpapi/routing_oauth_test.go
@@ -1,0 +1,543 @@
+package httpapi
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"scrumboy/internal/db"
+	"scrumboy/internal/mcp"
+	"scrumboy/internal/migrate"
+	"scrumboy/internal/store"
+)
+
+func newTestHTTPServerWithMCP(t *testing.T, mode string) (*httptest.Server, *sql.DB, func()) {
+	t.Helper()
+
+	dir := t.TempDir()
+	sqlDB, err := db.Open(filepath.Join(dir, "app.db"), db.Options{
+		BusyTimeout: 5000,
+		JournalMode: "WAL",
+		Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := migrate.Apply(context.Background(), sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+
+	st := store.New(sqlDB, nil)
+	srv := NewServer(st, Options{
+		MaxRequestBody: 1 << 20,
+		ScrumboyMode:   mode,
+		MCPHandler:     mcp.New(st, mcp.Options{Mode: mode}),
+	})
+	ts := httptest.NewServer(srv)
+	return ts, sqlDB, func() {
+		ts.Close()
+		_ = sqlDB.Close()
+	}
+}
+
+// pkcePair returns a random S256 code_verifier/code_challenge pair.
+func pkcePair(t *testing.T) (verifier, challenge string) {
+	t.Helper()
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	verifier = base64.RawURLEncoding.EncodeToString(b)
+	sum := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(sum[:])
+	return verifier, challenge
+}
+
+func registerOAuthClient(t *testing.T, baseURL, redirectURI string) string {
+	t.Helper()
+	client := &http.Client{}
+	var out map[string]any
+	resp, body := doJSON(t, client, http.MethodPost, baseURL+"/oauth/register", map[string]any{
+		"client_name":   "Test Client",
+		"redirect_uris": []string{redirectURI},
+	}, &out)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("register status=%d body=%s", resp.StatusCode, string(body))
+	}
+	clientID, _ := out["client_id"].(string)
+	if clientID == "" {
+		t.Fatalf("expected client_id in register response, got %+v", out)
+	}
+	return clientID
+}
+
+func authorizeURL(baseURL, clientID, redirectURI, challenge, state string) string {
+	q := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {state},
+	}
+	return baseURL + "/oauth/authorize?" + q.Encode()
+}
+
+func approveConsent(t *testing.T, client *http.Client, baseURL, clientID, redirectURI, challenge, state string) *url.URL {
+	t.Helper()
+	form := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {state},
+		"action":                {"approve"},
+	}
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/oauth/authorize", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("approve consent: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302 from consent approval, got %d", resp.StatusCode)
+	}
+	loc, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect location: %v", err)
+	}
+	return loc
+}
+
+func exchangeToken(t *testing.T, baseURL string, form url.Values) (int, map[string]any) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/oauth/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("token request: %v", err)
+	}
+	defer resp.Body.Close()
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	return resp.StatusCode, out
+}
+
+func TestOAuth_FullHappyPath(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServerWithMCP(t, "full")
+	defer cleanup()
+
+	cookieClient := newCookieClient(t)
+	cookieClient.CheckRedirect = func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }
+	bootstrapUserClient(t, cookieClient, ts.URL, "Owner", "owner@example.com", "password123")
+
+	redirectURI := "http://localhost:9999/callback"
+	clientID := registerOAuthClient(t, ts.URL, redirectURI)
+
+	// Discovery metadata sanity checks.
+	var asMeta map[string]any
+	if resp, _ := doJSON(t, http.DefaultClient, http.MethodGet, ts.URL+"/.well-known/oauth-authorization-server", nil, &asMeta); resp.StatusCode != http.StatusOK {
+		t.Fatalf("AS metadata status=%d", resp.StatusCode)
+	}
+	for _, field := range []string{"issuer", "authorization_endpoint", "token_endpoint", "registration_endpoint", "revocation_endpoint"} {
+		if asMeta[field] == nil || asMeta[field] == "" {
+			t.Fatalf("expected AS metadata field %q, got %+v", field, asMeta)
+		}
+	}
+	var prMeta map[string]any
+	if resp, _ := doJSON(t, http.DefaultClient, http.MethodGet, ts.URL+"/.well-known/oauth-protected-resource", nil, &prMeta); resp.StatusCode != http.StatusOK {
+		t.Fatalf("protected resource metadata status=%d", resp.StatusCode)
+	}
+	if prMeta["resource"] == nil {
+		t.Fatalf("expected protected resource metadata to include resource, got %+v", prMeta)
+	}
+
+	verifier, challenge := pkcePair(t)
+
+	// Unauthenticated GET /oauth/authorize should render a login prompt, not a consent form.
+	unauthResp, err := http.Get(authorizeURL(ts.URL, clientID, redirectURI, challenge, "s1"))
+	if err != nil {
+		t.Fatalf("unauthenticated authorize GET: %v", err)
+	}
+	unauthBody := make([]byte, 4096)
+	n, _ := unauthResp.Body.Read(unauthBody)
+	unauthResp.Body.Close()
+	if !strings.Contains(string(unauthBody[:n]), "Log in") {
+		t.Fatalf("expected login prompt for unauthenticated authorize GET, got: %s", unauthBody[:n])
+	}
+
+	// Authenticated GET should render the consent form.
+	consentResp, err := cookieClient.Get(authorizeURL(ts.URL, clientID, redirectURI, challenge, "s1"))
+	if err != nil {
+		t.Fatalf("authenticated authorize GET: %v", err)
+	}
+	consentBody := make([]byte, 4096)
+	cn, _ := consentResp.Body.Read(consentBody)
+	consentResp.Body.Close()
+	if !strings.Contains(string(consentBody[:cn]), "Approve access") {
+		t.Fatalf("expected consent form for authenticated authorize GET, got: %s", consentBody[:cn])
+	}
+
+	loc := approveConsent(t, cookieClient, ts.URL, clientID, redirectURI, challenge, "s1")
+	code := loc.Query().Get("code")
+	if code == "" {
+		t.Fatalf("expected code in redirect, got %s", loc.String())
+	}
+	if loc.Query().Get("state") != "s1" {
+		t.Fatalf("expected state echoed back, got %s", loc.String())
+	}
+
+	status, tokenResp := exchangeToken(t, ts.URL, url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"client_id":     {clientID},
+		"code_verifier": {verifier},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("token exchange status=%d body=%+v", status, tokenResp)
+	}
+	accessToken, _ := tokenResp["access_token"].(string)
+	if accessToken == "" {
+		t.Fatalf("expected access_token in response, got %+v", tokenResp)
+	}
+	if tokenResp["token_type"] != "Bearer" {
+		t.Fatalf("expected token_type=Bearer, got %+v", tokenResp)
+	}
+	if tokenResp["refresh_token"] == nil || tokenResp["refresh_token"] == "" {
+		t.Fatalf("expected refresh_token, got %+v", tokenResp)
+	}
+
+	// Use the OAuth access token as a Bearer credential on the MCP endpoint.
+	mcpReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"projects.list","arguments":{}}}`))
+	mcpReq.Header.Set("Content-Type", "application/json")
+	mcpReq.Header.Set("Authorization", "Bearer "+accessToken)
+	mcpResp, err := http.DefaultClient.Do(mcpReq)
+	if err != nil {
+		t.Fatalf("mcp call: %v", err)
+	}
+	defer mcpResp.Body.Close()
+	var mcpOut map[string]any
+	if err := json.NewDecoder(mcpResp.Body).Decode(&mcpOut); err != nil {
+		t.Fatalf("decode mcp response: %v", err)
+	}
+	result, ok := mcpOut["result"].(map[string]any)
+	if !ok || result["isError"] == true {
+		t.Fatalf("expected successful MCP tool call with OAuth bearer token, got %+v", mcpOut)
+	}
+}
+
+func TestOAuth_PKCEMismatch(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServerWithMCP(t, "full")
+	defer cleanup()
+
+	cookieClient := newCookieClient(t)
+	cookieClient.CheckRedirect = func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }
+	bootstrapUserClient(t, cookieClient, ts.URL, "Owner", "owner@example.com", "password123")
+
+	redirectURI := "http://localhost:9999/callback"
+	clientID := registerOAuthClient(t, ts.URL, redirectURI)
+	_, challenge := pkcePair(t)
+
+	loc := approveConsent(t, cookieClient, ts.URL, clientID, redirectURI, challenge, "s1")
+	code := loc.Query().Get("code")
+
+	status, resp := exchangeToken(t, ts.URL, url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"client_id":     {clientID},
+		"code_verifier": {"totally-wrong-verifier"},
+	})
+	if status != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", status)
+	}
+	if resp["error"] != "invalid_grant" {
+		t.Fatalf("expected invalid_grant, got %+v", resp)
+	}
+}
+
+func TestOAuth_ExpiredAuthCode(t *testing.T) {
+	ts, sqlDB, cleanup := newTestHTTPServerWithMCP(t, "full")
+	defer cleanup()
+
+	cookieClient := newCookieClient(t)
+	cookieClient.CheckRedirect = func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }
+	bootstrapUserClient(t, cookieClient, ts.URL, "Owner", "owner@example.com", "password123")
+
+	redirectURI := "http://localhost:9999/callback"
+	clientID := registerOAuthClient(t, ts.URL, redirectURI)
+	verifier, challenge := pkcePair(t)
+
+	loc := approveConsent(t, cookieClient, ts.URL, clientID, redirectURI, challenge, "s1")
+	code := loc.Query().Get("code")
+
+	if _, err := sqlDB.Exec(`UPDATE oauth_auth_codes SET expires_at = 0`); err != nil {
+		t.Fatalf("backdate auth code: %v", err)
+	}
+
+	status, resp := exchangeToken(t, ts.URL, url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"client_id":     {clientID},
+		"code_verifier": {verifier},
+	})
+	if status != http.StatusBadRequest || resp["error"] != "invalid_grant" {
+		t.Fatalf("expected 400 invalid_grant for expired code, got status=%d body=%+v", status, resp)
+	}
+}
+
+func TestOAuth_ReplayedAuthCodeRejected(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServerWithMCP(t, "full")
+	defer cleanup()
+
+	cookieClient := newCookieClient(t)
+	cookieClient.CheckRedirect = func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }
+	bootstrapUserClient(t, cookieClient, ts.URL, "Owner", "owner@example.com", "password123")
+
+	redirectURI := "http://localhost:9999/callback"
+	clientID := registerOAuthClient(t, ts.URL, redirectURI)
+	verifier, challenge := pkcePair(t)
+
+	loc := approveConsent(t, cookieClient, ts.URL, clientID, redirectURI, challenge, "s1")
+	code := loc.Query().Get("code")
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"client_id":     {clientID},
+		"code_verifier": {verifier},
+	}
+	status1, resp1 := exchangeToken(t, ts.URL, form)
+	if status1 != http.StatusOK {
+		t.Fatalf("first exchange should succeed, got status=%d body=%+v", status1, resp1)
+	}
+
+	status2, resp2 := exchangeToken(t, ts.URL, form)
+	if status2 != http.StatusBadRequest || resp2["error"] != "invalid_grant" {
+		t.Fatalf("expected replay to be rejected with invalid_grant, got status=%d body=%+v", status2, resp2)
+	}
+}
+
+func TestOAuth_RedirectURIMismatchAtTokenExchange(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServerWithMCP(t, "full")
+	defer cleanup()
+
+	cookieClient := newCookieClient(t)
+	cookieClient.CheckRedirect = func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }
+	bootstrapUserClient(t, cookieClient, ts.URL, "Owner", "owner@example.com", "password123")
+
+	redirectURI := "http://localhost:9999/callback"
+	clientID := registerOAuthClient(t, ts.URL, redirectURI)
+	verifier, challenge := pkcePair(t)
+
+	loc := approveConsent(t, cookieClient, ts.URL, clientID, redirectURI, challenge, "s1")
+	code := loc.Query().Get("code")
+
+	status, resp := exchangeToken(t, ts.URL, url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {"http://localhost:9999/different-callback"},
+		"client_id":     {clientID},
+		"code_verifier": {verifier},
+	})
+	if status != http.StatusBadRequest || resp["error"] != "invalid_grant" {
+		t.Fatalf("expected 400 invalid_grant for redirect_uri mismatch, got status=%d body=%+v", status, resp)
+	}
+}
+
+func TestOAuth_AnonymousMode404s(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServerWithMCP(t, "anonymous")
+	defer cleanup()
+
+	paths := []string{
+		"/.well-known/oauth-authorization-server",
+		"/.well-known/oauth-protected-resource",
+		"/oauth/register",
+		"/oauth/authorize",
+		"/oauth/token",
+		"/oauth/revoke",
+	}
+	for _, p := range paths {
+		resp, err := http.Get(ts.URL + p)
+		if err != nil {
+			t.Fatalf("GET %s: %v", p, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("GET %s in anonymous mode: expected 404, got %d", p, resp.StatusCode)
+		}
+
+		postResp, err := http.Post(ts.URL+p, "application/x-www-form-urlencoded", strings.NewReader(""))
+		if err != nil {
+			t.Fatalf("POST %s: %v", p, err)
+		}
+		postResp.Body.Close()
+		if postResp.StatusCode != http.StatusNotFound {
+			t.Errorf("POST %s in anonymous mode: expected 404, got %d", p, postResp.StatusCode)
+		}
+	}
+}
+
+func TestOAuth_RefreshTokenFlow(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServerWithMCP(t, "full")
+	defer cleanup()
+
+	cookieClient := newCookieClient(t)
+	cookieClient.CheckRedirect = func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }
+	bootstrapUserClient(t, cookieClient, ts.URL, "Owner", "owner@example.com", "password123")
+
+	redirectURI := "http://localhost:9999/callback"
+	clientID := registerOAuthClient(t, ts.URL, redirectURI)
+	verifier, challenge := pkcePair(t)
+
+	loc := approveConsent(t, cookieClient, ts.URL, clientID, redirectURI, challenge, "s1")
+	code := loc.Query().Get("code")
+
+	status, tokenResp := exchangeToken(t, ts.URL, url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"client_id":     {clientID},
+		"code_verifier": {verifier},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("initial token exchange status=%d body=%+v", status, tokenResp)
+	}
+	firstAccessToken := tokenResp["access_token"].(string)
+	firstRefreshToken := tokenResp["refresh_token"].(string)
+
+	// Rotate.
+	status2, refreshResp := exchangeToken(t, ts.URL, url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {firstRefreshToken},
+	})
+	if status2 != http.StatusOK {
+		t.Fatalf("refresh exchange status=%d body=%+v", status2, refreshResp)
+	}
+	newAccessToken, _ := refreshResp["access_token"].(string)
+	if newAccessToken == "" || newAccessToken == firstAccessToken {
+		t.Fatalf("expected a new distinct access token, got %+v", refreshResp)
+	}
+
+	// Pre-rotation access token is unaffected by refresh rotation in v1 (only
+	// the refresh token itself is rotated) and remains usable until its own
+	// expiry.
+	mcpReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"projects.list","arguments":{}}}`))
+	mcpReq.Header.Set("Content-Type", "application/json")
+	mcpReq.Header.Set("Authorization", "Bearer "+firstAccessToken)
+	mcpResp, err := http.DefaultClient.Do(mcpReq)
+	if err != nil {
+		t.Fatalf("mcp call with pre-rotation access token: %v", err)
+	}
+	defer mcpResp.Body.Close()
+	var mcpOut map[string]any
+	json.NewDecoder(mcpResp.Body).Decode(&mcpOut)
+	if result, ok := mcpOut["result"].(map[string]any); !ok || result["isError"] == true {
+		t.Fatalf("expected pre-rotation access token to still work, got %+v", mcpOut)
+	}
+
+	// Reusing the already-rotated-away-from refresh token must fail.
+	status3, reuseResp := exchangeToken(t, ts.URL, url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {firstRefreshToken},
+	})
+	if status3 != http.StatusBadRequest || reuseResp["error"] != "invalid_grant" {
+		t.Fatalf("expected reused refresh token to be rejected, got status=%d body=%+v", status3, reuseResp)
+	}
+}
+
+func TestOAuth_RevokedAccessTokenRejectedByMCP(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServerWithMCP(t, "full")
+	defer cleanup()
+
+	cookieClient := newCookieClient(t)
+	cookieClient.CheckRedirect = func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }
+	bootstrapUserClient(t, cookieClient, ts.URL, "Owner", "owner@example.com", "password123")
+
+	redirectURI := "http://localhost:9999/callback"
+	clientID := registerOAuthClient(t, ts.URL, redirectURI)
+	verifier, challenge := pkcePair(t)
+
+	loc := approveConsent(t, cookieClient, ts.URL, clientID, redirectURI, challenge, "s1")
+	code := loc.Query().Get("code")
+
+	_, tokenResp := exchangeToken(t, ts.URL, url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"client_id":     {clientID},
+		"code_verifier": {verifier},
+	})
+	accessToken := tokenResp["access_token"].(string)
+
+	// Revoking an active token succeeds (200), and a nonexistent/garbage
+	// token also returns 200 (RFC 7009 §2.2: no token-existence oracle).
+	revokeResp, err := http.PostForm(ts.URL+"/oauth/revoke", url.Values{"token": {accessToken}})
+	if err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	revokeResp.Body.Close()
+	if revokeResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from revoke, got %d", revokeResp.StatusCode)
+	}
+
+	garbageRevokeResp, err := http.PostForm(ts.URL+"/oauth/revoke", url.Values{"token": {"not-a-real-token"}})
+	if err != nil {
+		t.Fatalf("revoke garbage token: %v", err)
+	}
+	garbageRevokeResp.Body.Close()
+	if garbageRevokeResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from revoking a nonexistent token, got %d", garbageRevokeResp.StatusCode)
+	}
+
+	mcpReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp", strings.NewReader(`{"tool":"projects.list","input":{}}`))
+	mcpReq.Header.Set("Content-Type", "application/json")
+	mcpReq.Header.Set("Authorization", "Bearer "+accessToken)
+	mcpResp, err := http.DefaultClient.Do(mcpReq)
+	if err != nil {
+		t.Fatalf("mcp call with revoked token: %v", err)
+	}
+	defer mcpResp.Body.Close()
+	if mcpResp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for revoked access token on legacy /mcp, got %d", mcpResp.StatusCode)
+	}
+}
+
+func TestOAuth_DCRMissingRedirectURIs(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServerWithMCP(t, "full")
+	defer cleanup()
+
+	var out map[string]any
+	resp, body := doJSON(t, http.DefaultClient, http.MethodPost, ts.URL+"/oauth/register", map[string]any{
+		"client_name": "No Redirect",
+	}, &out)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", resp.StatusCode, string(body))
+	}
+	if out["error"] != "invalid_redirect_uri" {
+		t.Fatalf("expected invalid_redirect_uri, got %+v", out)
+	}
+}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -119,6 +119,15 @@ type storeAPI interface {
 	ListUserAPITokens(ctx context.Context, userID int64) ([]store.APITokenMeta, error)
 	RevokeUserAPIToken(ctx context.Context, userID, tokenID int64) error
 
+	// OAuth 2.1 authorization server (RFC 7591/6749/7636/7009) for MCP clients.
+	CreateOAuthClient(ctx context.Context, clientID, clientName, redirectURI string) (store.OAuthClient, error)
+	GetOAuthClient(ctx context.Context, clientID string) (store.OAuthClient, error)
+	CreateOAuthAuthCode(ctx context.Context, clientID string, userID int64, redirectURI, codeChallenge, codeChallengeMethod string) (string, error)
+	ConsumeOAuthAuthCode(ctx context.Context, rawCode string) (store.OAuthAuthCode, error)
+	IssueOAuthTokenPair(ctx context.Context, clientID string, userID int64) (store.OAuthTokenPair, error)
+	ConsumeOAuthRefreshToken(ctx context.Context, rawToken string) (clientID string, userID int64, err error)
+	RevokeOAuthToken(ctx context.Context, rawToken, hint string) error
+
 	GetUserByOIDCIdentity(ctx context.Context, issuer, subject string) (store.User, error)
 	GetUserByEmail(ctx context.Context, email string) (store.User, error)
 	LinkOIDCIdentity(ctx context.Context, userID int64, issuer, subject, email string) error
@@ -417,6 +426,19 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if s.mcpHandler != nil && (r.URL.Path == "/mcp" || strings.HasPrefix(r.URL.Path, "/mcp/")) {
 		s.mcpHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if r.URL.Path == "/.well-known/oauth-protected-resource" {
+		s.handleOAuthProtectedResourceMetadata(w, r)
+		return
+	}
+	if r.URL.Path == "/.well-known/oauth-authorization-server" {
+		s.handleOAuthASMetadata(w, r)
+		return
+	}
+	if strings.HasPrefix(r.URL.Path, "/oauth/") {
+		s.handleOAuth(w, r)
 		return
 	}
 

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -16,6 +16,7 @@ type storeAPI interface {
 	CountUsers(ctx context.Context) (int, error)
 	GetUserBySessionToken(ctx context.Context, token string) (store.User, error)
 	GetUserByAPIToken(ctx context.Context, rawToken string) (store.User, error)
+	GetUserByOAuthAccessToken(ctx context.Context, rawToken string) (store.User, error)
 	ListProjects(ctx context.Context) ([]store.ProjectListEntry, error)
 	GetProjectContextBySlug(ctx context.Context, slug string, mode store.Mode) (store.ProjectContext, error)
 	CreateTodo(ctx context.Context, projectID int64, in store.CreateTodoInput, mode store.Mode) (store.Todo, error)
@@ -125,6 +126,12 @@ func (a *Adapter) resolveRequestAuth(r *http.Request) requestAuthResult {
 			return requestAuthResult{Ctx: ctx, BearerAuthFailed: true}
 		}
 		u, err := a.store.GetUserByAPIToken(ctx, cred)
+		if errors.Is(err, store.ErrNotFound) {
+			// OAuth-issued access tokens (RFC 6749) live in a separate table
+			// from manually-created API tokens; fall back to that lookup
+			// before giving up. This never falls back to the session cookie.
+			u, err = a.store.GetUserByOAuthAccessToken(ctx, cred)
+		}
 		if err != nil {
 			if errors.Is(err, store.ErrNotFound) {
 				return requestAuthResult{Ctx: ctx, BearerAuthFailed: true}

--- a/internal/mcp/adapter_test.go
+++ b/internal/mcp/adapter_test.go
@@ -364,6 +364,33 @@ func TestMCP_InvalidBearerDoesNotFallBackToSessionCookie(t *testing.T) {
 			t.Fatalf("expected AUTH_REQUIRED, got %#v", errObj["code"])
 		}
 	})
+
+	// An invalid OAuth-shaped bearer token (no sb_ prefix, matching what
+	// GetUserByOAuthAccessToken checks) must behave identically: 401, no
+	// fallback to the valid session cookie carried by this same client.
+	t.Run("OAuthShapedToken", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/mcp", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Authorization", "Bearer "+strings.Repeat("z", 43))
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("GET status=%d want 401", resp.StatusCode)
+		}
+		var out map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatal(err)
+		}
+		errObj := out["error"].(map[string]any)
+		if errObj["code"] != "AUTH_REQUIRED" {
+			t.Fatalf("expected AUTH_REQUIRED, got %#v", errObj["code"])
+		}
+	})
 }
 
 func TestMCP_BearerTokenEndToEnd(t *testing.T) {

--- a/internal/migrate/migrations/055_add_oauth_authorization_server.sql
+++ b/internal/migrate/migrations/055_add_oauth_authorization_server.sql
@@ -1,0 +1,54 @@
+-- Migration 055: OAuth 2.1 authorization server support for MCP clients (DCR + PKCE)
+
+PRAGMA foreign_keys = ON;
+
+-- Dynamically-registered OAuth clients (RFC 7591). Public clients only (no
+-- client_secret): MCP clients like Claude Code register as public clients and
+-- use PKCE instead of a confidential client secret.
+CREATE TABLE oauth_clients (
+  id TEXT PRIMARY KEY,
+  client_name TEXT,
+  redirect_uri TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+-- Short-lived, single-use authorization codes.
+CREATE TABLE oauth_auth_codes (
+  code_hash TEXT PRIMARY KEY,
+  client_id TEXT NOT NULL REFERENCES oauth_clients(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  redirect_uri TEXT NOT NULL,
+  code_challenge TEXT NOT NULL,
+  code_challenge_method TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  consumed_at INTEGER
+);
+
+CREATE INDEX idx_oauth_auth_codes_expires_at ON oauth_auth_codes(expires_at);
+
+-- Opaque OAuth-issued access tokens, kept separate from api_tokens so
+-- OAuth-issued and manually-created tokens are never conflated for
+-- revocation/introspection.
+CREATE TABLE oauth_access_tokens (
+  token_hash TEXT PRIMARY KEY,
+  client_id TEXT NOT NULL REFERENCES oauth_clients(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  revoked_at INTEGER
+);
+
+CREATE INDEX idx_oauth_access_tokens_user_id ON oauth_access_tokens(user_id);
+
+-- Opaque refresh tokens, rotated on use (no reuse-detection chain in v1).
+CREATE TABLE oauth_refresh_tokens (
+  token_hash TEXT PRIMARY KEY,
+  client_id TEXT NOT NULL REFERENCES oauth_clients(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  revoked_at INTEGER
+);
+
+CREATE INDEX idx_oauth_refresh_tokens_user_id ON oauth_refresh_tokens(user_id);

--- a/internal/oauth/errors.go
+++ b/internal/oauth/errors.go
@@ -1,0 +1,50 @@
+package oauth
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Error codes from RFC 6749 §5.2 (token endpoint) and §4.1.2.1 (authorize endpoint).
+const (
+	ErrInvalidRequest       = "invalid_request"
+	ErrInvalidClient        = "invalid_client"
+	ErrInvalidGrant         = "invalid_grant"
+	ErrUnauthorizedClient   = "unauthorized_client"
+	ErrUnsupportedGrantType = "unsupported_grant_type"
+	ErrInvalidScope         = "invalid_scope"
+	ErrAccessDenied         = "access_denied"
+	ErrUnsupportedResponse  = "unsupported_response_type"
+	ErrServerError          = "server_error"
+)
+
+// Error codes from RFC 7591 §3.2.2 (dynamic client registration).
+const (
+	ErrInvalidRedirectURI    = "invalid_redirect_uri"
+	ErrInvalidClientMetadata = "invalid_client_metadata"
+)
+
+// ErrorResponse is the flat wire shape required by RFC 6749 §5.2 and RFC 7591
+// §3.2.2 — deliberately not Scrumboy's usual {"error":{"code":...}} envelope,
+// since OAuth clients parse these exact top-level "error"/"error_description" keys.
+type ErrorResponse struct {
+	Code        string `json:"error"`
+	Description string `json:"error_description,omitempty"`
+}
+
+// WriteJSON writes an OAuth-shaped error response with the given HTTP status.
+func WriteJSON(w http.ResponseWriter, status int, code, description string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(ErrorResponse{Code: code, Description: description})
+}
+
+// StatusForCode returns the RFC 6749 §5.2-mandated HTTP status for a given
+// token-endpoint error code (400 for everything except invalid_client, which
+// is 401).
+func StatusForCode(code string) int {
+	if code == ErrInvalidClient {
+		return http.StatusUnauthorized
+	}
+	return http.StatusBadRequest
+}

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -1,0 +1,37 @@
+// Package oauth implements the pure, DB-independent parts of a minimal OAuth
+// 2.1 authorization server for Scrumboy's MCP endpoint: PKCE verification,
+// opaque secret generation, and the OAuth error wire format. DB-backed
+// persistence (clients, codes, tokens) lives in internal/store/oauth.go;
+// HTTP glue lives in internal/httpapi/routing_oauth.go.
+package oauth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+)
+
+// GenerateClientID returns a new public client identifier for dynamic client
+// registration (RFC 7591). Prefixed distinctly from api_tokens' "sb_" secrets
+// since a client_id is a public identifier, not a bearer secret.
+func GenerateClientID() (string, error) {
+	b := make([]byte, 18)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("rand client id: %w", err)
+	}
+	return "oc_" + base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// GenerateOpaqueSecret returns a new random opaque secret (authorization
+// code, access token, or refresh token plaintext). Unlike api_tokens' "sb_"
+// prefix, these carry no fixed prefix: they are never human-copied, always
+// exchanged programmatically, and a distinct shape lets GetUserByAPIToken's
+// existing "sb_" prefix check short-circuit instantly instead of doing a
+// wasted hash+DB lookup on every MCP request bearing one of these tokens.
+func GenerateOpaqueSecret() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("rand secret: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/internal/oauth/oauth_test.go
+++ b/internal/oauth/oauth_test.go
@@ -1,0 +1,87 @@
+package oauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+)
+
+func challengeFor(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func TestVerifyPKCE_S256Match(t *testing.T) {
+	verifier := "test-verifier-value-1234567890"
+	challenge := challengeFor(verifier)
+	if !VerifyPKCE("S256", verifier, challenge) {
+		t.Fatal("expected matching S256 verifier/challenge to verify")
+	}
+}
+
+func TestVerifyPKCE_S256Mismatch(t *testing.T) {
+	challenge := challengeFor("correct-verifier")
+	if VerifyPKCE("S256", "wrong-verifier", challenge) {
+		t.Fatal("expected mismatched verifier to fail")
+	}
+}
+
+func TestVerifyPKCE_EmptyValues(t *testing.T) {
+	if VerifyPKCE("S256", "", "somechallenge") {
+		t.Fatal("expected empty verifier to fail")
+	}
+	if VerifyPKCE("S256", "someverifier", "") {
+		t.Fatal("expected empty challenge to fail")
+	}
+}
+
+func TestVerifyPKCE_PlainMethodRejected(t *testing.T) {
+	verifier := "plain-verifier"
+	if VerifyPKCE("plain", verifier, verifier) {
+		t.Fatal("expected \"plain\" method to be rejected regardless of match")
+	}
+}
+
+func TestVerifyPKCE_UnknownMethodRejected(t *testing.T) {
+	verifier := "some-verifier"
+	if VerifyPKCE("S512", verifier, challengeFor(verifier)) {
+		t.Fatal("expected unsupported method to be rejected")
+	}
+}
+
+func TestGenerateClientID(t *testing.T) {
+	id1, err := GenerateClientID()
+	if err != nil {
+		t.Fatalf("GenerateClientID: %v", err)
+	}
+	id2, err := GenerateClientID()
+	if err != nil {
+		t.Fatalf("GenerateClientID: %v", err)
+	}
+	if id1 == "" || id2 == "" {
+		t.Fatal("expected non-empty client ids")
+	}
+	if id1 == id2 {
+		t.Fatal("expected unique client ids across calls")
+	}
+	if len(id1) < 4 || id1[:3] != "oc_" {
+		t.Fatalf("expected client id to have oc_ prefix, got %q", id1)
+	}
+}
+
+func TestGenerateOpaqueSecret(t *testing.T) {
+	s1, err := GenerateOpaqueSecret()
+	if err != nil {
+		t.Fatalf("GenerateOpaqueSecret: %v", err)
+	}
+	s2, err := GenerateOpaqueSecret()
+	if err != nil {
+		t.Fatalf("GenerateOpaqueSecret: %v", err)
+	}
+	if s1 == "" || s2 == "" {
+		t.Fatal("expected non-empty secrets")
+	}
+	if s1 == s2 {
+		t.Fatal("expected unique secrets across calls")
+	}
+}

--- a/internal/oauth/pkce.go
+++ b/internal/oauth/pkce.go
@@ -1,0 +1,19 @@
+package oauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+// VerifyPKCE checks a presented code_verifier against the code_challenge recorded
+// at /oauth/authorize time. Only the S256 method is supported: OAuth 2.1 mandates
+// S256-only PKCE, and MCP clients (Claude Code included) always use it. The
+// "plain" method (RFC 7636 §4.2) is deliberately rejected.
+func VerifyPKCE(method, verifier, challenge string) bool {
+	if method != "S256" || verifier == "" || challenge == "" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	computed := base64.RawURLEncoding.EncodeToString(sum[:])
+	return computed == challenge
+}

--- a/internal/store/oauth.go
+++ b/internal/store/oauth.go
@@ -1,0 +1,336 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"scrumboy/internal/oauth"
+)
+
+const (
+	authCodeTTL     = 60 * time.Second
+	accessTokenTTL  = 1 * time.Hour
+	refreshTokenTTL = 30 * 24 * time.Hour
+)
+
+// OAuthClient is a dynamically-registered public OAuth client (RFC 7591).
+type OAuthClient struct {
+	ID          string
+	ClientName  string
+	RedirectURI string
+	CreatedAt   time.Time
+}
+
+// OAuthAuthCode is a resolved, not-yet-consumed authorization code, returned
+// by ConsumeOAuthAuthCode so the caller can verify PKCE/redirect_uri/client_id
+// before treating the code as spent.
+type OAuthAuthCode struct {
+	ClientID            string
+	UserID              int64
+	RedirectURI         string
+	CodeChallenge       string
+	CodeChallengeMethod string
+}
+
+// OAuthTokenPair is a freshly minted access+refresh token pair.
+type OAuthTokenPair struct {
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    int64 // seconds
+}
+
+// CreateOAuthClient registers a new public OAuth client (RFC 7591 DCR).
+func (s *Store) CreateOAuthClient(ctx context.Context, clientID, clientName, redirectURI string) (OAuthClient, error) {
+	if clientID == "" || redirectURI == "" {
+		return OAuthClient{}, fmt.Errorf("%w: client id and redirect uri are required", ErrValidation)
+	}
+	nowMs := time.Now().UTC().UnixMilli()
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO oauth_clients(id, client_name, redirect_uri, created_at)
+VALUES (?, ?, ?, ?)
+`, clientID, clientName, redirectURI, nowMs)
+	if err != nil {
+		return OAuthClient{}, fmt.Errorf("insert oauth client: %w", err)
+	}
+	return OAuthClient{
+		ID:          clientID,
+		ClientName:  clientName,
+		RedirectURI: redirectURI,
+		CreatedAt:   time.UnixMilli(nowMs).UTC(),
+	}, nil
+}
+
+// GetOAuthClient looks up a registered client by id.
+func (s *Store) GetOAuthClient(ctx context.Context, clientID string) (OAuthClient, error) {
+	if clientID == "" {
+		return OAuthClient{}, ErrNotFound
+	}
+	var (
+		c           OAuthClient
+		clientName  sql.NullString
+		createdAtMs int64
+	)
+	err := s.db.QueryRowContext(ctx, `
+SELECT id, client_name, redirect_uri, created_at
+FROM oauth_clients
+WHERE id = ?
+`, clientID).Scan(&c.ID, &clientName, &c.RedirectURI, &createdAtMs)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return OAuthClient{}, ErrNotFound
+		}
+		return OAuthClient{}, fmt.Errorf("get oauth client: %w", err)
+	}
+	c.ClientName = clientName.String
+	c.CreatedAt = time.UnixMilli(createdAtMs).UTC()
+	return c, nil
+}
+
+// CreateOAuthAuthCode issues a new single-use authorization code (plaintext
+// returned once) with a 60s TTL, bound to the presented PKCE code_challenge.
+func (s *Store) CreateOAuthAuthCode(ctx context.Context, clientID string, userID int64, redirectURI, codeChallenge, codeChallengeMethod string) (plaintext string, err error) {
+	if clientID == "" || userID <= 0 || redirectURI == "" || codeChallenge == "" {
+		return "", fmt.Errorf("%w: missing required auth code fields", ErrValidation)
+	}
+	secret, err := oauth.GenerateOpaqueSecret()
+	if err != nil {
+		return "", err
+	}
+	codeHash := hashToken(secret)
+	nowMs := time.Now().UTC().UnixMilli()
+	expiresMs := time.Now().UTC().Add(authCodeTTL).UnixMilli()
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO oauth_auth_codes(code_hash, client_id, user_id, redirect_uri, code_challenge, code_challenge_method, created_at, expires_at, consumed_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+`, codeHash, clientID, userID, redirectURI, codeChallenge, codeChallengeMethod, nowMs, expiresMs)
+	if err != nil {
+		return "", fmt.Errorf("insert oauth auth code: %w", err)
+	}
+	return secret, nil
+}
+
+// ConsumeOAuthAuthCode atomically redeems a not-yet-consumed, not-yet-expired
+// authorization code: single-use is enforced by the conditional UPDATE below,
+// not merely by an in-memory check, so a replayed code can never redeem twice
+// even under concurrent requests.
+func (s *Store) ConsumeOAuthAuthCode(ctx context.Context, rawCode string) (OAuthAuthCode, error) {
+	rawCode = strings.TrimSpace(rawCode)
+	if rawCode == "" {
+		return OAuthAuthCode{}, ErrNotFound
+	}
+	codeHash := hashToken(rawCode)
+	nowMs := time.Now().UTC().UnixMilli()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OAuthAuthCode{}, fmt.Errorf("begin consume auth code tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	var ac OAuthAuthCode
+	err = tx.QueryRowContext(ctx, `
+SELECT client_id, user_id, redirect_uri, code_challenge, code_challenge_method
+FROM oauth_auth_codes
+WHERE code_hash = ? AND consumed_at IS NULL AND expires_at > ?
+`, codeHash, nowMs).Scan(&ac.ClientID, &ac.UserID, &ac.RedirectURI, &ac.CodeChallenge, &ac.CodeChallengeMethod)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return OAuthAuthCode{}, ErrNotFound
+		}
+		return OAuthAuthCode{}, fmt.Errorf("select oauth auth code: %w", err)
+	}
+
+	res, err := tx.ExecContext(ctx, `
+UPDATE oauth_auth_codes SET consumed_at = ?
+WHERE code_hash = ? AND consumed_at IS NULL AND expires_at > ?
+`, nowMs, codeHash, nowMs)
+	if err != nil {
+		return OAuthAuthCode{}, fmt.Errorf("consume oauth auth code: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return OAuthAuthCode{}, fmt.Errorf("consume oauth auth code rows: %w", err)
+	}
+	if n == 0 {
+		// Consumed concurrently between the SELECT and UPDATE above.
+		return OAuthAuthCode{}, ErrNotFound
+	}
+	if err := tx.Commit(); err != nil {
+		return OAuthAuthCode{}, fmt.Errorf("commit consume auth code tx: %w", err)
+	}
+	return ac, nil
+}
+
+// IssueOAuthTokenPair mints a new access token (1h TTL) and refresh token (30d
+// TTL) for a client/user pair, e.g. after a successful authorization_code or
+// refresh_token grant.
+func (s *Store) IssueOAuthTokenPair(ctx context.Context, clientID string, userID int64) (OAuthTokenPair, error) {
+	if clientID == "" || userID <= 0 {
+		return OAuthTokenPair{}, fmt.Errorf("%w: missing client id or user id", ErrValidation)
+	}
+	accessSecret, err := oauth.GenerateOpaqueSecret()
+	if err != nil {
+		return OAuthTokenPair{}, err
+	}
+	refreshSecret, err := oauth.GenerateOpaqueSecret()
+	if err != nil {
+		return OAuthTokenPair{}, err
+	}
+
+	now := time.Now().UTC()
+	nowMs := now.UnixMilli()
+	accessExpiresMs := now.Add(accessTokenTTL).UnixMilli()
+	refreshExpiresMs := now.Add(refreshTokenTTL).UnixMilli()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OAuthTokenPair{}, fmt.Errorf("begin issue token pair tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO oauth_access_tokens(token_hash, client_id, user_id, created_at, expires_at, revoked_at)
+VALUES (?, ?, ?, ?, ?, NULL)
+`, hashToken(accessSecret), clientID, userID, nowMs, accessExpiresMs); err != nil {
+		return OAuthTokenPair{}, fmt.Errorf("insert oauth access token: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO oauth_refresh_tokens(token_hash, client_id, user_id, created_at, expires_at, revoked_at)
+VALUES (?, ?, ?, ?, ?, NULL)
+`, hashToken(refreshSecret), clientID, userID, nowMs, refreshExpiresMs); err != nil {
+		return OAuthTokenPair{}, fmt.Errorf("insert oauth refresh token: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return OAuthTokenPair{}, fmt.Errorf("commit issue token pair tx: %w", err)
+	}
+
+	return OAuthTokenPair{
+		AccessToken:  accessSecret,
+		RefreshToken: refreshSecret,
+		ExpiresIn:    int64(accessTokenTTL.Seconds()),
+	}, nil
+}
+
+// ConsumeOAuthRefreshToken validates and revokes (rotates away from) a
+// refresh token, returning the client/user it was issued to so a new token
+// pair can be minted. Revocation happens unconditionally on first successful
+// use, which is what makes reuse of an already-rotated token fail.
+func (s *Store) ConsumeOAuthRefreshToken(ctx context.Context, rawToken string) (clientID string, userID int64, err error) {
+	rawToken = strings.TrimSpace(rawToken)
+	if rawToken == "" {
+		return "", 0, ErrNotFound
+	}
+	tokenHash := hashToken(rawToken)
+	nowMs := time.Now().UTC().UnixMilli()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", 0, fmt.Errorf("begin consume refresh token tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	err = tx.QueryRowContext(ctx, `
+SELECT client_id, user_id
+FROM oauth_refresh_tokens
+WHERE token_hash = ? AND revoked_at IS NULL AND expires_at > ?
+`, tokenHash, nowMs).Scan(&clientID, &userID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", 0, ErrNotFound
+		}
+		return "", 0, fmt.Errorf("select oauth refresh token: %w", err)
+	}
+
+	res, err := tx.ExecContext(ctx, `
+UPDATE oauth_refresh_tokens SET revoked_at = ?
+WHERE token_hash = ? AND revoked_at IS NULL
+`, nowMs, tokenHash)
+	if err != nil {
+		return "", 0, fmt.Errorf("revoke oauth refresh token: %w", err)
+	}
+	if n, err := res.RowsAffected(); err != nil {
+		return "", 0, fmt.Errorf("revoke oauth refresh token rows: %w", err)
+	} else if n == 0 {
+		return "", 0, ErrNotFound
+	}
+	if err := tx.Commit(); err != nil {
+		return "", 0, fmt.Errorf("commit consume refresh token tx: %w", err)
+	}
+	return clientID, userID, nil
+}
+
+// GetUserByOAuthAccessToken returns the user for an active (non-revoked,
+// non-expired) OAuth access token. Mirrors GetUserByAPIToken's shape exactly
+// so internal/mcp/adapter.go can use it as a drop-in fallback lookup.
+func (s *Store) GetUserByOAuthAccessToken(ctx context.Context, rawToken string) (User, error) {
+	rawToken = strings.TrimSpace(rawToken)
+	if rawToken == "" {
+		return User{}, ErrNotFound
+	}
+	tokenHash := hashToken(rawToken)
+	nowMs := time.Now().UTC().UnixMilli()
+
+	var (
+		u                User
+		isBootstrap      bool
+		systemRoleStr    string
+		createdAt        int64
+		twoFactorEnabled bool
+	)
+	err := s.db.QueryRowContext(ctx, `
+SELECT u.id, u.email, u.name, u.is_bootstrap, u.system_role, u.created_at, u.two_factor_enabled
+FROM oauth_access_tokens t
+JOIN users u ON u.id = t.user_id
+WHERE t.token_hash = ?
+  AND t.revoked_at IS NULL
+  AND t.expires_at > ?
+`, tokenHash, nowMs).Scan(&u.ID, &u.Email, &u.Name, &isBootstrap, &systemRoleStr, &createdAt, &twoFactorEnabled)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return User{}, ErrNotFound
+		}
+		return User{}, fmt.Errorf("get oauth access token user: %w", err)
+	}
+	u.IsBootstrap = isBootstrap
+	if role, ok := ParseSystemRole(systemRoleStr); ok {
+		u.SystemRole = role
+	} else {
+		u.SystemRole = SystemRoleUser
+	}
+	u.CreatedAt = time.UnixMilli(createdAt).UTC()
+	u.TwoFactorEnabled = twoFactorEnabled
+	return u, nil
+}
+
+// RevokeOAuthToken revokes an access or refresh token by its plaintext value
+// (RFC 7009). If hint is "access_token" or "refresh_token" only that table is
+// checked; otherwise both are tried. Always succeeds (no-op if the token
+// isn't found) so callers can return 200 unconditionally per RFC 7009 §2.2,
+// avoiding a token-existence oracle.
+func (s *Store) RevokeOAuthToken(ctx context.Context, rawToken, hint string) error {
+	rawToken = strings.TrimSpace(rawToken)
+	if rawToken == "" {
+		return nil
+	}
+	tokenHash := hashToken(rawToken)
+	nowMs := time.Now().UTC().UnixMilli()
+
+	if hint != "refresh_token" {
+		if _, err := s.db.ExecContext(ctx, `
+UPDATE oauth_access_tokens SET revoked_at = ? WHERE token_hash = ? AND revoked_at IS NULL
+`, nowMs, tokenHash); err != nil {
+			return fmt.Errorf("revoke oauth access token: %w", err)
+		}
+	}
+	if hint != "access_token" {
+		if _, err := s.db.ExecContext(ctx, `
+UPDATE oauth_refresh_tokens SET revoked_at = ? WHERE token_hash = ? AND revoked_at IS NULL
+`, nowMs, tokenHash); err != nil {
+			return fmt.Errorf("revoke oauth refresh token: %w", err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Adds a minimal OAuth 2.1 authorization server (RFC 8414/9728 discovery, RFC 7591 Dynamic Client Registration, PKCE-only auth-code flow, refresh rotation, RFC 7009 revocation) so MCP clients that support automatic OAuth (e.g. Claude Code's `claude mcp add --transport http`) can connect without manually minting a static API token.
- OAuth-issued access tokens plug into the existing `resolveRequestAuth` MCP auth boundary additively — static Bearer API tokens and session-cookie auth are unchanged.
- New migration `055_add_oauth_authorization_server.sql` (`oauth_clients`, `oauth_auth_codes`, `oauth_access_tokens`, `oauth_refresh_tokens`), new `internal/oauth` (PKCE + error vocab), new `internal/store/oauth.go`, new `internal/httpapi/routing_oauth.go` (discovery/register/authorize/token/revoke), new `docs/oauth.md`.
- Deliberately scoped down for a personal/small-team instance: public clients only (no client secrets), single fixed consent scope, one redirect URI per client, no admin UI, no refresh-token reuse-detection cascade — see `docs/oauth.md`'s "Not Implemented" section.

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./... -count=1 -timeout=5m` — all packages pass, including extended `TestMCP_InvalidBearerDoesNotFallBackToSessionCookie`
- [x] New `internal/oauth` unit tests (PKCE S256 match/mismatch/plain-rejected, token generation)
- [x] New `internal/httpapi/routing_oauth_test.go` integration tests: full happy path (register → authorize → consent → token exchange → MCP call), PKCE mismatch, expired code, replayed code, redirect_uri mismatch, anonymous-mode 404s, refresh rotation + reuse rejection, revoked-token rejection by MCP, DCR validation
- [x] Manual end-to-end smoke test against a running local instance: DCR, login-gated consent screen, approve/deny, token exchange, MCP tool call with the OAuth access token, revoke, anonymous-mode 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7vL1gMBGNpkphS36VG43v