### PR TITLE
Mcp/spec normalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ coverage.out
 /docs/draft/
 f.bat
 a.bat
+tests.bat
 win_reset_factory.bat
 win_build_web.bat
 *.pem

--- a/API.md
+++ b/API.md
@@ -54,10 +54,10 @@ In addition to the **`/mcp`** HTTP interface above, Scrumboy exposes a Model Con
 - Uses **JSON-RPC 2.0**.
 - **`jsonrpc`:** must be the string `"2.0"`.
 - **`method`:** required (string).
-- **`id`:** required for **requests** that expect a JSON body (`initialize`, `tools/list`, `tools/call`). Omitted for **notifications** (see below). For **parse errors**, the response uses `"id": null` per JSON-RPC.
-- **`params`:** `initialize` requires `protocolVersion`, `capabilities`, and `clientInfo.name`. `tools/list` may omit it. For **`tools/call`**, `params` must be a JSON object (see below).
+- **`id`:** required for supported request-only methods (`initialize`, `ping`, `tools/list`, `tools/call`). Omitted for **notifications** (see below). A request-only method without an `id` is rejected with HTTP **400** and is not dispatched. For **parse errors**, the response uses `"id": null` per JSON-RPC.
+- **`params`:** `initialize` requires `protocolVersion`, `capabilities`, `clientInfo.name`, and `clientInfo.version`. `tools/list` may omit it. For **`tools/call`**, `params` must be a JSON object (see below).
 
-After Origin validation and authentication, **non-POST** methods receive an empty **405 Method Not Allowed** with `Allow: POST`; authenticated GET does not open an SSE stream. **HTTP status** for normal JSON-RPC replies is **200** for both success and protocol error objects in the body. Accepted notifications, including **`notifications/initialized`**, receive empty **202 Accepted** responses.
+After Origin validation and authentication, **non-POST** methods receive an empty **405 Method Not Allowed** with `Allow: POST`; authenticated GET does not open an SSE stream. **HTTP status** for normal JSON-RPC requests with IDs is **200** for both success and protocol error objects in the body. Accepted notifications, including **`notifications/initialized`**, receive empty **202 Accepted** responses. Structurally rejected notifications receive **400** and have no side effect; an emitted JSON-RPC error uses `id: null`.
 
 **Example request:**
 

--- a/API.md
+++ b/API.md
@@ -1,12 +1,12 @@
 # Scrumboy MCP HTTP API
 
-Updated: 2026-04-23 14:28:12 -04:00
+Updated: 2026-07-18
 
 This API is intended for programmatic clients (e.g., agents or integrations), not direct browser use.
 
 This document describes the **Model Context Protocol (MCP) HTTP surface** implemented under `internal/mcp` and mounted by the Scrumboy HTTP server. It reflects **current behavior only**, not a roadmap.
 
-**Base path:** `/mcp` (exactly; paths like `/mcp/foo` return 404).
+**Interfaces:** legacy `/mcp` and canonical MCP Streamable HTTP `/mcp/rpc`. They share tool implementations but not wire semantics or OAuth audience.
 
 The MCP adapter is constructed in `cmd/scrumboy/main.go` with server mode from configuration and registered on the main `httpapi` server.
 
@@ -45,7 +45,7 @@ Responses use `Cache-Control: no-store` and `Content-Type: application/json; cha
 
 In addition to the **`/mcp`** HTTP interface above, Scrumboy exposes a Model Context Protocol (MCP) oriented endpoint that speaks **JSON-RPC 2.0**. This is a **separate** transport from the legacy `{ "tool", "input" }` POST body; both are mounted on the same MCP adapter.
 
-**Endpoint:** `POST /mcp/rpc` (trailing slash `/mcp/rpc/` is accepted).
+**Endpoint:** `/mcp/rpc`. Native MCP clients must be configured with this exact URL. `/mcp/rpc/` returns a same-origin 308 redirect to the canonical path before authentication.
 
 **Intended use:** MCP-style clients (e.g. Claude Desktop, agent frameworks) that expect JSON-RPC framing.
 
@@ -55,9 +55,9 @@ In addition to the **`/mcp`** HTTP interface above, Scrumboy exposes a Model Con
 - **`jsonrpc`:** must be the string `"2.0"`.
 - **`method`:** required (string).
 - **`id`:** required for **requests** that expect a JSON body (`initialize`, `tools/list`, `tools/call`). Omitted for **notifications** (see below). For **parse errors**, the response uses `"id": null` per JSON-RPC.
-- **`params`:** optional for `initialize` and `tools/list` (may be omitted or an object). For **`tools/call`**, `params` must be a JSON object (see below).
+- **`params`:** `initialize` requires `protocolVersion`, `capabilities`, and `clientInfo.name`. `tools/list` may omit it. For **`tools/call`**, `params` must be a JSON object (see below).
 
-**Non-POST** requests receive a JSON-RPC error (`id` null). **HTTP status** for normal JSON-RPC replies is **200** for both success and error objects in the body (errors are not signaled only by HTTP status). The **`notifications/initialized`** (or **`initialized`**) notification is answered with **204 No Content** and an empty body.
+After Origin validation and authentication, **non-POST** methods receive an empty **405 Method Not Allowed** with `Allow: POST`; authenticated GET does not open an SSE stream. **HTTP status** for normal JSON-RPC replies is **200** for both success and protocol error objects in the body. Accepted notifications, including **`notifications/initialized`**, receive empty **202 Accepted** responses.
 
 **Example request:**
 
@@ -66,17 +66,21 @@ In addition to the **`/mcp`** HTTP interface above, Scrumboy exposes a Model Con
   "jsonrpc": "2.0",
   "id": 1,
   "method": "initialize",
-  "params": {}
+  "params": {
+    "protocolVersion": "2025-11-25",
+    "capabilities": {},
+    "clientInfo": {"name": "example", "version": "1"}
+  }
 }
 ```
 
 ### Supported methods
 
-**`initialize`** — Initial handshake. Requires `id`. Returns `protocolVersion` (currently `2024-11-05`), `capabilities`, `serverInfo`, and optional `instructions`. `params` may be omitted or empty.
+**`initialize`** — Initial handshake. Requires `id` and the fields shown above. Supported stable versions are `2025-03-26`, `2025-06-18`, and `2025-11-25`; a supported requested version is echoed, while an unsupported initialize version negotiates to latest stable `2025-11-25`.
 
-**`notifications/initialized`** or **`initialized`** — Client acknowledgment after `initialize`. Must be sent **without** `id` (notification). Server responds with **204** and no JSON body. If an `id` is present, the server rejects the call.
+**`notifications/initialized`** or **`initialized`** — Client acknowledgment after `initialize`. Must be sent **without** `id` (notification). Server responds with **202** and no JSON body. If an `id` is present, the server rejects the call.
 
-**`tools/list`** — Requires `id`. Returns `{ "tools": [ ... ] }`. Each entry has `name`, `description`, and `inputSchema` (JSON Schema object). The array includes **every** tool in `implementedTools` from the in-code catalog (`internal/mcp/tool_catalog.go`), not a subset. **`tools/list` does not require a prior `initialize`.** The handler does **not** run `resolveRequestAuth`; the catalog is returned without an MCP-layer authentication gate (same visibility as any client that can reach `POST /mcp/rpc`).
+**`tools/list`** — Requires `id`. Returns `{ "tools": [ ... ] }`. Each entry has `name`, `description`, and `inputSchema` (JSON Schema object). The array includes **every** tool in `implementedTools` from the in-code catalog (`internal/mcp/tool_catalog.go`), not a subset. The transport is stateless and does not enforce a prior `initialize`, but full-mode authentication protects this request like every other `/mcp/rpc` request.
 
 **`tools/call`** — Invokes a tool by name. Requires `id` and a **`params` object** containing:
 
@@ -152,7 +156,11 @@ All JSON-RPC **responses with a body** include `"jsonrpc": "2.0"` and preserve t
 
 - **Stateless HTTP:** there is no server-side session between requests; behavior does not depend on having called `initialize` first for `tools/list` or `tools/call`.
 - **`initialize` is supported** for clients that expect the handshake; it is **not** enforced before discovery or tool calls on this server.
-- **Authentication** follows the same rules as **`/mcp`** (session cookie and Bearer token in `full` mode; anonymous mode boundary unchanged). See [Authentication and capability model](#authentication-and-capability-model).
+- **Authentication** is endpoint-specific. `/mcp/rpc` accepts a session cookie, static `sb_…` API token, or a Scrumboy OAuth token bound to `<origin>/mcp/rpc`; `/mcp` accepts only the first two. See [Authentication and capability model](#authentication-and-capability-model).
+- **Streamable HTTP media:** POST requires `Content-Type: application/json` (optional UTF-8 charset). Native clients send `Accept: application/json, text/event-stream`; missing Accept and `*/*` remain tolerated, while a restrictive value must allow both types. Accepted notifications return 202 without a body or content type.
+- **Protocol header:** after initialization, send `MCP-Protocol-Version`. Missing defaults to `2025-03-26`; malformed, duplicate, or unsupported values return 400.
+- **Origin:** validation runs before authentication. A supplied Origin must match the trusted public origin; invalid Origin returns empty 403 without an OAuth challenge. Non-browser requests may omit Origin.
+- **Stateless JSON-only:** Scrumboy emits no MCP session ID and offers no SSE GET stream, resumability, or server-initiated requests.
 - The **legacy `GET` / `POST /mcp`** endpoint remains **unchanged** and is documented in the sections above.
 
 ---
@@ -197,9 +205,9 @@ All JSON-RPC **responses with a body** include `"jsonrpc": "2.0"` and preserve t
 
 **Session (cookie):** In `full` mode, the adapter reads the `scrumboy_session` cookie and loads the user into request context when the cookie is valid.
 
-**Bearer (API access token):** In `full` mode, clients may send `Authorization: Bearer <token>` using an opaque secret minted via [`/api/me/tokens`](#api-access-tokens-rest) (prefix `sb_`, stored as a hash server-side).
+**Bearer credentials:** In `full` mode, clients may send an opaque static secret minted via [`/api/me/tokens`](#api-access-tokens-rest) (prefix `sb_`, stored as a hash server-side). `/mcp/rpc` additionally accepts Scrumboy's own opaque OAuth access tokens only when the stored audience equals its trusted canonical `<origin>/mcp/rpc` resource.
 
-**Precedence:** If the request includes a **`Bearer` authorization attempt** (scheme `Bearer` per RFC 9110, with the credential in the segment after the first space; trim applies **only** to that credential string), the adapter validates that token and **does not** fall back to the session cookie when validation fails for that attempt. On **legacy** `GET /mcp` and **`POST /mcp`**, a failed Bearer yields **401** with **`AUTH_REQUIRED`** before the handler runs. On **`POST /mcp/rpc`**, **`initialize`** and **`tools/list`** do **not** call **`resolveRequestAuth`**, so a bad Bearer alone does not fail those calls. **`tools/call`** does call **`resolveRequestAuth`**; a failed Bearer there returns HTTP **200** with a JSON-RPC **`result`** where **`isError`** is **`true`** and the text message is **`authentication required`** (not the legacy **`AUTH_REQUIRED`** envelope). If there is no Bearer attempt, the adapter uses the session cookie as before.
+**Precedence and endpoint boundary:** If the request includes a **`Bearer` authorization attempt** (scheme `Bearer` per RFC 9110, with the credential in the segment after the first space; trim applies **only** to that credential string), the adapter validates that token and **does not** fall back to the session cookie when validation fails. Legacy `GET /mcp` and `POST /mcp` accept static tokens only; an OAuth token or any other failed Bearer returns the existing **401** `AUTH_REQUIRED` envelope and no OAuth challenge. The whole `/mcp/rpc` transport accepts static or correctly resource-bound OAuth tokens; missing credentials return an empty **401** RFC 9728 challenge, while invalid Bearers add `error="invalid_token"`. No transport 401 contains a JSON-RPC `result` or `CallToolResult`.
 
 **Anonymous mode:** Session cookies and Bearer tokens are **not** applied for MCP (same anonymous boundary as the documented HTTP API for cookies).
 
@@ -209,7 +217,7 @@ All JSON-RPC **responses with a body** include `"jsonrpc": "2.0"` and preserve t
 
 **Typical codes:** `AUTH_REQUIRED` when the transport rejects the principal (failed Bearer, or tool needs a signed-in user but none is in context) or when a tool requires sign-in without a session/API token. `CAPABILITY_UNAVAILABLE` when the server is in **anonymous mode**, or **before bootstrap** (no users yet), or the tool is otherwise gated as unavailable.
 
-**Practical rule:** Almost all project-scoped tools (todos, sprints, tags, members, board) require **full mode**, **post-bootstrap**, and a **valid session or valid API bearer token**. When no `Authorization: Bearer` header is sent, **`GET /mcp`** / **`system.getCapabilities`** still run without sign-in so clients can inspect the server. **If** a Bearer attempt is present and invalid, **`GET /mcp`** and legacy **`POST /mcp`** fail at **401** first; JSON-RPC **`tools/call`** surfaces the failure as a tool error result instead (see above).
+**Practical rule:** Almost all project-scoped tools require full mode, post-bootstrap, and a valid principal. Legacy `/mcp` preserves unauthenticated capability/bootstrap inspection. In full mode, `/mcp/rpc` always authenticates before method, media, protocol, or JSON-RPC dispatch; use a cookie, static token, or correctly resource-bound Scrumboy OAuth token.
 
 ## Authentication example (curl)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Changelog
 
-> **Upgrades:** No breaking changes in **3.7.x** / **3.8.x** / **3.9.x** / **3.10.x** / **3.11.x** / **3.12.x** / **3.13.x** / **3.14.x** / **3.15.x** / **3.16.x** / **3.17.x** / **3.18.x** / **3.19.x** / **3.20.x** / **3.21.x** unless noted below.
+> **Upgrades:** No breaking changes in **3.7.x** / **3.8.x** / **3.9.x** / **3.10.x** / **3.11.x** / **3.12.x** / **3.13.x** / **3.14.x** / **3.15.x** / **3.16.x** / **3.17.x** / **3.18.x** / **3.19.x** / **3.20.x** / **3.21.x** / **3.22.x** unless noted below.
+
+## [3.22.0] - 2026-07-18
+
+### Added
+
+- **Resource-bound remote MCP OAuth** - `/mcp/rpc` is the sole OAuth protected resource. Authorization codes, access tokens, and refresh tokens are bound to the trusted canonical `<origin>/mcp/rpc` URI throughout authorization, exchange, refresh, storage, and validation. Invalid client, redirect, PKCE, or resource attempts no longer consume otherwise valid grants.
+- **Path-derived protected-resource discovery** - `/.well-known/oauth-protected-resource/mcp/rpc` publishes the canonical resource and authorization server. The root RFC 9728 endpoint remains a compatibility alias with the same identity, and authorization-server metadata advertises `protected_resources`.
+- **Streamable HTTP transport normalization** - `/mcp/rpc` now enforces Origin, method, JSON media, Accept, JSON-RPC message classification, and stable MCP protocol-version rules. Accepted notifications return empty 202 responses; authenticated GET returns 405 because Scrumboy remains stateless and JSON-only.
+
+### Changed
+
+- **Endpoint-specific MCP authentication** - Legacy `/mcp` continues to accept cookies and static `sb_…` tokens but no longer accepts OAuth access tokens or emits OAuth challenges. `/mcp/rpc` accepts cookies, static tokens, and Scrumboy OAuth tokens bound exactly to its canonical resource. Agora remains cookie/static only and cannot act as a deputy for `/mcp/rpc` OAuth tokens.
+- **OAuth artifact migration** - Migration `057_bind_oauth_tokens_to_mcp_resource.sql` invalidates existing unbound authorization codes and tokens without deleting DCR client registrations. OAuth clients must authorize once again; cookies and static API tokens are unaffected.
+- **MCP protocol versions** - Streamable HTTP supports `2025-03-26`, `2025-06-18`, and `2025-11-25`; the old `2024-11-05` version is no longer advertised on this transport.
+
+### Fixed
+
+- **Native client OAuth discovery** - Full-mode unauthenticated `/mcp/rpc` requests now return an empty HTTP 401 with a path-derived RFC 9728 `WWW-Authenticate` challenge. Invalid Bearers add `error="invalid_token"`; transport authentication failures never masquerade as successful JSON-RPC tool results.
+- **MCP JSON-RPC lifecycle and parsing** - `/mcp/rpc` handles `ping`, requires nonempty `clientInfo.version` on `initialize`, rejects non-object/array `params`, and echoes recoverable request IDs on Invalid Request errors.
+- **OAuth token exchange atomicity** - Authorization-code and refresh-token exchanges consume/revoke the grant and insert the new token pair in one database transaction.
+- **OAuth form parse errors** - Malformed authorize/token form bodies return `invalid_request`; `invalid_target` is reserved for resource parameter problems after a successful parse.
+
+### Documentation
+
+- **Remote client and deployment acceptance** - Updated MCP/OAuth/API guidance to configure native clients directly with `/mcp/rpc`; added a provider-neutral release checklist using Keycloak only as Vega's documented upstream OIDC provider.
+
+### Tests
+
+- **Security and compatibility boundary** - Added trusted-origin/resource canonicalization, migration invalidation, non-burning concurrent grant redemption, OAuth continuation, metadata/challenge, transport, Origin, protocol-version, Agora, legacy `/mcp`, cookie/static, wrong-resource, and no-cookie-fallback coverage.
 
 ## [3.21.0] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Changelog
 
-> **Upgrades:** No breaking changes in **3.7.x** / **3.8.x** / **3.9.x** / **3.10.x** / **3.11.x** / **3.12.x** / **3.13.x** / **3.14.x** / **3.15.x** / **3.16.x** / **3.17.x** / **3.18.x** / **3.19.x** / **3.20.x** / **3.21.x** / **3.22.x** unless noted below.
+> **Upgrades:** No breaking changes in **3.7.x** / **3.8.x** / **3.9.x** / **3.10.x** / **3.11.x** / **3.12.x** / **3.13.x** / **3.14.x** / **3.15.x** / **3.16.x** / **3.17.x** / **3.18.x** / **3.19.x** / **3.20.x** / **3.21.x** unless noted below. **3.22.0** has MCP/OAuth upgrade impact — see that release.
 
 ## [3.22.0] - 2026-07-18
+
+### Breaking / upgrade impact
+
+These are intentional compatibility breaks for remote MCP OAuth and Streamable HTTP. Cookies, static `sb_…` API tokens, human OIDC login, and DCR client registrations are unaffected unless noted.
+
+- **Reauthorize MCP OAuth clients** - Migration `057_bind_oauth_tokens_to_mcp_resource.sql` invalidates existing unbound authorization codes, access tokens, and refresh tokens. Clear stale client credentials and complete consent again. DCR registrations remain; cookies and static API tokens keep working.
+- **Point native clients at `/mcp/rpc`, not `/mcp`** - Claude Code, Cursor, and other Streamable HTTP clients must use `https://<host>/mcp/rpc` (for example `claude mcp add --transport http scrumboy https://<host>/mcp/rpc`). Legacy `/mcp` still serves the `{ "tool", "input" }` API with cookies or static tokens, but **rejects OAuth Bearers** and emits no OAuth discovery challenge.
+- **Require `resource=<origin>/mcp/rpc`** - Authorize, token, and refresh requests must send exactly one absolute resource URI for the trusted public origin's `/mcp/rpc`. Missing, duplicate, or wrong values fail with `invalid_target`. Tokens minted for another audience are rejected on `/mcp/rpc`.
+- **OAuth tokens are `/mcp/rpc`-only** - A valid `/mcp/rpc` OAuth access token does not authorize legacy `/mcp` or `/agora/v1/*`.
+- **Drop Streamable HTTP protocol `2024-11-05`** - Supported versions are `2025-03-26`, `2025-06-18`, and `2025-11-25`.
+- **Stricter `/mcp/rpc` transport and initialize** - Invalid browser `Origin` returns empty 403; media-type / Accept / protocol-version rules are enforced; accepted notifications return empty 202; authenticated GET returns 405. `initialize` requires nonempty `clientInfo.name` and `clientInfo.version`.
+
+See [`docs/oauth.md`](docs/oauth.md), [`docs/mcp.md`](docs/mcp.md), and [`docs/mcp-oauth-acceptance.md`](docs/mcp-oauth-acceptance.md).
 
 ### Added
 
@@ -12,9 +25,8 @@
 
 ### Changed
 
-- **Endpoint-specific MCP authentication** - Legacy `/mcp` continues to accept cookies and static `sb_…` tokens but no longer accepts OAuth access tokens or emits OAuth challenges. `/mcp/rpc` accepts cookies, static tokens, and Scrumboy OAuth tokens bound exactly to its canonical resource. Agora remains cookie/static only and cannot act as a deputy for `/mcp/rpc` OAuth tokens.
-- **OAuth artifact migration** - Migration `057_bind_oauth_tokens_to_mcp_resource.sql` invalidates existing unbound authorization codes and tokens without deleting DCR client registrations. OAuth clients must authorize once again; cookies and static API tokens are unaffected.
-- **MCP protocol versions** - Streamable HTTP supports `2025-03-26`, `2025-06-18`, and `2025-11-25`; the old `2024-11-05` version is no longer advertised on this transport.
+- **Endpoint-specific MCP authentication** - Legacy `/mcp` continues to accept cookies and static `sb_…` tokens. `/mcp/rpc` accepts cookies, static tokens, and Scrumboy OAuth tokens bound exactly to its canonical resource. Agora remains cookie/static only and cannot act as a deputy for `/mcp/rpc` OAuth tokens.
+- **MCP protocol versions** - Streamable HTTP advertises and accepts `2025-03-26`, `2025-06-18`, and `2025-11-25`.
 
 ### Fixed
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -9,6 +9,7 @@
 - [What does the done lane mean for dashboard stats?](#what-does-the-done-lane-mean-for-dashboard-stats)
 - [Are tag colors personal, or shared with the team?](#are-tag-colors-personal-or-shared-with-the-team)
 - [How do I use Scrumboy with Claude or other MCP clients?](#how-do-i-use-scrumboy-with-claude-or-other-mcp-clients)
+- [My Claude or Cursor MCP connection broke after upgrading to 3.22 — what do I do?](#my-claude-or-cursor-mcp-connection-broke-after-upgrading-to-322--what-do-i-do)
 - [Can Scrumboy MCP OAuth work with OIDC-only login?](#can-scrumboy-mcp-oauth-work-with-oidc-only-login)
 - [Can one account use both a Scrumboy password and SSO?](#can-one-account-use-both-a-scrumboy-password-and-sso)
 - [What happens if the SSO provider is unavailable?](#what-happens-if-the-sso-provider-is-unavailable)
@@ -151,20 +152,52 @@ When you open a board, Scrumboy refreshes colors from that board so what you see
 
 ## How do I use Scrumboy with Claude or other MCP clients?
 
-**Yes.** Scrumboy exposes an **MCP-compatible HTTP API** on the instance you run. AI assistants and automation (Claude, Cursor, custom agents, scripts) can list and call tools to manage projects, todos, sprints, tags, members, and board snapshots - without using the web UI for every change.
+Scrumboy exposes an **MCP-compatible HTTP API** on the instance you run. AI assistants and automation (Claude, Cursor, custom agents, scripts) can list and call tools to manage projects, todos, sprints, tags, members, and board snapshots — without using the web UI for every change.
 
-**Recommended for MCP-style clients:** `POST /mcp/rpc` with **JSON-RPC 2.0** (`initialize`, `tools/list`, `tools/call`). That is the same protocol shape many MCP clients expect, served over HTTP to your Scrumboy URL.
+**Canonical endpoint for native MCP clients (Claude Code, Cursor, and similar):** `https://YOUR_HOST/mcp/rpc`
 
-**Also available:** `POST /mcp` with a simple `{"tool":"…","input":{…}}` envelope for scripts and older integrations.
+Configure the client with that exact URL, for example:
 
-**Authentication:** sign in and use your session cookie, or create an **API access token** (starts with `sb_`) and send `Authorization: Bearer sb_…`. Tokens are created via the API while logged in (see the **Integrations & API Access** section in [`README.md`](README.md)).
+```sh
+claude mcp add --transport http scrumboy https://YOUR_HOST/mcp/rpc
+```
+
+That surface speaks **JSON-RPC 2.0** (`initialize`, `ping`, `tools/list`, `tools/call`) over Streamable HTTP. It is also the **sole OAuth protected resource**: clients discover Scrumboy’s authorization server from the 401 `WWW-Authenticate` challenge, register via DCR, and send Bearer tokens only to `/mcp/rpc`.
+
+**Legacy envelope (scripts / older integrations):** `POST /mcp` with `{"tool":"…","input":{…}}`. It accepts a session cookie or a static **`sb_…` API token**, not MCP OAuth access tokens.
+
+**Authentication options:**
+
+| Credential | `/mcp/rpc` | `/mcp` |
+|------------|------------|--------|
+| Session cookie | Yes | Yes |
+| Static `sb_…` Bearer | Yes | Yes |
+| Scrumboy MCP OAuth access token (bound to `/mcp/rpc`) | Yes | No |
 
 **Important limits today:**
 
 - Scrumboy is an **HTTP** MCP server on your host. It does **not** speak **stdio** MCP (the process-spawn model some desktop apps use). Clients must connect to your Scrumboy base URL over HTTP, or use a bridge that translates stdio to HTTP.
 - All traffic stays between the client and **your** Scrumboy server. Scrumboy does not host a cloud MCP relay for you.
 
-For tool names, auth rules, examples, and the optional Agora discover/invoke edge, see [`docs/mcp.md`](docs/mcp.md). For full HTTP behavior, see [`API.md`](API.md).
+For OAuth details see [`docs/oauth.md`](docs/oauth.md). For tool names and examples see [`docs/mcp.md`](docs/mcp.md). For full HTTP behavior see [`API.md`](API.md). Upgrade impact is summarized in [`CHANGELOG.md`](CHANGELOG.md) under **3.22.0**.
+
+## My Claude or Cursor MCP connection broke after upgrading to 3.22 — what do I do?
+
+**3.22** tightened remote MCP OAuth on purpose. If a client that worked on **3.20 / 3.21** suddenly fails, check these in order:
+
+1. **URL must be `/mcp/rpc`, not `/mcp`.**  
+   Remove the old server entry and re-add with the canonical path, for example:  
+   `claude mcp add --transport http scrumboy https://YOUR_HOST/mcp/rpc`
+
+2. **Clear stale OAuth credentials and authorize again.**  
+   Migration `057` invalidates pre-3.22 authorization codes and access/refresh tokens. DCR client registrations remain; you still need a fresh browser consent. Cookies and static `sb_…` tokens are unaffected.
+
+3. **Do not expect an OAuth token to work on `/mcp` or Agora.**  
+   Those surfaces stay cookie / static-token only. Native clients use `/mcp/rpc` only.
+
+4. **Confirm the client speaks a supported protocol version** (`2025-03-26`, `2025-06-18`, or `2025-11-25`) and sends `clientInfo.name` **and** `clientInfo.version` on `initialize`.
+
+Details: [`CHANGELOG.md`](CHANGELOG.md) (**3.22.0 → Breaking / upgrade impact**), [`docs/oauth.md`](docs/oauth.md), [`docs/mcp-oauth-acceptance.md`](docs/mcp-oauth-acceptance.md).
 
 ## Can Scrumboy MCP OAuth work with OIDC-only login?
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.21.0-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.22.0-blue" alt="version" />
   <img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" />
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml">

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" />
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/markrai/scrumboy/ci.yml?branch=main&label=tests" alt="tests" />
+    <img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" />
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -285,18 +285,26 @@ curl -X POST http://localhost:8080/mcp \
 
 ### MCP (JSON-RPC) for AI agents
 
-Scrumboy exposes a **Model Context Protocol (MCP) compatible JSON-RPC endpoint** for AI agents (Claude, etc.) and MCP-compatible clients.
+Scrumboy exposes a standards-based, JSON-only Streamable HTTP endpoint for native MCP clients such as Cursor and Claude Code.
 
 **Endpoint:** `POST /mcp/rpc`
 
 This is separate from the `/mcp` HTTP endpoint above and follows **JSON-RPC 2.0** (`initialize`, `tools/list`, `tools/call`, etc.). See **[`docs/mcp.md`](docs/mcp.md)** for tools, auth, response shapes, and examples; **[`API.md`](API.md)** for the full HTTP/MCP behavior reference.
+
+Native clients must be configured directly with `/mcp/rpc`. It is the sole OAuth protected resource; `/mcp` remains the legacy Scrumboy `{tool,input}` API.
+
+```bash
+claude mcp add --transport http scrumboy https://scrumboy.example.com/mcp/rpc
+```
 
 #### Example: `initialize`
 
 ```bash
 curl -X POST http://localhost:8080/mcp/rpc \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer sb_your_token_here" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}'
 ```
 
 #### Example: list tools
@@ -304,6 +312,9 @@ curl -X POST http://localhost:8080/mcp/rpc \
 ```bash
 curl -X POST http://localhost:8080/mcp/rpc \
   -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "MCP-Protocol-Version: 2025-11-25" \
+  -H "Authorization: Bearer sb_your_token_here" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
 ```
 
@@ -312,6 +323,8 @@ curl -X POST http://localhost:8080/mcp/rpc \
 ```bash
 curl -X POST http://localhost:8080/mcp/rpc \
   -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "MCP-Protocol-Version: 2025-11-25" \
   -H "Authorization: Bearer sb_your_token_here" \
   -d '{
     "jsonrpc":"2.0",
@@ -331,7 +344,8 @@ curl -X POST http://localhost:8080/mcp/rpc \
 
 - Compatible with MCP clients that support **HTTP JSON-RPC** to this URL.
 - Some MCP clients expect **stdio**-based servers - those are **not** supported here.
-- Authentication works via **session cookie** or **Bearer** token (same rules as `/mcp`).
+- `/mcp/rpc` accepts a **session cookie**, a static **`sb_…` Bearer** token, or a Scrumboy OAuth token bound to this exact resource. `/mcp` accepts cookies and static tokens only.
+- In full mode, unauthenticated `/mcp/rpc` requests receive an empty 401 with RFC 9728 protected-resource discovery metadata.
 - Compatible Codex/Claude-style agent workspaces that support local or manual
   plugin loading can use the Scrumboy Board Operator plugin package in
   [`plugins/scrumboy-board-operator`](plugins/scrumboy-board-operator). The
@@ -477,7 +491,8 @@ Invariants (e.g. canonical URL `/{slug}`, no UI links to `/p/{id}`) are enforced
 
 - **Architecture diagrams:** [`docs/diagrams/`](docs/diagrams/) - Mermaid sources and self-contained viewer (`serve-diagrams.bat` or `python serve.py` in that folder, then open `http://127.0.0.1:8775/`)
 - **MCP (HTTP tools + JSON-RPC):** [`docs/mcp.md`](docs/mcp.md) - tool catalog, auth, legacy vs `/mcp/rpc`, examples (agents & automation). See also [`API.md`](API.md) for exhaustive MCP HTTP detail.
-- **OAuth 2.1 for MCP clients:** [`docs/oauth.md`](docs/oauth.md) - discovery, Dynamic Client Registration, PKCE, authorize/token/revoke flow for clients like Claude Code's `--transport http` OAuth connect.
+- **OAuth 2.1 for MCP clients:** [`docs/oauth.md`](docs/oauth.md) - resource discovery, Dynamic Client Registration, PKCE, and resource-bound authorize/token/revoke flows for native clients such as Cursor and Claude Code.
+- **Remote MCP/OAuth release acceptance:** [`docs/mcp-oauth-acceptance.md`](docs/mcp-oauth-acceptance.md) - Vega/Keycloak evidence record plus Cursor, Claude Code, cookie/static, legacy, and negative-resource gates.
 - **Agent plugin package:** [`plugins/scrumboy-board-operator`](plugins/scrumboy-board-operator) - local/manual plugin metadata, board-operator Skill, and seed eval cases for MCP/Agoragentic agent workflows.
 - **PWA / Web Push (VAPID):** [`docs/pwa.md`](docs/pwa.md) - keys, subscriber contact, post-login auto-subscribe when VAPID is configured, Settings opt-out, tradeoffs.
 - **Roles and permissions:** [`docs/roles_and_permissions.md`](docs/roles_and_permissions.md) - project roles, backend authorization, anonymous boards.

--- a/cmd/scrumboy/main.go
+++ b/cmd/scrumboy/main.go
@@ -21,6 +21,7 @@ import (
 	"scrumboy/internal/migrate"
 	"scrumboy/internal/oidc"
 	"scrumboy/internal/projectcolor"
+	"scrumboy/internal/publicorigin"
 	"scrumboy/internal/store"
 	"scrumboy/internal/tlsredirect"
 )
@@ -120,7 +121,8 @@ func main() {
 	if maxB <= 0 {
 		maxB = 1 << 20
 	}
-	mcpH := mcp.New(st, mcp.Options{Mode: cfg.ScrumboyMode})
+	publicOrigin := publicorigin.New(cfg.PublicBaseURL, cfg.TrustProxy)
+	mcpH := mcp.New(st, mcp.Options{Mode: cfg.ScrumboyMode, PublicOrigin: publicOrigin})
 	srv := httpapi.NewServer(st, httpapi.Options{
 		Logger:               logger,
 		MaxRequestBody:       cfg.MaxRequestBodyBytes,
@@ -146,6 +148,7 @@ func main() {
 		SMTPTLSMode:          cfg.SMTPTLSMode,
 		SMTPDebug:            cfg.SMTPDebug,
 		PublicBaseURL:        cfg.PublicBaseURL,
+		PublicOrigin:         publicOrigin,
 		TrustProxy:           cfg.TrustProxy,
 	})
 	st.SetTodoAssignedPublisher(srv.PublishTodoAssigned)

--- a/docs/agoragentic.md
+++ b/docs/agoragentic.md
@@ -4,11 +4,12 @@
 
 **Agora** is a small HTTP **edge adapter** in front of Scrumboy’s existing MCP (Model Context Protocol) support. It exposes two paths that return a fixed JSON **envelope** (`ok` / `result` / `error`) suited for **Agoragentic v1**-style listings, while the real tool catalog and tool execution still run on Scrumboy’s **unchanged** MCP implementation.
 
-You do **not** call Agora instead of MCP for other clients. **Claude, curl, and MCP-style clients** that already use `GET /mcp`, `POST /mcp`, or `POST /mcp/rpc` should keep using those—behavior there is the same with or without Agora enabled.
+You do **not** call Agora instead of MCP for native clients. Cursor, Claude Code, and other Streamable HTTP clients must use `/mcp/rpc`; legacy Scrumboy integrations keep using `/mcp`.
 
 | Surface | Role |
 |--------|------|
-| **`/mcp`**, **`/mcp/rpc`** | Canonical Scrumboy MCP: legacy and JSON-RPC tools. |
+| **`/mcp`** | Legacy Scrumboy bootstrap and `{tool,input}` API. |
+| **`/mcp/rpc`** | Canonical MCP Streamable HTTP transport and sole OAuth protected resource. |
 | **`/agora/v1/discover`**, **`/agora/v1/invoke`** | Agoragentic-oriented adapter: same tools in-process, different URL and response envelope. |
 
 The adapter does **not** reimplement tools. It forwards each call to the same in-process **JSON-RPC** flow as `POST /mcp/rpc` (`tools/list` and `tools/call`), reusing the same server handler and auth as a normal MCP request.
@@ -41,12 +42,12 @@ A minimal machine-readable stub for these two listings is in [`docs/examples/ago
 
 ## Authentication
 
-Agora uses the **same rules as `POST /mcp/rpc`**:
+Agora preserves the non-OAuth authentication methods used by existing integrations:
 
 - **Session:** send `Cookie: scrumboy_session=…` when the user is signed in through the app.
 - **API token (full / normal mode):** `Authorization: Bearer <token>` (the token string Scrumboy issues, e.g. `sb_…`).
 
-The adapter **does not** add or strip credentials. It passes your request through to the MCP stack, so an invalid or missing Bearer token behaves like a direct `tools/call` (e.g. tool error text for auth failures, depending on tool and mode). See `docs/mcp.md` for full MCP auth behavior, anonymous mode, and bootstrap edge cases.
+The adapter passes cookies and static API tokens to the in-process MCP tool stack. It deliberately disables OAuth-token lookup: an access token bound to `/mcp/rpc` cannot authorize `/agora/v1/*`, and Agora emits no MCP OAuth discovery challenge. Invalid credentials return a 401 Agora error envelope and never fall back to a cookie. See `docs/mcp.md` for the canonical MCP auth behavior, anonymous mode, and bootstrap edge cases.
 
 ---
 

--- a/docs/mcp-oauth-acceptance.md
+++ b/docs/mcp-oauth-acceptance.md
@@ -1,0 +1,111 @@
+# Remote MCP/OAuth release acceptance
+
+Updated: 2026-07-18
+
+This is the release gate for Scrumboy's remote MCP OAuth boundary. Run it against the exact release candidate deployed to Vega. Do not record client secrets, authorization codes, access or refresh tokens, session cookies, or PKCE verifiers.
+
+Production authentication remains provider-neutral. Vega uses Keycloak as its upstream OIDC provider for this acceptance run; Keycloak is not Scrumboy's MCP authorization server and its access tokens are not MCP credentials.
+
+## Evidence record
+
+Record before testing:
+
+- Scrumboy commit and version:
+- Vega public origin:
+- Cursor version:
+- Claude Code version:
+- Keycloak version:
+- Keycloak realm:
+- Keycloak OIDC client type and standard authorization-code-flow settings:
+- Keycloak issuer URL:
+- Scrumboy OIDC callback: `https://<vega-host>/api/auth/oidc/callback`
+- Sanitized reverse-proxy configuration:
+- `SCRUMBOY_PUBLIC_BASE_URL` value:
+- Whether `SCRUMBOY_TRUST_PROXY` is enabled and which forwarding headers the proxy overwrites:
+
+Cursor and Claude dynamically register their redirect URIs with Scrumboy's `/oauth/register` endpoint. Do not add those client callbacks to Keycloak. Keycloak knows only Scrumboy's OIDC callback above.
+
+## Deployment preparation
+
+1. Back up Vega's SQLite database and record the recoverable backup location.
+2. Deploy the release candidate and migration 057.
+3. Confirm users and OAuth client registrations remain; confirm pre-migration codes and tokens have been invalidated.
+4. Set `SCRUMBOY_PUBLIC_BASE_URL=https://<vega-host>`.
+5. Configure the existing provider-neutral `SCRUMBOY_OIDC_*` values from Keycloak discovery and client configuration.
+6. Enable `SCRUMBOY_TRUST_PROXY` only when the trusted proxy strips or overwrites client-supplied `X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Host`, and `CF-Visitor` values as applicable.
+
+## Discovery and transport checks
+
+Verify the exact public values, saving sanitized headers and JSON:
+
+1. `GET /.well-known/oauth-protected-resource/mcp/rpc` returns:
+
+   ```json
+   {
+     "resource": "https://<vega-host>/mcp/rpc",
+     "authorization_servers": ["https://<vega-host>"]
+   }
+   ```
+
+2. `GET /.well-known/oauth-protected-resource` returns the same resource identity as a compatibility alias.
+3. `GET /.well-known/oauth-authorization-server` has issuer `https://<vega-host>` and `protected_resources: ["https://<vega-host>/mcp/rpc"]`.
+4. An unauthenticated request to `/mcp/rpc` returns an empty 401 and:
+
+   ```text
+   WWW-Authenticate: Bearer resource_metadata="https://<vega-host>/.well-known/oauth-protected-resource/mcp/rpc"
+   ```
+
+5. An invalid Bearer returns an empty 401 with `error="invalid_token"` and the same metadata URL.
+6. A cross-origin `Origin` value returns empty 403 without `WWW-Authenticate`.
+7. An authenticated GET returns empty 405 with `Allow: POST`.
+8. A valid notification returns empty 202. No response issues `MCP-Session-Id`.
+
+## Cursor browser OAuth
+
+1. Clear any old Scrumboy OAuth credentials from the client.
+2. Configure `https://<vega-host>/mcp/rpc`, not `/mcp`.
+3. Confirm the initial request receives the path-derived protected-resource challenge.
+4. Complete DCR and record only the registered redirect URI shape. Current releases may use `http://localhost:8787/callback`; older releases may use `cursor://anysphere.cursor-mcp/oauth/callback` or multiple URIs.
+5. Complete Scrumboy authorization. When Scrumboy needs human authentication, follow its standard OIDC redirect to Keycloak.
+6. Confirm Keycloak returns only to `https://<vega-host>/api/auth/oidc/callback`, then Scrumboy resumes consent.
+7. Approve consent, complete the Scrumboy code exchange, and invoke `projects.list` successfully.
+
+If this exact Cursor build registers multiple redirect URIs or requires a private-use scheme that current DCR policy rejects, stop the release. Handle normalized multi-URI storage, exact selected-URI matching, and private-use-scheme policy in a separate prerequisite change; do not silently discard registration values in P1B.
+
+## Claude Code browser OAuth
+
+1. Clear old Scrumboy OAuth credentials.
+2. Configure:
+
+   ```sh
+   claude mcp add --transport http scrumboy https://<vega-host>/mcp/rpc
+   ```
+
+3. Confirm the unauthenticated request receives the canonical challenge.
+4. Complete browser OAuth through Scrumboy's `/oauth/*` endpoints and Keycloak-backed human login.
+5. Invoke `projects.list` successfully.
+
+## Compatibility and negative checks
+
+1. Invoke a `/mcp/rpc` tool with a valid Scrumboy session cookie.
+2. Invoke a `/mcp/rpc` tool with a valid static `sb_…` API token.
+3. Verify legacy `GET /mcp` capability/bootstrap JSON with a cookie and static token.
+4. Verify legacy `POST /mcp` still accepts `{ "tool": "…", "input": {} }` with a cookie and static token.
+5. Present a valid `/mcp/rpc` OAuth access token to `/mcp`; expect the legacy 401 authentication envelope and no OAuth challenge.
+6. Present the same OAuth access token to `/agora/v1/*`; expect 401 and no OAuth challenge.
+7. Verify revoked, expired, wrong-resource, and unbound OAuth artifacts are rejected identically on `/mcp/rpc`.
+8. Confirm authorize, token, refresh, stored grants/tokens, metadata, and challenges consistently identify exactly `https://<vega-host>/mcp/rpc`.
+9. Review Scrumboy, reverse-proxy, and Keycloak logs for secrets or bearer credentials. Record only sanitized evidence.
+
+## Result
+
+- Date/time and operator:
+- Cursor result and redirect URI shape:
+- Claude Code result and redirect URI shape:
+- Cookie/static/legacy result:
+- Negative-resource tests:
+- Log review result:
+- Release accepted or blocked:
+- Follow-up issue links:
+
+Authentik remains an interoperability target for another contributor, but it is not a substitute for Vega/Keycloak acceptance. Do not claim live Authentik validation unless a real environment was tested and its version, issuer, callback, client configuration, and sanitized evidence were reviewed.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,6 +1,6 @@
 # Scrumboy MCP Interface
 
-Updated: 2026-04-23 14:28:12 -04:00
+Updated: 2026-07-18
 
 Designed for use by AI agents (Claude, custom MCP clients) and automation workflows.
 
@@ -86,16 +86,16 @@ JSON-RPC responses on **`POST /mcp/rpc`** use JSON-RPC **`result`** / **`error`*
 
 ## Base URL
 
-The MCP handler is mounted at **`/mcp`** on the same origin as the Scrumboy HTTP server (see `internal/httpapi/server.go`: requests where the path is `/mcp` or `/mcp/` or `/mcp/rpc` are dispatched to the MCP handler).
+The MCP handler exposes two deliberately separate interfaces on the same origin:
 
 - **Legacy tool API:** `GET /mcp`, `POST /mcp` (and optional trailing slash).
-- **JSON-RPC API:** `POST /mcp/rpc` only.
+- **Canonical MCP Streamable HTTP transport:** `/mcp/rpc`. Native MCP clients must be configured with this exact URL. `/mcp/rpc/` redirects to `/mcp/rpc` and is not a second resource identity.
 
 There are no other MCP paths under `/mcp/` in the current implementation.
 
 ## Agoragentic HTTP adapter (Agora)
 
-For **Agoragentic**-style listings (HTTP envelope and fixed paths), Scrumboy exposes **`POST /agora/v1/discover`** and **`POST /agora/v1/invoke`**, which delegate in-process to the same JSON-RPC **`tools/list`** and **`tools/call`** flow as **`POST /mcp/rpc`**. **`/mcp`** and **`/mcp/rpc`** remain the canonical MCP surfaces; this layer is an edge adapter only. Request/response shapes, required fields, and schema notes are documented in **`docs/agoragentic.md`**, with a minimal example manifest at **`docs/examples/agoragentic-manifest.json`**.
+For **Agoragentic**-style listings (HTTP envelope and fixed paths), Scrumboy exposes **`POST /agora/v1/discover`** and **`POST /agora/v1/invoke`**, which delegate in-process to the same JSON-RPC **`tools/list`** and **`tools/call`** flow as **`POST /mcp/rpc`**. **`/mcp`** remains the legacy Scrumboy surface and **`/mcp/rpc`** is the canonical standards-based MCP transport; this layer is an edge adapter only. Request/response shapes, required fields, and schema notes are documented in **`docs/agoragentic.md`**, with a minimal example manifest at **`docs/examples/agoragentic-manifest.json`**.
 
 ## Choosing an Interface
 
@@ -114,12 +114,24 @@ Both interfaces expose the **same** underlying tools.
 
 ## Authentication
 
-Behavior is implemented in `internal/mcp/adapter.go` (`resolveRequestAuth`).
+Behavior is implemented at the endpoint boundary in `internal/mcp`.
 
 **Full mode (`SCRUMBOY_MODE=full`):**
 
-1. If `Authorization` is present and the scheme is **`Bearer`** (case-insensitive, with a space after `Bearer` per normal header parsing), the remainder of the header is treated as a **user API token** (same secret the app issues, including the `sb_` prefix). Valid token → request context gets that user. Invalid or missing token after `Bearer` → **401** with `AUTH_REQUIRED` and message **`Authentication required`** on the legacy surface (`resolveAndValidateAuth` in `internal/mcp/http_handler.go`); **no** tool runs, **including** **`GET /mcp`** and **`system.getCapabilities`**. JSON-RPC **`tools/call`** uses the same auth resolution and returns a tool error result with text **`authentication required`**. **Invalid Bearer does not fall back to the session cookie.**
-2. If Bearer is **not** sent, the **`scrumboy_session`** cookie is read. Valid session → user is attached to context. Missing or invalid cookie → request is **unauthenticated** (no user in context). In that case **`GET /mcp`** and tool **`system.getCapabilities`** still run and return capabilities; other tools may return **401** / `AUTH_REQUIRED` with **`Sign-in required for this tool`** (or **`CAPABILITY_UNAVAILABLE`** when anonymous / pre-bootstrap).
+| Endpoint | Session cookie | Static `sb_…` Bearer | Scrumboy OAuth Bearer |
+|---|---:|---:|---:|
+| `/mcp` | Yes | Yes | No |
+| `/mcp/rpc` | Yes | Yes | Yes, only when bound to `<origin>/mcp/rpc` |
+
+If `Authorization: Bearer` is present, a failed token never falls back to a valid cookie. On legacy `/mcp`, a rejected Bearer returns the existing **401** `AUTH_REQUIRED` envelope and no OAuth discovery challenge. OAuth tokens are deliberately rejected there. Without a Bearer, `/mcp` preserves its existing cookie and unauthenticated capability/bootstrap behavior.
+
+In full mode, authentication protects the entire `/mcp/rpc` transport, including `initialize`, `tools/list`, and `GET`. Missing credentials return an empty **401** with:
+
+```text
+WWW-Authenticate: Bearer resource_metadata="<origin>/.well-known/oauth-protected-resource/mcp/rpc"
+```
+
+Malformed, invalid, expired, revoked, unbound, or wrong-resource Bearer tokens return the same empty **401** with `error="invalid_token"`. Valid session cookies, static API tokens, and Scrumboy-issued OAuth tokens bound to `/mcp/rpc` continue. Upstream OIDC-provider tokens are never accepted as MCP credentials.
 
 **Anonymous mode (`SCRUMBOY_MODE=anonymous`):**
 
@@ -129,7 +141,7 @@ Behavior is implemented in `internal/mcp/adapter.go` (`resolveRequestAuth`).
 
 **Bootstrap:** When the user table is empty (`CountUsers == 0`), capabilities include `bootstrapAvailable: true` and `auth.authenticatedToolsUsable: false`. Most tools return **`CAPABILITY_UNAVAILABLE`** (*unavailable before bootstrap*) until the first user exists.
 
-**OAuth 2.1 (full mode only):** Scrumboy's MCP endpoint also supports OAuth 2.1 for clients that support automatic discovery and Dynamic Client Registration (e.g. Claude Code's `--transport http` OAuth flow), as an alternative to manually minting a static API token. See **[`docs/oauth.md`](oauth.md)** for the discovery endpoints, authorize/token/revoke flow, and token lifetimes. Static Bearer API tokens (above) remain fully supported and unaffected — an OAuth-issued access token is just another Bearer credential accepted by the same `resolveRequestAuth` boundary.
+**OAuth 2.1 (full mode only):** `/mcp/rpc` is the sole OAuth protected resource. Clients discover its Scrumboy authorization server through the path-derived RFC 9728 metadata URL in the 401 challenge. See **[`docs/oauth.md`](oauth.md)** for DCR, PKCE, resource binding, authorize/token/revoke, and token lifetimes. `/mcp` never accepts these OAuth tokens.
 
 ## Capabilities
 
@@ -143,7 +155,7 @@ Behavior is implemented in `internal/mcp/adapter.go` (`resolveRequestAuth`).
 
 **JSON-RPC:**
 
-- After `initialize`, call **`tools/list`** to receive the catalog (`name`, `description`, `inputSchema` per tool), implemented in `internal/mcp/jsonrpc_handler.go` / `internal/mcp/tool_catalog.go`. **`tools/list`** does **not** invoke **`resolveRequestAuth`**; the catalog is returned without an MCP-layer auth check (any caller that can `POST /mcp/rpc` receives the tool list and schemas).
+- After authentication and `initialize`, call **`tools/list`** to receive the catalog (`name`, `description`, `inputSchema` per tool), implemented in `internal/mcp/jsonrpc_handler.go` / `internal/mcp/tool_catalog.go`.
 
 **Example `data` object** (structure from `internal/mcp/types.go` `capabilitiesData`; values below match a **full-mode, pre-bootstrap** instance as asserted in tests — your `serverMode`, `bootstrapAvailable`, and `implementedTools` may differ):
 
@@ -474,19 +486,21 @@ This demonstrates a complete interaction cycle using MCP tools: discover context
 
 The JSON-RPC interface follows **MCP-style** tool discovery and invocation: **`tools/list`** (catalog + `inputSchema`) and **`tools/call`** (invoke by name with `arguments`), plus **`initialize`** / optional **`notifications/initialized`** as implemented in `internal/mcp/jsonrpc_handler.go`.
 
-All requests are **`POST /mcp/rpc`** with **`Content-Type: application/json`** and body **`{"jsonrpc":"2.0",...}`**. Responses are JSON-RPC **`result`** or **`error`**; normal protocol responses use **HTTP 200** (see Error Handling).
+All requests are **`POST /mcp/rpc`** with **`Content-Type: application/json`**, **`Accept: application/json, text/event-stream`**, credentials in full mode, and body **`{"jsonrpc":"2.0",...}`**. After initialization, send **`MCP-Protocol-Version`** on later requests. Responses are JSON-RPC **`result`** or **`error`**; normal protocol responses use **HTTP 200** (see Error Handling).
 
 **1. `initialize`** (request must include **`id`**):
 
 ```bash
 curl -sS -X POST 'https://YOUR_HOST/mcp/rpc' \
   -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'Authorization: Bearer sb_YOUR_TOKEN' \
   -d '{
     "jsonrpc": "2.0",
     "id": 1,
     "method": "initialize",
     "params": {
-      "protocolVersion": "2024-11-05",
+      "protocolVersion": "2025-11-25",
       "capabilities": {},
       "clientInfo": { "name": "my-agent", "version": "1.0.0" }
     }
@@ -500,7 +514,7 @@ Example **`result`** (values from `internal/mcp/jsonrpc_handler.go`):
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
-    "protocolVersion": "2024-11-05",
+    "protocolVersion": "2025-11-25",
     "capabilities": {
       "tools": { "listChanged": false }
     },
@@ -513,23 +527,28 @@ Example **`result`** (values from `internal/mcp/jsonrpc_handler.go`):
 }
 ```
 
-**2. `notifications/initialized`** (optional client ack): POST body with **`method`** **`notifications/initialized`** or **`initialized`** (both accepted), **no `id`**. Server responds **204 No Content** and an empty body.
+**2. `notifications/initialized`** (optional client ack): POST body with **`method`** **`notifications/initialized`** or **`initialized`** (both accepted), **no `id`**. Accepted notifications return **202 Accepted** with an empty body.
 
 **3. `tools/list`**:
 
 ```bash
 curl -sS -X POST 'https://YOUR_HOST/mcp/rpc' \
   -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'MCP-Protocol-Version: 2025-11-25' \
+  -H 'Authorization: Bearer sb_YOUR_TOKEN' \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
 ```
 
 **`result`** contains **`tools`**: an array of objects with **`name`**, **`description`**, **`inputSchema`** (one entry per implemented tool; length matches **`implementedTools`** in capabilities).
 
-**4. `tools/call`** — same auth resolution as legacy **`POST /mcp`** (**`resolveRequestAuth`**: session cookie or **`Authorization: Bearer`**), but Bearer failures map to a JSON-RPC **tool** result with **`isError: true`** and message **`authentication required`**, not the legacy **`AUTH_REQUIRED`** envelope. **`params.name`** is the tool name; **`params.arguments`** is the tool input object (catalog **`required`** keys are checked before the handler; unknown keys in **`arguments`** fail **`decodeInput`** for most tools — see **Overview** for exceptions).
+**4. `tools/call`** — **`params.name`** is the tool name; **`params.arguments`** is the tool input object (catalog **`required`** keys are checked before the handler; unknown keys in **`arguments`** fail **`decodeInput`** for most tools — see **Overview** for exceptions). Transport authentication has already completed before dispatch.
 
 ```bash
 curl -sS -X POST 'https://YOUR_HOST/mcp/rpc' \
   -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'MCP-Protocol-Version: 2025-11-25' \
   -H 'Cookie: scrumboy_session=YOUR_SESSION_TOKEN' \
   -d '{
     "jsonrpc": "2.0",
@@ -587,6 +606,9 @@ Same **`code`** for a rejected **Bearer** token, with **`message`: `Authenticati
 
 ### JSON-RPC `POST /mcp/rpc`
 
+- **Transport authentication failure:** empty HTTP **401**, no JSON-RPC `result` or tool result, and a complete RFC 9728 `WWW-Authenticate` challenge. Invalid Bearers add `error="invalid_token"`.
+- **Invalid Origin:** empty HTTP **403** without an OAuth challenge. Requests with no `Origin` remain valid for non-browser clients; a supplied Origin must match the trusted public origin.
+- **Method/media/transport failures:** authenticated GET and unsupported methods return empty **405** with `Allow: POST`; restrictive `Accept` values that do not allow both JSON and SSE return **406**; unsupported JSON content types return **415**; accepted notifications return empty **202**.
 - **Protocol errors** (bad JSON, unknown method, etc.): response is JSON-RPC **`error`** with integer **`code`** (e.g. `-32700` parse error, `-32601` method not found). **HTTP status is 200** for these encoded responses (see `writeJSONRPCError`).
 - **Tool execution failure** (`tools/call`): HTTP **200** with a **`result`** object containing **`isError: true`**, **`content`** (text), and no successful `structuredContent` in the error path (`writeJSONRPCToolErrorResult` in `internal/mcp/jsonrpc_handler.go`).
 - **Tool success**: **`result`** includes **`content`** (JSON text of payload) and **`structuredContent`** (parsed tool `data`).
@@ -594,7 +616,9 @@ Same **`code`** for a rejected **Bearer** token, with **`message`: `Authenticati
 ## Notes / Limitations
 
 - This is not a stdio-based MCP server. All interactions occur over HTTP.
-- **Two wire formats:** Legacy `{tool,input}` vs JSON-RPC `initialize` / `tools/list` / `tools/call`. Pick one consistently for a client; they share the same tool handlers and auth.
+- **Two wire formats:** Legacy `{tool,input}` vs JSON-RPC `initialize` / `tools/list` / `tools/call`. Pick one consistently for a client; they share tool handlers but deliberately have different OAuth boundaries.
+- **Stateless JSON-only transport:** Scrumboy does not issue MCP session IDs, offer an SSE GET stream, resumability, or server-initiated requests. An authenticated GET returns 405.
+- **Protocol versions:** Streamable HTTP supports `2025-03-26`, `2025-06-18`, and `2025-11-25`. Unsupported initialize versions negotiate to `2025-11-25`. A missing post-initialize header defaults to `2025-03-26`; malformed or unsupported headers return 400.
 - **Anonymous mode:** Effectively no authenticated tools; capabilities still describe the server.
 - **Pagination:** Global defaults in capabilities mention `limit` / `cursor` / `nextCursor` / `hasMore`; **`board.get`** uses **`cursorByColumn`** (per column key) — see `tool_catalog.go` and `pagination.futureSpecialCases` in capabilities.
 - **`sprints.update` `patch`:** Catalog documents `plannedStartAt` / `plannedEndAt` as **Unix milliseconds** (integers), not RFC3339 strings (unlike `sprints.create`).

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -527,7 +527,7 @@ Example **`result`** (values from `internal/mcp/jsonrpc_handler.go`):
 }
 ```
 
-**2. `notifications/initialized`** (optional client ack): POST body with **`method`** **`notifications/initialized`** or **`initialized`** (both accepted), **no `id`**. Accepted notifications return **202 Accepted** with an empty body.
+**2. `notifications/initialized`** (optional client ack): POST body with **`method`** **`notifications/initialized`** or **`initialized`** (both accepted), **no `id`**. Accepted notifications return **202 Accepted** with an empty body. A structurally invalid notification (for example, scalar or `null` `params`) returns **400** and has no side effect.
 
 **3. `tools/list`**:
 
@@ -608,8 +608,8 @@ Same **`code`** for a rejected **Bearer** token, with **`message`: `Authenticati
 
 - **Transport authentication failure:** empty HTTP **401**, no JSON-RPC `result` or tool result, and a complete RFC 9728 `WWW-Authenticate` challenge. Invalid Bearers add `error="invalid_token"`.
 - **Invalid Origin:** empty HTTP **403** without an OAuth challenge. Requests with no `Origin` remain valid for non-browser clients; a supplied Origin must match the trusted public origin.
-- **Method/media/transport failures:** authenticated GET and unsupported methods return empty **405** with `Allow: POST`; restrictive `Accept` values that do not allow both JSON and SSE return **406**; unsupported JSON content types return **415**; accepted notifications return empty **202**.
-- **Protocol errors** (bad JSON, unknown method, etc.): response is JSON-RPC **`error`** with integer **`code`** (e.g. `-32700` parse error, `-32601` method not found). **HTTP status is 200** for these encoded responses (see `writeJSONRPCError`).
+- **Method/media/transport failures:** authenticated GET and unsupported methods return empty **405** with `Allow: POST`; restrictive `Accept` values that do not allow both JSON and SSE return **406**; unsupported JSON content types return **415**; accepted notifications return empty **202**. Structurally rejected notifications and known request-only methods (`initialize`, `ping`, `tools/list`, and `tools/call`) sent without an `id` return **400** and do not run a handler.
+- **Protocol errors** (bad JSON, unknown method, etc.): response is JSON-RPC **`error`** with integer **`code`** (e.g. `-32700` parse error, `-32601` method not found). Valid requests with an `id` keep the normal **200** protocol-error response. Rejected no-`id` messages use **400**, with `id: null` when an error body is emitted.
 - **Tool execution failure** (`tools/call`): HTTP **200** with a **`result`** object containing **`isError: true`**, **`content`** (text), and no successful `structuredContent` in the error path (`writeJSONRPCToolErrorResult` in `internal/mcp/jsonrpc_handler.go`).
 - **Tool success**: **`result`** includes **`content`** (JSON text of payload) and **`structuredContent`** (parsed tool `data`).
 

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -115,6 +115,8 @@ Static Bearer API tokens (`docs/mcp.md`) remain fully supported and unaffected �
 
 `/oauth/*` is deliberately outside `/api/*`: it does not require the `X-Scrumboy: 1` CSRF header that `/api/*` writes require. The consent form at `/oauth/authorize` instead combines `SameSite=Lax` session-cookie semantics with a canonical `Origin` check (falling back to `Referer` when `Origin` is absent). A submission whose browser origin does not match the OAuth issuer is rejected. See the Consent section for why `Referrer-Policy: same-origin` is required for that fallback.
 
+`/oauth/token` and `/oauth/revoke` accept OAuth parameters only in a POST body encoded as `application/x-www-form-urlencoded` (media-type parameters are allowed). Defined parameters in the query string, unsupported or malformed content types, and duplicate defined parameters are rejected with `invalid_request`; token `resource` cardinality and value errors retain `invalid_target`. Token endpoint responses, including errors, send `Cache-Control: no-store` and `Pragma: no-cache`.
+
 ---
 
 ## Example: token exchange
@@ -164,7 +166,7 @@ Codes used: **`invalid_request`**, **`invalid_client`**, **`invalid_grant`**, **
 
 `/oauth/authorize` failures either redirect to the client's `redirect_uri` with `error`/`error_description`/`state` query params (once `redirect_uri` itself is verified against the registered client), or — if `redirect_uri` cannot be verified — render a plain error page instead of redirecting, to avoid an open-redirect.
 
-`/oauth/revoke` always returns `200`, whether or not the presented token existed (RFC 7009 §2.2) — this is intentional and prevents the endpoint from being used to probe for token existence.
+For a well-formed form-body request, `/oauth/revoke` returns `200` whether or not the presented token existed (RFC 7009 §2.2). Malformed, query-supplied, or duplicate parameters return `invalid_request` without revoking a token. This preserves existence hiding without accepting credentials from URLs.
 
 ---
 

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,24 +1,24 @@
 # OAuth 2.1 for MCP Clients
 
-Updated: 2026-07-16
+Updated: 2026-07-18
 
-Scrumboy's MCP endpoint (`/mcp`, `/mcp/rpc`) supports OAuth 2.1 for clients that implement automatic discovery, PKCE, and Dynamic Client Registration (DCR) — for example Claude Code's `claude mcp add --transport http` flow. This is an alternative to manually minting a static API token via `POST /api/me/tokens`; no manual client registration is needed — the client self-registers and the user approves access through a normal browser consent screen. **No environment variables are required for a direct-TLS or loopback/localhost deployment.** When `SCRUMBOY_TRUST_PROXY=1`, OAuth issuer discovery requires either `SCRUMBOY_PUBLIC_BASE_URL` or a proxy-provided `X-Forwarded-Host` together with a forwarded HTTPS indication. See [Issuer / discovery origin](#issuer--discovery-origin) below.
+Scrumboy's canonical MCP Streamable HTTP endpoint, `/mcp/rpc`, supports OAuth 2.1 for clients that implement automatic discovery, PKCE, and Dynamic Client Registration (DCR) — for example Cursor and Claude Code. `/mcp/rpc` is the sole OAuth protected resource. The separate `/mcp` endpoint remains Scrumboy's legacy bootstrap/tool API and accepts session cookies or static `sb_…` API tokens, never OAuth access tokens. **No environment variables are required for a direct-TLS or loopback/localhost deployment.** When `SCRUMBOY_TRUST_PROXY=1`, OAuth issuer discovery requires either `SCRUMBOY_PUBLIC_BASE_URL` or a proxy-provided `X-Forwarded-Host` together with a forwarded HTTPS indication. See [Issuer / discovery origin](#issuer--discovery-origin) below.
 
-Compatible clients: any MCP client that speaks HTTP OAuth discovery (RFC 8414 / RFC 9728), PKCE (RFC 7636, S256 only), and Dynamic Client Registration (RFC 7591). Claude Code is the primary target; any other MCP-over-HTTP client with the same OAuth support works identically.
+Compatible clients: any MCP client that speaks HTTP OAuth discovery (RFC 8414 / RFC 9728), PKCE (RFC 7636, S256 only), Dynamic Client Registration (RFC 7591), and OAuth resource indicators. Cursor and Claude Code are the live-acceptance targets; other compatible MCP-over-HTTP clients use the same protocol.
 
 ---
 
 ## Quick Start
 
-For direct-TLS and loopback/localhost deployments, point an MCP client at your Scrumboy instance's `/mcp` endpoint:
+Point a native MCP client directly at `/mcp/rpc`:
 
 ```sh
-claude mcp add --transport http scrumboy https://scrumboy.example.com/mcp
+claude mcp add --transport http scrumboy https://scrumboy.example.com/mcp/rpc
 ```
 
 The client will:
 
-1. Fetch `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server` to discover the endpoints below.
+1. Receive `WWW-Authenticate: Bearer resource_metadata="https://scrumboy.example.com/.well-known/oauth-protected-resource/mcp/rpc"` from the protected transport, then fetch that document and `/.well-known/oauth-authorization-server`.
 2. `POST /oauth/register` to self-register as a public client (no `client_secret`).
 3. Open a browser to `/oauth/authorize` with a PKCE `code_challenge`.
 4. Prompt you to log in (if not already) and approve access.
@@ -30,13 +30,13 @@ Static Bearer API tokens (`docs/mcp.md`) remain fully supported and unaffected �
 
 ## How It Works
 
-1. MCP client discovers endpoints via `GET /.well-known/oauth-authorization-server` and `GET /.well-known/oauth-protected-resource`.
+1. MCP client discovers endpoints via the challenged `GET /.well-known/oauth-protected-resource/mcp/rpc` document and `GET /.well-known/oauth-authorization-server`. The root protected-resource endpoint remains a compatibility fallback and describes the same `/mcp/rpc` resource.
 2. Client registers itself via `POST /oauth/register` (RFC 7591) and receives a `client_id` (no secret — public client).
-3. Client redirects the user's browser to `GET /oauth/authorize` with `response_type=code`, its `client_id`, `redirect_uri`, and a PKCE `code_challenge` (S256).
+3. Client redirects the user's browser to `GET /oauth/authorize` with `response_type=code`, its `client_id`, `redirect_uri`, a PKCE `code_challenge` (S256), and exactly one `resource=https://scrumboy.example.com/mcp/rpc` parameter.
 4. If the user has no active Scrumboy session, the authorization page offers the configured sign-in methods: local password, SSO, or both. Successful sign-in returns to the pending authorization request and shows consent ("Approve access for `<client name>`?").
 5. On approval, Scrumboy redirects back to the client's `redirect_uri` with a single-use authorization code.
-6. Client exchanges the code (plus its `code_verifier`) for an access token and refresh token at `POST /oauth/token`.
-7. Client sends the access token as `Authorization: Bearer <token>` on `/mcp` or `/mcp/rpc` requests, exactly like a static API token.
+6. Client exchanges the code (plus its `code_verifier`) for an access token and refresh token at `POST /oauth/token`, repeating the same `resource` value. Refresh requests also include `client_id` and the canonical `resource`.
+7. Client sends the opaque Scrumboy access token as `Authorization: Bearer <token>` only to `/mcp/rpc`.
 
 ---
 
@@ -51,6 +51,13 @@ Static Bearer API tokens (`docs/mcp.md`) remain fully supported and unaffected �
 
 - Required on every authorization request. Only `S256` is accepted; `plain` is rejected.
 
+**Protected resource binding**
+
+- Authorization and token requests require exactly one absolute `resource` URI identifying `<trusted-public-origin>/mcp/rpc`; missing, duplicate, malformed, or different values fail with `invalid_target`.
+- Scheme and hostname case are accepted case-insensitively for interoperability. Path, port, escaping, query, fragment, and trailing-slash semantics are not normalized. The path must be exactly `/mcp/rpc`.
+- Authorization codes, access tokens, and refresh tokens persist the canonical resource. Code and refresh redemption validate client, redirect URI, PKCE, and resource before the artifact is consumed, and consume/revoke plus access/refresh token insertion run in a single database transaction so a failed issue does not leave a spent grant without tokens.
+- `/mcp/rpc` accepts only Scrumboy's own opaque OAuth access tokens bound to its current canonical resource. Upstream OIDC-provider tokens are not MCP credentials. OAuth artifacts issued before resource binding are invalidated during migration and require one reauthorization; DCR client registrations remain usable.
+
 **Authentication / OIDC continuation**
 
 - Initial instance ownership is still established through the main app: while Scrumboy has zero users, OAuth authorization shows **Set up Scrumboy first** and does not start SSO. After that one-time bootstrap, the configured login modes below apply.
@@ -59,6 +66,7 @@ Static Bearer API tokens (`docs/mcp.md`) remain fully supported and unaffected �
 - The SSO action sends the complete current `/oauth/authorize?...` request as the OIDC login route's `return_to`. The existing OIDC sanitizer requires that continuation to remain an internal relative Scrumboy path. A client parameter also named `return_to` may remain inside the preserved authorize query, but `/oauth/authorize` does not use it for navigation and it cannot replace the server-constructed outer continuation.
 - After successful SSO, the existing callback creates the session and returns to the full pending authorize request, which then renders consent. Failed or cancelled SSO keeps the existing internal `/?oidc_error=...` destination; restart the authorization request after a failure.
 - Password accounts with 2FA complete the challenge inline on the same authorization page through the existing `/api/auth/login` and `/api/auth/login/2fa` APIs. The pending token remains only in page memory; successful verification reloads the authorize request into consent. **Start over** clears the challenge and restores password login, while hybrid deployments keep **Continue with SSO** available. Invalid, expired, and rate-limited attempts use fixed user-facing messages rather than raw API errors.
+- Upstream human sign-in remains provider-neutral: Scrumboy uses standard OIDC discovery, authorization code flow, issuer validation, and `(issuer, subject)` identity binding. The upstream provider receives only Scrumboy's configured callback (for Vega, `https://<vega-host>/api/auth/oidc/callback`). Cursor and Claude redirect URIs are dynamically registered with Scrumboy's OAuth server and are not registered with the upstream provider.
 
 **Consent**
 
@@ -97,7 +105,8 @@ Static Bearer API tokens (`docs/mcp.md`) remain fully supported and unaffected �
 
 | Method | Path | Purpose |
 |---|---|---|
-| `GET` | `/.well-known/oauth-protected-resource` | RFC 9728 — advertises this MCP resource's authorization server. |
+| `GET` | `/.well-known/oauth-protected-resource/mcp/rpc` | Canonical RFC 9728 metadata for `<origin>/mcp/rpc`. |
+| `GET` | `/.well-known/oauth-protected-resource` | Compatibility metadata alias; returns the identical `/mcp/rpc` resource identity. |
 | `GET` | `/.well-known/oauth-authorization-server` | RFC 8414 — advertises the endpoints below. |
 | `POST` | `/oauth/register` | RFC 7591 — self-service client registration. |
 | `GET`/`POST` | `/oauth/authorize` | RFC 6749 §3.1 — login/consent, then issues an authorization code. |
@@ -117,7 +126,8 @@ curl -X POST https://scrumboy.example.com/oauth/token \
   --data-urlencode "code=$CODE" \
   --data-urlencode "redirect_uri=$REDIRECT_URI" \
   --data-urlencode "client_id=$CLIENT_ID" \
-  --data-urlencode "code_verifier=$CODE_VERIFIER"
+  --data-urlencode "code_verifier=$CODE_VERIFIER" \
+  --data-urlencode "resource=https://scrumboy.example.com/mcp/rpc"
 ```
 
 ```json
@@ -134,6 +144,8 @@ Then use it exactly like a static API token:
 ```sh
 curl -X POST https://scrumboy.example.com/mcp/rpc \
   -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "MCP-Protocol-Version: 2025-11-25" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"projects.list","arguments":{}}}'
 ```
@@ -148,7 +160,7 @@ curl -X POST https://scrumboy.example.com/mcp/rpc \
 {"error": "invalid_grant", "error_description": "the authorization code is invalid, expired, or already used"}
 ```
 
-Codes used: **`invalid_request`**, **`invalid_client`**, **`invalid_grant`**, **`unsupported_grant_type`**, **`access_denied`**, **`unsupported_response_type`**, **`invalid_redirect_uri`**, **`invalid_client_metadata`**.
+Codes used: **`invalid_request`**, **`invalid_client`**, **`invalid_grant`**, **`invalid_target`**, **`unsupported_grant_type`**, **`access_denied`**, **`unsupported_response_type`**, **`invalid_redirect_uri`**, **`invalid_client_metadata`**.
 
 `/oauth/authorize` failures either redirect to the client's `redirect_uri` with `error`/`error_description`/`state` query params (once `redirect_uri` itself is verified against the registered client), or — if `redirect_uri` cannot be verified — render a plain error page instead of redirecting, to avoid an open-redirect.
 

--- a/internal/agora/adapter.go
+++ b/internal/agora/adapter.go
@@ -108,8 +108,11 @@ func (h *handler) serveDiscover(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	rpc := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
-	_, out := roundTrip(h.mcp, r, rpc)
-	if err := h.writeDiscoverFromMCP(w, out); err != nil {
+	rpcResponse := roundTrip(h.mcp, r, rpc)
+	if h.forwardMCPTransportError(w, rpcResponse) {
+		return
+	}
+	if err := h.writeDiscoverFromMCP(w, rpcResponse.Body); err != nil {
 		h.writeAdapterError(w, http.StatusBadGateway, err.Error())
 	}
 }
@@ -169,10 +172,29 @@ func (h *handler) serveInvoke(w http.ResponseWriter, r *http.Request) {
 	rpc.WriteString(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":`)
 	rpc.Write(params)
 	rpc.WriteByte('}')
-	_, out := roundTrip(h.mcp, r, rpc.Bytes())
-	if err := h.writeInvokeFromMCP(w, out); err != nil {
+	rpcResponse := roundTrip(h.mcp, r, rpc.Bytes())
+	if h.forwardMCPTransportError(w, rpcResponse) {
+		return
+	}
+	if err := h.writeInvokeFromMCP(w, rpcResponse.Body); err != nil {
 		h.writeAdapterError(w, http.StatusBadGateway, err.Error())
 	}
+}
+
+func (h *handler) forwardMCPTransportError(w http.ResponseWriter, response roundTripResponse) bool {
+	if response.Status == http.StatusOK {
+		return false
+	}
+	if response.Status == http.StatusUnauthorized {
+		h.writeAdapterError(w, http.StatusUnauthorized, "authentication required")
+		return true
+	}
+	if response.Status == http.StatusForbidden {
+		h.writeAdapterError(w, http.StatusForbidden, "request origin is not allowed")
+		return true
+	}
+	h.writeAdapterError(w, http.StatusBadGateway, "MCP transport request failed")
+	return true
 }
 
 var errTooLarge = errors.New("body too large")

--- a/internal/agora/agora_test.go
+++ b/internal/agora/agora_test.go
@@ -8,9 +8,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"scrumboy/internal/agora"
 	"scrumboy/internal/db"
@@ -19,6 +22,8 @@ import (
 	"scrumboy/internal/migrate"
 	"scrumboy/internal/store"
 )
+
+var agoraTestBearerTokens sync.Map
 
 func newAgoraTestServer(t *testing.T, mode string, withAgora bool) (*httptest.Server, *sql.DB, func()) {
 	t.Helper()
@@ -48,21 +53,49 @@ func newAgoraTestServer(t *testing.T, mode string, withAgora bool) (*httptest.Se
 	}
 	srv := httpapi.NewServer(st, opts)
 	ts := httptest.NewServer(srv)
+	if mode == "full" {
+		registerAgoraTestStaticToken(t, ts.URL, st)
+	}
 	return ts, sqlDB, func() {
 		ts.Close()
 		_ = sqlDB.Close()
 	}
 }
 
-func postRaw(t *testing.T, client *http.Client, url string, contentType string, body []byte) *http.Response {
+func registerAgoraTestStaticToken(t *testing.T, baseURL string, st *store.Store) {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	user, err := st.BootstrapUser(context.Background(), "agora@example.com", "Password123!", "Agora Test")
+	if err != nil {
+		t.Fatalf("bootstrap Agora test user: %v", err)
+	}
+	_, token, _, err := st.CreateUserAPIToken(context.Background(), user.ID, nil)
+	if err != nil {
+		t.Fatalf("create Agora test token: %v", err)
+	}
+	agoraTestBearerTokens.Store(baseURL, token)
+	t.Cleanup(func() { agoraTestBearerTokens.Delete(baseURL) })
+}
+
+func authorizeAgoraTestRequest(req *http.Request) {
+	if req.Header.Get("Authorization") != "" {
+		return
+	}
+	baseURL := (&url.URL{Scheme: req.URL.Scheme, Host: req.URL.Host}).String()
+	if token, ok := agoraTestBearerTokens.Load(baseURL); ok {
+		req.Header.Set("Authorization", "Bearer "+token.(string))
+	}
+}
+
+func postRaw(t *testing.T, client *http.Client, targetURL string, contentType string, body []byte) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
+	authorizeAgoraTestRequest(req)
 	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("do: %v", err)
@@ -203,33 +236,73 @@ func TestAgora_BearerPassthroughInvoke(t *testing.T) {
 	bB, _ := io.ReadAll(rB.Body)
 	_ = rB.Body.Close()
 
-	var aMap, bMap map[string]any
+	var aMap map[string]any
 	if err := json.Unmarshal(bA, &aMap); err != nil {
 		t.Fatalf("adapter body: %v", err)
 	}
-	if err := json.Unmarshal(bB, &bMap); err != nil {
-		t.Fatalf("mcp body: %v", err)
+	if rA.StatusCode != http.StatusUnauthorized || rB.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status adapter=%d mcp=%d, want 401", rA.StatusCode, rB.StatusCode)
 	}
 	if aMap["ok"] != false {
 		t.Fatalf("adapter expected ok false, got %v", aMap["ok"])
 	}
-	resB, _ := bMap["result"].(map[string]any)
-	if resB == nil || resB["isError"] != true {
-		t.Fatalf("mcp expected tool isError, got %v", bMap)
+	if len(bB) != 0 {
+		t.Fatalf("MCP 401 body = %q, want empty", bB)
 	}
 	ae, _ := aMap["error"].(map[string]any)
-	if ae == nil || ae["message"] == nil {
+	if ae == nil || ae["message"] != "authentication required" {
 		t.Fatalf("adapter error shape: %v", aMap)
 	}
-	cB, _ := resB["content"].([]any)
-	if len(cB) < 1 {
-		t.Fatalf("mcp content: %v", bMap)
+	if aChallenge, mcpChallenge := rA.Header.Get("WWW-Authenticate"), rB.Header.Get("WWW-Authenticate"); aChallenge != "" || mcpChallenge == "" {
+		t.Fatalf("challenge adapter=%q mcp=%q", aChallenge, mcpChallenge)
 	}
-	cb0, _ := cB[0].(map[string]any)
-	tb, _ := cb0["text"].(string)
-	aa, _ := ae["message"].(string)
-	if tb != aa {
-		t.Fatalf("message mismatch adapter %q vs mcp text %q", aa, tb)
+}
+
+func TestAgora_DoesNotAcceptMCPResourceOAuthToken(t *testing.T) {
+	t.Parallel()
+	ts, sqlDB, cleanup := newAgoraTestServer(t, "full", true)
+	defer cleanup()
+	st := store.New(sqlDB, nil)
+	user, err := st.GetUserByEmail(context.Background(), "agora@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := st.CreateOAuthClient(context.Background(), "agora-boundary", "Agora Boundary", "http://127.0.0.1/callback")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pair, err := st.IssueOAuthTokenPair(context.Background(), client.ID, user.ID, ts.URL+"/mcp/rpc")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rpcBody := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	rpcReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp/rpc", bytes.NewReader(rpcBody))
+	rpcReq.Header.Set("Content-Type", "application/json")
+	rpcReq.Header.Set("Accept", "application/json, text/event-stream")
+	rpcReq.Header.Set("Authorization", "Bearer "+pair.AccessToken)
+	rpcResp, err := http.DefaultClient.Do(rpcReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, rpcResp.Body)
+	_ = rpcResp.Body.Close()
+	if rpcResp.StatusCode != http.StatusOK {
+		t.Fatalf("direct MCP OAuth status = %d, want 200", rpcResp.StatusCode)
+	}
+
+	agoraBody := []byte(`{"tool":"projects.list","arguments":{}}`)
+	agoraReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/agora/v1/invoke", bytes.NewReader(agoraBody))
+	agoraReq.Header.Set("Content-Type", "application/json")
+	agoraReq.Header.Set("Authorization", "Bearer "+pair.AccessToken)
+	agoraResp, err := http.DefaultClient.Do(agoraReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := io.ReadAll(agoraResp.Body)
+	_ = agoraResp.Body.Close()
+	if agoraResp.StatusCode != http.StatusUnauthorized || agoraResp.Header.Get("WWW-Authenticate") != "" {
+		t.Fatalf("Agora OAuth status=%d challenge=%q body=%s", agoraResp.StatusCode, agoraResp.Header.Get("WWW-Authenticate"), raw)
 	}
 }
 
@@ -343,6 +416,7 @@ func TestAgora_InvokeArgumentsPassThrough(t *testing.T) {
 	h := agora.New(wrap, agora.Options{MaxRequestBytes: 1 << 20})
 	ts := httptest.NewServer(h)
 	defer ts.Close()
+	registerAgoraTestStaticToken(t, ts.URL, st)
 	cl := &http.Client{}
 	invokeBody := `{"tool":"system.getCapabilities","arguments":{"unusedKey":1}}`
 	resp := postRaw(t, cl, ts.URL+"/agora/v1/invoke", "application/json", []byte(invokeBody))
@@ -606,6 +680,7 @@ func TestAgora_DiscoverWhitespaceBodyOK(t *testing.T) {
 	defer cleanup()
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/agora/v1/discover", bytes.NewBufferString("   \n\t  "))
 	req.Header.Set("Content-Type", "application/json")
+	authorizeAgoraTestRequest(req)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -639,6 +714,14 @@ func TestAgora_CookiePassthroughParity(t *testing.T) {
 	}
 	defer func() { _ = sqlDB.Close() }()
 	st := store.New(sqlDB, nil)
+	user, err := st.BootstrapUser(context.Background(), "cookie@example.com", "Password123!", "Cookie Test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionToken, _, err := st.CreateSession(context.Background(), user.ID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
 	mcpH := mcp.New(st, mcp.Options{Mode: "full"})
 	var seen []string
 	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -654,20 +737,32 @@ func TestAgora_CookiePassthroughParity(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 	cl := &http.Client{}
-	const want = "scrumboy_session=cookie-passthrough-parity"
+	want := "scrumboy_session=" + sessionToken
 	r1, _ := http.NewRequest(http.MethodPost, ts.URL+"/agora/v1/invoke", bytes.NewBufferString(`{"tool":"system.getCapabilities","arguments":{}}`))
 	r1.Header.Set("Content-Type", "application/json")
 	r1.Header.Set("Cookie", want)
-	if _, err := cl.Do(r1); err != nil {
+	resp1, err := cl.Do(r1)
+	if err != nil {
 		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, resp1.Body)
+	_ = resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("Agora cookie status = %d, want 200", resp1.StatusCode)
 	}
 	r2, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp/rpc", bytes.NewBufferString(
 		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"system.getCapabilities","arguments":{}}}`,
 	))
 	r2.Header.Set("Content-Type", "application/json")
 	r2.Header.Set("Cookie", want)
-	if _, err := cl.Do(r2); err != nil {
+	resp2, err := cl.Do(r2)
+	if err != nil {
 		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, resp2.Body)
+	_ = resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("MCP cookie status = %d, want 200", resp2.StatusCode)
 	}
 	if len(seen) != 2 {
 		t.Fatalf("expected 2 handler calls, got %d %v", len(seen), seen)

--- a/internal/agora/roundtrip.go
+++ b/internal/agora/roundtrip.go
@@ -6,9 +6,16 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+
+	"scrumboy/internal/mcp"
 )
 
-func roundTrip(mcp http.Handler, r *http.Request, rpcBody []byte) (int, []byte) {
+type roundTripResponse struct {
+	Status int
+	Body   []byte
+}
+
+func roundTrip(mcpHandler http.Handler, r *http.Request, rpcBody []byte) roundTripResponse {
 	rec := httptest.NewRecorder()
 	u := url.URL{Scheme: "http", Host: "127.0.0.1", Path: "/mcp/rpc"}
 	sub := r.Clone(r.Context())
@@ -22,6 +29,9 @@ func roundTrip(mcp http.Handler, r *http.Request, rpcBody []byte) (int, []byte) 
 	}
 	sub.Header = r.Header.Clone()
 	sub.Header.Set("Content-Type", "application/json; charset=utf-8")
-	mcp.ServeHTTP(rec, sub)
-	return rec.Code, rec.Body.Bytes()
+	sub.Header.Set("Accept", "application/json, text/event-stream")
+	sub.Header.Set("MCP-Protocol-Version", "2025-11-25")
+	sub = mcp.WithoutOAuthBearer(sub)
+	mcpHandler.ServeHTTP(rec, sub)
+	return roundTripResponse{Status: rec.Code, Body: rec.Body.Bytes()}
 }

--- a/internal/httpapi/http_authority.go
+++ b/internal/httpapi/http_authority.go
@@ -1,11 +1,6 @@
 package httpapi
 
-import (
-	"net"
-	"strconv"
-	"strings"
-	"unicode"
-)
+import "scrumboy/internal/publicorigin"
 
 // parseHTTPAuthority validates an HTTP authority consisting of a hostname and
 // an optional port. It deliberately does not rely on net/url's permissive
@@ -16,87 +11,5 @@ import (
 // hostname omits IPv6 brackets so callers can perform address checks without
 // parsing the authority a second time.
 func parseHTTPAuthority(raw string) (authority, hostname string, ok bool) {
-	if raw == "" {
-		return "", "", false
-	}
-	for _, r := range raw {
-		if unicode.IsControl(r) || unicode.IsSpace(r) {
-			return "", "", false
-		}
-	}
-	// Percent escapes are intentionally rejected. Accepting them here would
-	// make different callers disagree about whether an encoded delimiter is
-	// part of the hostname or another authority/URL component.
-	if strings.ContainsAny(raw, `,/?#@%\`) {
-		return "", "", false
-	}
-
-	if raw[0] == '[' {
-		closeBracket := strings.IndexByte(raw, ']')
-		if closeBracket <= 1 {
-			return "", "", false
-		}
-		hostname = raw[1:closeBracket]
-		// Brackets are reserved for IPv6 literals. IPv4 and registered names
-		// must use their ordinary unbracketed form.
-		if ip := net.ParseIP(hostname); ip == nil || !strings.Contains(hostname, ":") {
-			return "", "", false
-		}
-		remainder := raw[closeBracket+1:]
-		if remainder == "" {
-			return raw, hostname, true
-		}
-		if remainder[0] != ':' || !validHTTPAuthorityPort(remainder[1:]) {
-			return "", "", false
-		}
-		return raw, hostname, true
-	}
-
-	if strings.ContainsAny(raw, "[]") || strings.Count(raw, ":") > 1 {
-		return "", "", false
-	}
-	hostname = raw
-	if colon := strings.LastIndexByte(raw, ':'); colon >= 0 {
-		hostname = raw[:colon]
-		if !validHTTPAuthorityPort(raw[colon+1:]) {
-			return "", "", false
-		}
-	}
-	if hostname == "" || !validHTTPRegName(hostname) {
-		return "", "", false
-	}
-	return raw, hostname, true
-}
-
-func validHTTPAuthorityPort(raw string) bool {
-	if raw == "" {
-		return false
-	}
-	for i := range raw {
-		if raw[i] < '0' || raw[i] > '9' {
-			return false
-		}
-	}
-	port, err := strconv.Atoi(raw)
-	return err == nil && port >= 1 && port <= 65535
-}
-
-// validHTTPRegName accepts the ASCII registered-name characters permitted in
-// an authority, except percent escapes and comma, which parseHTTPAuthority
-// rejects above. IP literals without colons (including IPv4) are covered by
-// the same character set.
-func validHTTPRegName(raw string) bool {
-	for i := range raw {
-		c := raw[i]
-		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' {
-			continue
-		}
-		switch c {
-		case '-', '.', '_', '~', '!', '$', '&', '\'', '(', ')', '*', '+', ';', '=':
-			continue
-		default:
-			return false
-		}
-	}
-	return true
+	return publicorigin.ParseHTTPAuthority(raw)
 }

--- a/internal/httpapi/routing_oauth.go
+++ b/internal/httpapi/routing_oauth.go
@@ -8,13 +8,13 @@ import (
 	"html"
 	"io"
 	"mime"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"unicode/utf8"
 
 	"scrumboy/internal/oauth"
+	"scrumboy/internal/publicorigin"
 	"scrumboy/internal/store"
 )
 
@@ -46,7 +46,7 @@ func (s *Server) handleOAuth(w http.ResponseWriter, r *http.Request) {
 // errOAuthIssuerUnavailable is returned by oauthIssuer when no origin can be
 // derived that this server can vouch for. Callers must fail closed (a
 // controlled error response) rather than fall back to a guessed value.
-var errOAuthIssuerUnavailable = errors.New("no trustworthy issuer origin for this request")
+var errOAuthIssuerUnavailable = publicorigin.ErrUnavailable
 
 // oauthIssuer returns the origin advertised in discovery metadata and used to
 // build absolute endpoint URLs, in order:
@@ -66,22 +66,7 @@ var errOAuthIssuerUnavailable = errors.New("no trustworthy issuer origin for thi
 //     a cleartext connection) would let an attacker spoof the metadata
 //     issuer or downgrade it to HTTP.
 func (s *Server) oauthIssuer(r *http.Request) (string, error) {
-	if s.publicBaseURL != "" {
-		return oauthPublicBaseURLIssuer(s.publicBaseURL)
-	}
-	authority, hostname, authorityOK := parseHTTPAuthority(r.Host)
-	if r.TLS != nil && authorityOK {
-		return "https://" + authority, nil
-	}
-	if s.trustProxy {
-		if origin, ok := forwardedOAuthOrigin(r); ok {
-			return origin, nil
-		}
-	}
-	if authorityOK && isLoopbackHostname(hostname) {
-		return "http://" + authority, nil
-	}
-	return "", errOAuthIssuerUnavailable
+	return s.publicOrigin.Origin(r)
 }
 
 // oauthPublicBaseURLIssuer reports whether configured PUBLIC_BASE_URL may be
@@ -89,95 +74,14 @@ func (s *Server) oauthIssuer(r *http.Request) (string, error) {
 // expect HTTPS for non-loopback AS endpoints). Global NormalizeBaseURL still
 // permits http for password-reset compatibility; this check is OAuth-only.
 func oauthPublicBaseURLIssuer(base string) (string, error) {
-	u, err := url.Parse(base)
-	if err != nil || u.Scheme == "" || u.Host == "" {
-		return "", errOAuthIssuerUnavailable
-	}
-	scheme := strings.ToLower(u.Scheme)
-	_, hostname, ok := parseHTTPAuthority(u.Host)
-	if !ok {
-		return "", errOAuthIssuerUnavailable
-	}
-	switch scheme {
-	case "https":
-		return base, nil
-	case "http":
-		if isLoopbackHostname(hostname) {
-			return base, nil
-		}
-		return "", errOAuthIssuerUnavailable
-	default:
-		return "", errOAuthIssuerUnavailable
-	}
-}
-
-// forwardedOAuthOrigin derives scheme+host as one validated decision from
-// X-Forwarded-Proto/X-Forwarded-Host (falling back to CF-Visitor for scheme
-// only when X-Forwarded-Proto is entirely absent). Only called when
-// SCRUMBOY_TRUST_PROXY is enabled. X-Forwarded-Host is required explicitly;
-// the backend-facing r.Host is never used as a fallback. Only https is
-// accepted here. Each trusted forwarded header must be a single field with a
-// single value (no comma-separated hop lists / duplicate fields).
-func forwardedOAuthOrigin(r *http.Request) (string, bool) {
-	proto, ok := forwardedOAuthScheme(r)
-	if !ok || proto != "https" {
-		return "", false
-	}
-	hostValues := r.Header.Values("X-Forwarded-Host")
-	if len(hostValues) != 1 {
-		return "", false
-	}
-	authority, _, ok := parseHTTPAuthority(hostValues[0])
-	if !ok {
-		return "", false
-	}
-	return "https://" + authority, true
-}
-
-// forwardedOAuthScheme returns a single validated forwarded scheme for OAuth
-// issuer construction. X-Forwarded-Proto wins when present (exactly one field,
-// no commas). CF-Visitor is consulted only when X-Forwarded-Proto is absent,
-// and then only if exactly one CF-Visitor field is present.
-func forwardedOAuthScheme(r *http.Request) (string, bool) {
-	protoValues := r.Header.Values("X-Forwarded-Proto")
-	if len(protoValues) > 0 {
-		if len(protoValues) != 1 {
-			return "", false
-		}
-		proto := strings.ToLower(strings.TrimSpace(protoValues[0]))
-		if proto == "" || strings.Contains(proto, ",") {
-			return "", false
-		}
-		return proto, true
-	}
-	cfValues := r.Header.Values("CF-Visitor")
-	if len(cfValues) != 1 {
-		return "", false
-	}
-	var cfVisitor struct {
-		Scheme string `json:"scheme"`
-	}
-	if err := json.Unmarshal([]byte(cfValues[0]), &cfVisitor); err != nil {
-		return "", false
-	}
-	proto := strings.ToLower(strings.TrimSpace(cfVisitor.Scheme))
-	if proto == "" || strings.Contains(proto, ",") {
-		return "", false
-	}
-	return proto, true
+	return publicorigin.ConfiguredOrigin(base)
 }
 
 // isLoopbackHostname reports whether a validated, port-free hostname refers
 // to localhost, 127.0.0.0/8, or ::1.
 // Deliberately does not treat RFC1918/LAN addresses (192.168.x.x, etc.) as
 // loopback — LAN cleartext HTTP is a separate product decision.
-func isLoopbackHostname(hostname string) bool {
-	if strings.EqualFold(hostname, "localhost") {
-		return true
-	}
-	ip := net.ParseIP(hostname)
-	return ip != nil && ip.IsLoopback()
-}
+func isLoopbackHostname(hostname string) bool { return publicorigin.IsLoopbackHostname(hostname) }
 
 // handleOAuthProtectedResourceMetadata serves RFC 9728 discovery: the two
 // fields Claude Code's MCP OAuth client actually reads.
@@ -196,7 +100,7 @@ func (s *Server) handleOAuthProtectedResourceMetadata(w http.ResponseWriter, r *
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"resource":              issuer + "/mcp",
+		"resource":              issuer + publicorigin.MCPResourcePath,
 		"authorization_servers": []string{issuer},
 	})
 }
@@ -227,6 +131,7 @@ func (s *Server) handleOAuthASMetadata(w http.ResponseWriter, r *http.Request) {
 		"code_challenge_methods_supported":           []string{"S256"},
 		"token_endpoint_auth_methods_supported":      []string{"none"},
 		"revocation_endpoint_auth_methods_supported": []string{"none"},
+		"protected_resources":                        []string{issuer + publicorigin.MCPResourcePath},
 	})
 }
 
@@ -325,9 +230,19 @@ type authorizeParams struct {
 	CodeChallenge       string
 	CodeChallengeMethod string
 	State               string
+	Resource            string
+	ResourceCount       int
 }
 
-func parseAuthorizeParams(r *http.Request) authorizeParams {
+func parseAuthorizeParams(r *http.Request) (authorizeParams, error) {
+	if err := r.ParseForm(); err != nil {
+		return authorizeParams{}, err
+	}
+	resources := r.Form["resource"]
+	resource := ""
+	if len(resources) == 1 {
+		resource = resources[0]
+	}
 	return authorizeParams{
 		ResponseType:        r.FormValue("response_type"),
 		ClientID:            r.FormValue("client_id"),
@@ -335,7 +250,9 @@ func parseAuthorizeParams(r *http.Request) authorizeParams {
 		CodeChallenge:       r.FormValue("code_challenge"),
 		CodeChallengeMethod: r.FormValue("code_challenge_method"),
 		State:               r.FormValue("state"),
-	}
+		Resource:            resource,
+		ResourceCount:       len(resources),
+	}, nil
 }
 
 func oauthAuthorizeRequestURI(params authorizeParams) string {
@@ -345,6 +262,7 @@ func oauthAuthorizeRequestURI(params authorizeParams) string {
 	query.Set("redirect_uri", params.RedirectURI)
 	query.Set("code_challenge", params.CodeChallenge)
 	query.Set("code_challenge_method", params.CodeChallengeMethod)
+	query.Set("resource", params.Resource)
 	if params.State != "" {
 		query.Set("state", params.State)
 	}
@@ -364,7 +282,11 @@ func (s *Server) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	params := parseAuthorizeParams(r)
+	params, err := parseAuthorizeParams(r)
+	if err != nil {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "malformed request body")
+		return
+	}
 	ctx := s.requestContext(r)
 
 	client, err := s.store.GetOAuthClient(ctx, params.ClientID)
@@ -382,6 +304,20 @@ func (s *Server) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 
 	// From here on redirect_uri is trusted (exact match to the registered
 	// client), so remaining validation failures redirect with error params.
+	if params.ResourceCount != 1 {
+		s.redirectOAuthError(w, r, params.RedirectURI, oauth.ErrInvalidTarget, "exactly one resource parameter is required", params.State)
+		return
+	}
+	resource, err := s.publicOrigin.ValidateMCPResource(r, params.Resource)
+	if err != nil {
+		if errors.Is(err, publicorigin.ErrUnavailable) {
+			s.writeOAuthIssuerUnavailable(w)
+			return
+		}
+		s.redirectOAuthError(w, r, params.RedirectURI, oauth.ErrInvalidTarget, "resource must identify this server's MCP RPC endpoint", params.State)
+		return
+	}
+	params.Resource = resource
 	if params.ResponseType != "code" {
 		s.redirectOAuthError(w, r, params.RedirectURI, oauth.ErrUnsupportedResponse, "only response_type=code is supported", params.State)
 		return
@@ -450,7 +386,7 @@ func (s *Server) handleOAuthAuthorizeSubmit(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	code, err := s.store.CreateOAuthAuthCode(ctx, client.ID, userID, params.RedirectURI, params.CodeChallenge, params.CodeChallengeMethod)
+	code, err := s.store.CreateOAuthAuthCode(ctx, client.ID, userID, params.RedirectURI, params.CodeChallenge, params.CodeChallengeMethod, params.Resource)
 	if err != nil {
 		writeInternal(w, err)
 		return
@@ -480,6 +416,10 @@ func (s *Server) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Cache-Control", "no-store")
+	if err := r.ParseForm(); err != nil {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "malformed request body")
+		return
+	}
 	ctx := s.requestContext(r)
 
 	switch r.FormValue("grant_type") {
@@ -497,32 +437,22 @@ func (s *Server) handleOAuthTokenAuthCode(w http.ResponseWriter, r *http.Request
 	redirectURI := r.FormValue("redirect_uri")
 	clientID := r.FormValue("client_id")
 	codeVerifier := r.FormValue("code_verifier")
+	resource, ok := s.oauthTokenResource(w, r)
+	if !ok {
+		return
+	}
 
 	if code == "" || redirectURI == "" || clientID == "" || codeVerifier == "" {
 		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "code, redirect_uri, client_id, and code_verifier are required")
 		return
 	}
 
-	ac, err := s.store.ConsumeOAuthAuthCode(ctx, code)
+	pair, err := s.store.RedeemOAuthAuthCodeAndIssue(ctx, code, clientID, redirectURI, resource, codeVerifier)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidGrant, "the authorization code is invalid, expired, or already used")
 			return
 		}
-		writeInternal(w, err)
-		return
-	}
-	if ac.ClientID != clientID || ac.RedirectURI != redirectURI {
-		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidGrant, "client_id or redirect_uri does not match the authorization request")
-		return
-	}
-	if !oauth.VerifyPKCE(ac.CodeChallengeMethod, codeVerifier, ac.CodeChallenge) {
-		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidGrant, "code_verifier does not match the original code_challenge")
-		return
-	}
-
-	pair, err := s.store.IssueOAuthTokenPair(ctx, ac.ClientID, ac.UserID)
-	if err != nil {
 		writeInternal(w, err)
 		return
 	}
@@ -536,26 +466,21 @@ func (s *Server) handleOAuthTokenAuthCode(w http.ResponseWriter, r *http.Request
 
 func (s *Server) handleOAuthTokenRefresh(w http.ResponseWriter, r *http.Request, ctx context.Context) {
 	refreshToken := r.FormValue("refresh_token")
-	if refreshToken == "" {
-		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "refresh_token is required")
+	clientID := r.FormValue("client_id")
+	resource, ok := s.oauthTokenResource(w, r)
+	if !ok {
 		return
 	}
-	clientID, userID, err := s.store.ConsumeOAuthRefreshToken(ctx, refreshToken)
+	if refreshToken == "" || clientID == "" {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "refresh_token and client_id are required")
+		return
+	}
+	pair, err := s.store.ConsumeOAuthRefreshTokenAndIssue(ctx, refreshToken, clientID, resource)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidGrant, "the refresh token is invalid, expired, or already used")
 			return
 		}
-		writeInternal(w, err)
-		return
-	}
-	if reqClientID := r.FormValue("client_id"); reqClientID != "" && reqClientID != clientID {
-		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidGrant, "client_id does not match this refresh token")
-		return
-	}
-
-	pair, err := s.store.IssueOAuthTokenPair(ctx, clientID, userID)
-	if err != nil {
 		writeInternal(w, err)
 		return
 	}
@@ -565,6 +490,28 @@ func (s *Server) handleOAuthTokenRefresh(w http.ResponseWriter, r *http.Request,
 		"expires_in":    pair.ExpiresIn,
 		"refresh_token": pair.RefreshToken,
 	})
+}
+
+func (s *Server) oauthTokenResource(w http.ResponseWriter, r *http.Request) (string, bool) {
+	if err := r.ParseForm(); err != nil {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "malformed request body")
+		return "", false
+	}
+	values := r.Form["resource"]
+	if len(values) != 1 {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidTarget, "exactly one resource parameter is required")
+		return "", false
+	}
+	resource, err := s.publicOrigin.ValidateMCPResource(r, values[0])
+	if err != nil {
+		if errors.Is(err, publicorigin.ErrUnavailable) {
+			s.writeOAuthIssuerUnavailable(w)
+			return "", false
+		}
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidTarget, "resource must identify this server's MCP RPC endpoint")
+		return "", false
+	}
+	return resource, true
 }
 
 // handleOAuthRevoke implements RFC 7009 token revocation. Per §2.2, it always
@@ -874,6 +821,7 @@ func (s *Server) renderOAuthConsentPage(w http.ResponseWriter, client store.OAut
 <div class="card">
 <h1>Approve access for %s?</h1>
 <p>%s will be able to read and manage projects, todos, sprints, and tags in this Scrumboy instance on your behalf.</p>
+<p>Protected resource:<br><strong>%s</strong></p>
 <p>After you approve, you'll be redirected to:<br><strong>%s</strong></p>
 <p>Only approve this if you recognize the application above and intended to connect it — anyone can register a client with any name, so a name alone doesn't confirm who you're granting access to. Check that this destination is one you trust.</p>
 <form method="POST" action="/oauth/authorize">
@@ -882,13 +830,14 @@ func (s *Server) renderOAuthConsentPage(w http.ResponseWriter, client store.OAut
 <input type="hidden" name="redirect_uri" value="%s">
 <input type="hidden" name="code_challenge" value="%s">
 <input type="hidden" name="code_challenge_method" value="%s">
+<input type="hidden" name="resource" value="%s">
 <input type="hidden" name="state" value="%s">
 <button class="btn-primary" type="submit" name="action" value="approve">Approve</button>
 <button class="btn-secondary" type="submit" name="action" value="deny">Deny</button>
 </form>
 </div></body></html>`,
 		html.EscapeString(name), oauthPageStyle, html.EscapeString(name), html.EscapeString(name),
-		html.EscapeString(params.RedirectURI),
+		html.EscapeString(params.Resource), html.EscapeString(params.RedirectURI),
 		html.EscapeString(params.ResponseType), html.EscapeString(params.ClientID), html.EscapeString(params.RedirectURI),
-		html.EscapeString(params.CodeChallenge), html.EscapeString(params.CodeChallengeMethod), html.EscapeString(params.State))
+		html.EscapeString(params.CodeChallenge), html.EscapeString(params.CodeChallengeMethod), html.EscapeString(params.Resource), html.EscapeString(params.State))
 }

--- a/internal/httpapi/routing_oauth.go
+++ b/internal/httpapi/routing_oauth.go
@@ -232,6 +232,7 @@ type authorizeParams struct {
 	State               string
 	Resource            string
 	ResourceCount       int
+	DuplicateParameter  string
 }
 
 func parseAuthorizeParams(r *http.Request) (authorizeParams, error) {
@@ -239,20 +240,58 @@ func parseAuthorizeParams(r *http.Request) (authorizeParams, error) {
 		return authorizeParams{}, err
 	}
 	resources := r.Form["resource"]
-	resource := ""
-	if len(resources) == 1 {
-		resource = resources[0]
-	}
 	return authorizeParams{
-		ResponseType:        r.FormValue("response_type"),
-		ClientID:            r.FormValue("client_id"),
-		RedirectURI:         r.FormValue("redirect_uri"),
-		CodeChallenge:       r.FormValue("code_challenge"),
-		CodeChallengeMethod: r.FormValue("code_challenge_method"),
-		State:               r.FormValue("state"),
-		Resource:            resource,
+		ResponseType:        oauthSingleValue(r.Form, "response_type"),
+		ClientID:            oauthSingleValue(r.Form, "client_id"),
+		RedirectURI:         oauthSingleValue(r.Form, "redirect_uri"),
+		CodeChallenge:       oauthSingleValue(r.Form, "code_challenge"),
+		CodeChallengeMethod: oauthSingleValue(r.Form, "code_challenge_method"),
+		State:               oauthSingleValue(r.Form, "state"),
+		Resource:            oauthSingleValue(r.Form, "resource"),
 		ResourceCount:       len(resources),
+		DuplicateParameter: oauthDuplicateParameter(r.Form,
+			"response_type", "client_id", "redirect_uri", "code_challenge", "code_challenge_method", "state"),
 	}, nil
+}
+
+func oauthSingleValue(values url.Values, name string) string {
+	if len(values[name]) != 1 {
+		return ""
+	}
+	return values[name][0]
+}
+
+func oauthDuplicateParameter(values url.Values, names ...string) string {
+	for _, name := range names {
+		if len(values[name]) > 1 {
+			return name
+		}
+	}
+	return ""
+}
+
+func parseOAuthFormBody(r *http.Request, definedParameters ...string) (url.Values, error) {
+	contentTypes := r.Header.Values("Content-Type")
+	if len(contentTypes) != 1 {
+		return nil, errors.New("Content-Type must be application/x-www-form-urlencoded")
+	}
+	mediaType, _, err := mime.ParseMediaType(contentTypes[0])
+	if err != nil || !strings.EqualFold(mediaType, "application/x-www-form-urlencoded") {
+		return nil, errors.New("Content-Type must be application/x-www-form-urlencoded")
+	}
+	query, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		return nil, errors.New("malformed query string")
+	}
+	for _, name := range definedParameters {
+		if _, present := query[name]; present {
+			return nil, errors.New("OAuth parameters must be supplied in the form body")
+		}
+	}
+	if err := r.ParseForm(); err != nil {
+		return nil, errors.New("malformed request body")
+	}
+	return r.PostForm, nil
 }
 
 func oauthAuthorizeRequestURI(params authorizeParams) string {
@@ -287,6 +326,10 @@ func (s *Server) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "malformed request body")
 		return
 	}
+	if params.DuplicateParameter == "client_id" || params.DuplicateParameter == "redirect_uri" {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "duplicate OAuth parameter")
+		return
+	}
 	ctx := s.requestContext(r)
 
 	client, err := s.store.GetOAuthClient(ctx, params.ClientID)
@@ -304,6 +347,10 @@ func (s *Server) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 
 	// From here on redirect_uri is trusted (exact match to the registered
 	// client), so remaining validation failures redirect with error params.
+	if params.DuplicateParameter != "" {
+		s.redirectOAuthError(w, r, params.RedirectURI, oauth.ErrInvalidRequest, "OAuth parameters must occur at most once", params.State)
+		return
+	}
 	if params.ResourceCount != 1 {
 		s.redirectOAuthError(w, r, params.RedirectURI, oauth.ErrInvalidTarget, "exactly one resource parameter is required", params.State)
 		return
@@ -402,6 +449,8 @@ func (s *Server) handleOAuthAuthorizeSubmit(w http.ResponseWriter, r *http.Reque
 // handleOAuthToken implements the RFC 6749 §4.1.3/§6 token endpoint for the
 // authorization_code and refresh_token grants.
 func (s *Server) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 	if s.mode == "anonymous" {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", "not found", nil)
 		return
@@ -414,30 +463,34 @@ func (s *Server) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
 		oauth.WriteJSON(w, http.StatusTooManyRequests, oauth.ErrInvalidRequest, "too many attempts; try again later")
 		return
 	}
-
-	w.Header().Set("Cache-Control", "no-store")
-	if err := r.ParseForm(); err != nil {
-		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "malformed request body")
+	form, err := parseOAuthFormBody(r,
+		"grant_type", "code", "redirect_uri", "client_id", "code_verifier", "refresh_token", "resource")
+	if err != nil {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "request must use an application/x-www-form-urlencoded body")
+		return
+	}
+	if duplicate := oauthDuplicateParameter(form, "grant_type", "code", "redirect_uri", "client_id", "code_verifier", "refresh_token"); duplicate != "" {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "OAuth parameters must occur at most once")
 		return
 	}
 	ctx := s.requestContext(r)
 
-	switch r.FormValue("grant_type") {
+	switch form.Get("grant_type") {
 	case "authorization_code":
-		s.handleOAuthTokenAuthCode(w, r, ctx)
+		s.handleOAuthTokenAuthCode(w, r, ctx, form)
 	case "refresh_token":
-		s.handleOAuthTokenRefresh(w, r, ctx)
+		s.handleOAuthTokenRefresh(w, r, ctx, form)
 	default:
 		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrUnsupportedGrantType, "unsupported grant_type")
 	}
 }
 
-func (s *Server) handleOAuthTokenAuthCode(w http.ResponseWriter, r *http.Request, ctx context.Context) {
-	code := r.FormValue("code")
-	redirectURI := r.FormValue("redirect_uri")
-	clientID := r.FormValue("client_id")
-	codeVerifier := r.FormValue("code_verifier")
-	resource, ok := s.oauthTokenResource(w, r)
+func (s *Server) handleOAuthTokenAuthCode(w http.ResponseWriter, r *http.Request, ctx context.Context, form url.Values) {
+	code := form.Get("code")
+	redirectURI := form.Get("redirect_uri")
+	clientID := form.Get("client_id")
+	codeVerifier := form.Get("code_verifier")
+	resource, ok := s.oauthTokenResource(w, r, form)
 	if !ok {
 		return
 	}
@@ -464,10 +517,10 @@ func (s *Server) handleOAuthTokenAuthCode(w http.ResponseWriter, r *http.Request
 	})
 }
 
-func (s *Server) handleOAuthTokenRefresh(w http.ResponseWriter, r *http.Request, ctx context.Context) {
-	refreshToken := r.FormValue("refresh_token")
-	clientID := r.FormValue("client_id")
-	resource, ok := s.oauthTokenResource(w, r)
+func (s *Server) handleOAuthTokenRefresh(w http.ResponseWriter, r *http.Request, ctx context.Context, form url.Values) {
+	refreshToken := form.Get("refresh_token")
+	clientID := form.Get("client_id")
+	resource, ok := s.oauthTokenResource(w, r, form)
 	if !ok {
 		return
 	}
@@ -492,12 +545,8 @@ func (s *Server) handleOAuthTokenRefresh(w http.ResponseWriter, r *http.Request,
 	})
 }
 
-func (s *Server) oauthTokenResource(w http.ResponseWriter, r *http.Request) (string, bool) {
-	if err := r.ParseForm(); err != nil {
-		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "malformed request body")
-		return "", false
-	}
-	values := r.Form["resource"]
+func (s *Server) oauthTokenResource(w http.ResponseWriter, r *http.Request, form url.Values) (string, bool) {
+	values := form["resource"]
 	if len(values) != 1 {
 		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidTarget, "exactly one resource parameter is required")
 		return "", false
@@ -526,8 +575,17 @@ func (s *Server) handleOAuthRevoke(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed", nil)
 		return
 	}
-	token := r.FormValue("token")
-	hint := r.FormValue("token_type_hint")
+	form, err := parseOAuthFormBody(r, "token", "token_type_hint")
+	if err != nil {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "request must use an application/x-www-form-urlencoded body")
+		return
+	}
+	if duplicate := oauthDuplicateParameter(form, "token", "token_type_hint"); duplicate != "" {
+		oauth.WriteJSON(w, http.StatusBadRequest, oauth.ErrInvalidRequest, "OAuth parameters must occur at most once")
+		return
+	}
+	token := form.Get("token")
+	hint := form.Get("token_type_hint")
 	if token != "" {
 		if err := s.store.RevokeOAuthToken(s.requestContext(r), token, hint); err != nil {
 			s.logger.Printf("oauth: revoke token: %v", err)

--- a/internal/httpapi/routing_oauth_form_test.go
+++ b/internal/httpapi/routing_oauth_form_test.go
@@ -1,0 +1,404 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"scrumboy/internal/oauth"
+)
+
+type oauthGrantFixture struct {
+	baseURL     string
+	redirectURI string
+	clientID    string
+	verifier    string
+	challenge   string
+	code        string
+}
+
+func newOAuthGrantFixture(t *testing.T) oauthGrantFixture {
+	t.Helper()
+	ts, _, cleanup := newTestHTTPServerWithMCP(t, "full")
+	t.Cleanup(cleanup)
+	cookieClient := newCookieClient(t)
+	cookieClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	bootstrapUserClient(t, cookieClient, ts.URL, "Owner", "oauth-form@example.com", "password123")
+	redirectURI := "http://localhost:9999/callback"
+	clientID := registerOAuthClient(t, ts.URL, redirectURI)
+	verifier, challenge := pkcePair(t)
+	location := approveConsent(t, cookieClient, ts.URL, clientID, redirectURI, challenge, "form-test")
+	code := location.Query().Get("code")
+	if code == "" {
+		t.Fatal("authorization did not issue a code")
+	}
+	return oauthGrantFixture{
+		baseURL:     ts.URL,
+		redirectURI: redirectURI,
+		clientID:    clientID,
+		verifier:    verifier,
+		challenge:   challenge,
+		code:        code,
+	}
+}
+
+func (f oauthGrantFixture) codeForm() url.Values {
+	return url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {f.code},
+		"redirect_uri":  {f.redirectURI},
+		"client_id":     {f.clientID},
+		"code_verifier": {f.verifier},
+		"resource":      {f.baseURL + "/mcp/rpc"},
+	}
+}
+
+func postOAuthRequest(t *testing.T, method, target, contentType, body string) (*http.Response, map[string]any) {
+	t.Helper()
+	req, err := http.NewRequest(method, target, strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) == 0 {
+		return resp, nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("OAuth response is not JSON (status=%d)", resp.StatusCode)
+	}
+	return resp, out
+}
+
+func assertTokenNoCache(t *testing.T, resp *http.Response) {
+	t.Helper()
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control=%q, want no-store", got)
+	}
+	if got := resp.Header.Get("Pragma"); got != "no-cache" {
+		t.Fatalf("Pragma=%q, want no-cache", got)
+	}
+}
+
+func oauthBearerStatus(t *testing.T, baseURL, accessToken string) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/mcp/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	return resp.StatusCode
+}
+
+func TestOAuthTokenFormBodyOnlyAndAntiCaching(t *testing.T) {
+	t.Run("authorization code and refresh success", func(t *testing.T) {
+		fixture := newOAuthGrantFixture(t)
+		resp, out := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/token", "application/x-www-form-urlencoded; charset=UTF-8", fixture.codeForm().Encode())
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("authorization-code status=%d, want 200", resp.StatusCode)
+		}
+		assertTokenNoCache(t, resp)
+		refreshToken, _ := out["refresh_token"].(string)
+		if refreshToken == "" {
+			t.Fatal("authorization-code exchange did not issue a refresh token")
+		}
+		refreshForm := url.Values{
+			"grant_type":    {"refresh_token"},
+			"refresh_token": {refreshToken},
+			"client_id":     {fixture.clientID},
+			"resource":      {fixture.baseURL + "/mcp/rpc"},
+		}
+		refreshResp, refreshOut := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/token", "application/x-www-form-urlencoded", refreshForm.Encode())
+		if refreshResp.StatusCode != http.StatusOK || refreshOut["access_token"] == nil {
+			t.Fatalf("refresh status=%d, want token response", refreshResp.StatusCode)
+		}
+		assertTokenNoCache(t, refreshResp)
+	})
+
+	t.Run("query-only exchange does not consume code", func(t *testing.T) {
+		fixture := newOAuthGrantFixture(t)
+		queryResp, queryOut := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/token?"+fixture.codeForm().Encode(), "application/x-www-form-urlencoded", "")
+		if queryResp.StatusCode != http.StatusBadRequest || queryOut["error"] != oauth.ErrInvalidRequest || queryOut["access_token"] != nil {
+			t.Fatalf("query-only exchange status=%d error=%v", queryResp.StatusCode, queryOut["error"])
+		}
+		validResp, validOut := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/token", "application/x-www-form-urlencoded", fixture.codeForm().Encode())
+		if validResp.StatusCode != http.StatusOK || validOut["access_token"] == nil {
+			t.Fatalf("valid retry status=%d, want success", validResp.StatusCode)
+		}
+	})
+
+	t.Run("JSON plus query credentials", func(t *testing.T) {
+		ts, _, cleanup := newTestHTTPServerWithMCP(t, "full")
+		defer cleanup()
+		resp, out := postOAuthRequest(t, http.MethodPost, ts.URL+"/oauth/token?grant_type=authorization_code&code=query-code", "application/json", `{"client_id":"client"}`)
+		if resp.StatusCode != http.StatusBadRequest || out["error"] != oauth.ErrInvalidRequest || out["access_token"] != nil {
+			t.Fatalf("JSON/query exchange status=%d error=%v", resp.StatusCode, out["error"])
+		}
+	})
+}
+
+func TestOAuthTokenRejectsWrongMediaAndSetsNoCacheOnErrors(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServerWithMCP(t, "full")
+	defer cleanup()
+
+	for name, contentType := range map[string]string{
+		"missing":   "",
+		"JSON":      "application/json",
+		"text":      "text/plain",
+		"multipart": "multipart/form-data; boundary=test",
+		"malformed": "application/x-www-form-urlencoded; charset=\"",
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp, out := postOAuthRequest(t, http.MethodPost, ts.URL+"/oauth/token", contentType, "grant_type=authorization_code")
+			if resp.StatusCode != http.StatusBadRequest || out["error"] != oauth.ErrInvalidRequest {
+				t.Fatalf("status=%d error=%v, want invalid_request", resp.StatusCode, out["error"])
+			}
+			assertTokenNoCache(t, resp)
+		})
+	}
+
+	cases := []struct {
+		name string
+		form url.Values
+		want string
+	}{
+		{name: "invalid request", form: url.Values{"grant_type": {"authorization_code"}, "resource": {ts.URL + "/mcp/rpc"}}, want: oauth.ErrInvalidRequest},
+		{name: "invalid grant", form: url.Values{"grant_type": {"authorization_code"}, "code": {"invalid"}, "redirect_uri": {"http://localhost/callback"}, "client_id": {"invalid"}, "code_verifier": {"invalid"}, "resource": {ts.URL + "/mcp/rpc"}}, want: oauth.ErrInvalidGrant},
+		{name: "invalid target", form: url.Values{"grant_type": {"authorization_code"}, "code": {"invalid"}, "redirect_uri": {"http://localhost/callback"}, "client_id": {"invalid"}, "code_verifier": {"invalid"}, "resource": {ts.URL + "/mcp"}}, want: oauth.ErrInvalidTarget},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, out := postOAuthRequest(t, http.MethodPost, ts.URL+"/oauth/token", "application/x-www-form-urlencoded", tc.form.Encode())
+			if resp.StatusCode != http.StatusBadRequest || out["error"] != tc.want {
+				t.Fatalf("status=%d error=%v, want %s", resp.StatusCode, out["error"], tc.want)
+			}
+			assertTokenNoCache(t, resp)
+		})
+	}
+
+	methodResp, _ := postOAuthRequest(t, http.MethodGet, ts.URL+"/oauth/token", "", "")
+	if methodResp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("GET token status=%d, want 405", methodResp.StatusCode)
+	}
+	assertTokenNoCache(t, methodResp)
+}
+
+func TestOAuthAuthorizationRejectsDuplicateParameters(t *testing.T) {
+	ts, sqlDB, cleanup := newTestHTTPServerWithMCP(t, "full")
+	defer cleanup()
+	redirectURI := "http://localhost:9999/callback"
+	clientID := registerOAuthClient(t, ts.URL, redirectURI)
+	_, challenge := pkcePair(t)
+	base := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"state"},
+		"resource":              {ts.URL + "/mcp/rpc"},
+	}
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+
+	for name, mutate := range map[string]func(url.Values){
+		"identical response_type": func(q url.Values) { q["response_type"] = []string{"code", "code"} },
+		"conflicting challenge":   func(q url.Values) { q["code_challenge"] = []string{challenge, "different"} },
+	} {
+		t.Run(name, func(t *testing.T) {
+			q := cloneValues(base)
+			mutate(q)
+			resp, err := client.Get(ts.URL + "/oauth/authorize?" + q.Encode())
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp.Body.Close()
+			location, _ := url.Parse(resp.Header.Get("Location"))
+			if resp.StatusCode != http.StatusFound || location.Query().Get("error") != oauth.ErrInvalidRequest {
+				t.Fatalf("status=%d error=%q, want redirected invalid_request", resp.StatusCode, location.Query().Get("error"))
+			}
+		})
+	}
+
+	t.Run("ambiguous client is not redirected", func(t *testing.T) {
+		q := cloneValues(base)
+		q["client_id"] = []string{clientID, clientID}
+		resp, out := postOAuthRequest(t, http.MethodGet, ts.URL+"/oauth/authorize?"+q.Encode(), "", "")
+		if resp.StatusCode != http.StatusBadRequest || resp.Header.Get("Location") != "" || out["error"] != oauth.ErrInvalidRequest {
+			t.Fatalf("status=%d location=%q error=%v", resp.StatusCode, resp.Header.Get("Location"), out["error"])
+		}
+	})
+
+	t.Run("ambiguous redirect is not redirected", func(t *testing.T) {
+		q := cloneValues(base)
+		q["redirect_uri"] = []string{redirectURI, "https://attacker.example/callback"}
+		resp, out := postOAuthRequest(t, http.MethodGet, ts.URL+"/oauth/authorize?"+q.Encode(), "", "")
+		if resp.StatusCode != http.StatusBadRequest || resp.Header.Get("Location") != "" || out["error"] != oauth.ErrInvalidRequest {
+			t.Fatalf("status=%d location=%q error=%v", resp.StatusCode, resp.Header.Get("Location"), out["error"])
+		}
+	})
+
+	t.Run("query and body split", func(t *testing.T) {
+		form := cloneValues(base)
+		form.Set("state", "body-state")
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/oauth/authorize?state=query-state", strings.NewReader(form.Encode()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		location, _ := url.Parse(resp.Header.Get("Location"))
+		if resp.StatusCode != http.StatusFound || location.Query().Get("error") != oauth.ErrInvalidRequest {
+			t.Fatalf("status=%d error=%q, want redirected invalid_request", resp.StatusCode, location.Query().Get("error"))
+		}
+	})
+
+	t.Run("duplicate resource remains invalid_target", func(t *testing.T) {
+		q := cloneValues(base)
+		q["resource"] = []string{ts.URL + "/mcp/rpc", ts.URL + "/mcp/rpc"}
+		resp, err := client.Get(ts.URL + "/oauth/authorize?" + q.Encode())
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		location, _ := url.Parse(resp.Header.Get("Location"))
+		if resp.StatusCode != http.StatusFound || location.Query().Get("error") != oauth.ErrInvalidTarget {
+			t.Fatalf("status=%d error=%q, want invalid_target", resp.StatusCode, location.Query().Get("error"))
+		}
+	})
+
+	var codeCount int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM oauth_auth_codes`).Scan(&codeCount); err != nil {
+		t.Fatal(err)
+	}
+	if codeCount != 0 {
+		t.Fatalf("duplicate authorization attempts issued %d codes, want 0", codeCount)
+	}
+}
+
+func cloneValues(source url.Values) url.Values {
+	clone := make(url.Values, len(source))
+	for key, values := range source {
+		clone[key] = append([]string(nil), values...)
+	}
+	return clone
+}
+
+func TestOAuthTokenDuplicateParametersDoNotConsumeGrants(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		duplicate func(url.Values)
+	}{
+		{name: "identical code", duplicate: func(form url.Values) { form["code"] = []string{form.Get("code"), form.Get("code")} }},
+		{name: "conflicting verifier", duplicate: func(form url.Values) { form["code_verifier"] = []string{form.Get("code_verifier"), "different"} }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newOAuthGrantFixture(t)
+			form := fixture.codeForm()
+			tc.duplicate(form)
+			resp, out := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/token", "application/x-www-form-urlencoded", form.Encode())
+			if resp.StatusCode != http.StatusBadRequest || out["error"] != oauth.ErrInvalidRequest {
+				t.Fatalf("duplicate status=%d error=%v", resp.StatusCode, out["error"])
+			}
+			validResp, validOut := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/token", "application/x-www-form-urlencoded", fixture.codeForm().Encode())
+			if validResp.StatusCode != http.StatusOK || validOut["access_token"] == nil {
+				t.Fatalf("valid retry status=%d, want success", validResp.StatusCode)
+			}
+		})
+	}
+
+	t.Run("duplicate refresh token", func(t *testing.T) {
+		fixture := newOAuthGrantFixture(t)
+		_, issued := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/token", "application/x-www-form-urlencoded", fixture.codeForm().Encode())
+		refreshToken := issued["refresh_token"].(string)
+		form := url.Values{
+			"grant_type":    {"refresh_token"},
+			"refresh_token": {refreshToken, refreshToken},
+			"client_id":     {fixture.clientID},
+			"resource":      {fixture.baseURL + "/mcp/rpc"},
+		}
+		resp, out := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/token", "application/x-www-form-urlencoded", form.Encode())
+		if resp.StatusCode != http.StatusBadRequest || out["error"] != oauth.ErrInvalidRequest {
+			t.Fatalf("duplicate refresh status=%d error=%v", resp.StatusCode, out["error"])
+		}
+		form.Set("refresh_token", refreshToken)
+		validResp, validOut := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/token", "application/x-www-form-urlencoded", form.Encode())
+		if validResp.StatusCode != http.StatusOK || validOut["access_token"] == nil {
+			t.Fatalf("valid refresh retry status=%d, want success", validResp.StatusCode)
+		}
+	})
+}
+
+func TestOAuthRevocationIsFormBodyOnlyAndDuplicateSafe(t *testing.T) {
+	fixture := newOAuthGrantFixture(t)
+	_, issued := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/token", "application/x-www-form-urlencoded", fixture.codeForm().Encode())
+	accessToken := issued["access_token"].(string)
+
+	queryResp, queryOut := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/revoke?token="+url.QueryEscape(accessToken), "application/x-www-form-urlencoded", "")
+	if queryResp.StatusCode != http.StatusBadRequest || queryOut["error"] != oauth.ErrInvalidRequest {
+		t.Fatalf("query revocation status=%d error=%v", queryResp.StatusCode, queryOut["error"])
+	}
+	duplicate := url.Values{"token": {accessToken, accessToken}}
+	duplicateResp, duplicateOut := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/revoke", "application/x-www-form-urlencoded", duplicate.Encode())
+	if duplicateResp.StatusCode != http.StatusBadRequest || duplicateOut["error"] != oauth.ErrInvalidRequest {
+		t.Fatalf("duplicate revocation status=%d error=%v", duplicateResp.StatusCode, duplicateOut["error"])
+	}
+	if status := oauthBearerStatus(t, fixture.baseURL, accessToken); status != http.StatusOK {
+		t.Fatalf("rejected revocation changed token status to %d, want 200", status)
+	}
+
+	for name, contentType := range map[string]string{
+		"missing":   "",
+		"JSON":      "application/json",
+		"text":      "text/plain",
+		"multipart": "multipart/form-data; boundary=test",
+		"malformed": "application/x-www-form-urlencoded; charset=\"",
+	} {
+		t.Run(name, func(t *testing.T) {
+			wrongMediaResp, wrongMediaOut := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/revoke", contentType, `{}`)
+			if wrongMediaResp.StatusCode != http.StatusBadRequest || wrongMediaOut["error"] != oauth.ErrInvalidRequest {
+				t.Fatalf("wrong-media revocation status=%d error=%v", wrongMediaResp.StatusCode, wrongMediaOut["error"])
+			}
+		})
+	}
+	if status := oauthBearerStatus(t, fixture.baseURL, accessToken); status != http.StatusOK {
+		t.Fatalf("wrong-media revocation changed token status to %d, want 200", status)
+	}
+
+	validResp, validOut := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/revoke", "application/x-www-form-urlencoded", url.Values{"token": {accessToken}}.Encode())
+	if validResp.StatusCode != http.StatusOK || validOut != nil {
+		t.Fatalf("valid revocation status=%d, want empty 200", validResp.StatusCode)
+	}
+	unknownResp, unknownOut := postOAuthRequest(t, http.MethodPost, fixture.baseURL+"/oauth/revoke", "application/x-www-form-urlencoded", url.Values{"token": {"unknown-token"}}.Encode())
+	if unknownResp.StatusCode != http.StatusOK || unknownOut != nil {
+		t.Fatalf("unknown-token revocation status=%d, want empty 200", unknownResp.StatusCode)
+	}
+	if status := oauthBearerStatus(t, fixture.baseURL, accessToken); status != http.StatusUnauthorized {
+		t.Fatalf("revoked token status=%d, want 401", status)
+	}
+}

--- a/internal/httpapi/routing_oauth_oidc_test.go
+++ b/internal/httpapi/routing_oauth_oidc_test.go
@@ -360,6 +360,7 @@ func TestOAuthOIDCContinuationConsentApproveRefererOnly(t *testing.T) {
 		"code_challenge_method": {"S256"},
 		"state":                 {state},
 		"action":                {"approve"},
+		"resource":              {ts.URL + "/mcp/rpc"},
 	}
 	req, err := http.NewRequest(http.MethodPost, ts.URL+"/oauth/authorize", strings.NewReader(form.Encode()))
 	if err != nil {
@@ -405,6 +406,7 @@ func TestOAuthExpiredConsentPOSTReturnsToCompleteAuthorizeGET(t *testing.T) {
 		"code_challenge_method": {"S256"},
 		"state":                 {state},
 		"action":                {"approve"},
+		"resource":              {ts.URL + "/mcp/rpc"},
 	}
 	req, err := http.NewRequest(http.MethodPost, ts.URL+"/oauth/authorize", strings.NewReader(form.Encode()))
 	if err != nil {

--- a/internal/httpapi/routing_oauth_test.go
+++ b/internal/httpapi/routing_oauth_test.go
@@ -14,12 +14,14 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"scrumboy/internal/db"
 	"scrumboy/internal/mcp"
 	"scrumboy/internal/migrate"
+	"scrumboy/internal/oauth"
 	"scrumboy/internal/store"
 )
 
@@ -124,6 +126,7 @@ func authorizeURL(baseURL, clientID, redirectURI, challenge, state string) strin
 		"code_challenge":        {challenge},
 		"code_challenge_method": {"S256"},
 		"state":                 {state},
+		"resource":              {baseURL + "/mcp/rpc"},
 	}
 	return baseURL + "/oauth/authorize?" + q.Encode()
 }
@@ -138,6 +141,7 @@ func approveConsent(t *testing.T, client *http.Client, baseURL, clientID, redire
 		"code_challenge_method": {"S256"},
 		"state":                 {state},
 		"action":                {"approve"},
+		"resource":              {baseURL + "/mcp/rpc"},
 	}
 	req, err := http.NewRequest(http.MethodPost, baseURL+"/oauth/authorize", strings.NewReader(form.Encode()))
 	if err != nil {
@@ -162,6 +166,9 @@ func approveConsent(t *testing.T, client *http.Client, baseURL, clientID, redire
 
 func exchangeToken(t *testing.T, baseURL string, form url.Values) (int, map[string]any) {
 	t.Helper()
+	if _, ok := form["resource"]; !ok {
+		form.Set("resource", baseURL+"/mcp/rpc")
+	}
 	req, err := http.NewRequest(http.MethodPost, baseURL+"/oauth/token", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatalf("new request: %v", err)
@@ -252,12 +259,23 @@ func TestOAuth_FullHappyPath(t *testing.T) {
 			t.Fatalf("expected AS metadata field %q, got %+v", field, asMeta)
 		}
 	}
+	protected, ok := asMeta["protected_resources"].([]any)
+	if !ok || len(protected) != 1 || protected[0] != ts.URL+"/mcp/rpc" {
+		t.Fatalf("protected_resources = %#v, want canonical RPC resource", asMeta["protected_resources"])
+	}
 	var prMeta map[string]any
 	if resp, _ := doJSON(t, http.DefaultClient, http.MethodGet, ts.URL+"/.well-known/oauth-protected-resource", nil, &prMeta); resp.StatusCode != http.StatusOK {
 		t.Fatalf("protected resource metadata status=%d", resp.StatusCode)
 	}
-	if prMeta["resource"] == nil {
-		t.Fatalf("expected protected resource metadata to include resource, got %+v", prMeta)
+	if prMeta["resource"] != ts.URL+"/mcp/rpc" {
+		t.Fatalf("protected resource = %#v, want %s/mcp/rpc", prMeta["resource"], ts.URL)
+	}
+	var pathPRMeta map[string]any
+	if resp, _ := doJSON(t, http.DefaultClient, http.MethodGet, ts.URL+"/.well-known/oauth-protected-resource/mcp/rpc", nil, &pathPRMeta); resp.StatusCode != http.StatusOK {
+		t.Fatalf("path-derived protected resource metadata status=%d", resp.StatusCode)
+	}
+	if !reflect.DeepEqual(pathPRMeta, prMeta) {
+		t.Fatalf("path metadata = %+v, root compatibility metadata = %+v", pathPRMeta, prMeta)
 	}
 
 	verifier, challenge := pkcePair(t)
@@ -332,6 +350,113 @@ func TestOAuth_FullHappyPath(t *testing.T) {
 	result, ok := mcpOut["result"].(map[string]any)
 	if !ok || result["isError"] == true {
 		t.Fatalf("expected successful MCP tool call with OAuth bearer token, got %+v", mcpOut)
+	}
+
+	legacyReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp", strings.NewReader(`{"tool":"projects.list","input":{}}`))
+	legacyReq.Header.Set("Content-Type", "application/json")
+	legacyReq.Header.Set("Authorization", "Bearer "+accessToken)
+	legacyResp, err := http.DefaultClient.Do(legacyReq)
+	if err != nil {
+		t.Fatalf("legacy MCP request with OAuth token: %v", err)
+	}
+	defer legacyResp.Body.Close()
+	var legacyOut map[string]any
+	if err := json.NewDecoder(legacyResp.Body).Decode(&legacyOut); err != nil {
+		t.Fatalf("decode legacy authentication error: %v", err)
+	}
+	if legacyResp.StatusCode != http.StatusUnauthorized || legacyResp.Header.Get("WWW-Authenticate") != "" {
+		t.Fatalf("legacy OAuth token status=%d challenge=%q body=%+v", legacyResp.StatusCode, legacyResp.Header.Get("WWW-Authenticate"), legacyOut)
+	}
+	if legacyOut["ok"] != false {
+		t.Fatalf("legacy OAuth token must retain the legacy error envelope: %+v", legacyOut)
+	}
+}
+
+func TestOAuthResourceParameterValidation(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServerWithMCP(t, "full")
+	defer cleanup()
+	redirectURI := "http://localhost:9999/callback"
+	clientID := registerOAuthClient(t, ts.URL, redirectURI)
+	_, challenge := pkcePair(t)
+
+	query := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"resource-test"},
+	}
+	client := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }}
+	resp, err := client.Get(ts.URL + "/oauth/authorize?" + query.Encode())
+	if err != nil {
+		t.Fatalf("authorize without resource: %v", err)
+	}
+	resp.Body.Close()
+	location, _ := url.Parse(resp.Header.Get("Location"))
+	if resp.StatusCode != http.StatusFound || location.Query().Get("error") != oauth.ErrInvalidTarget {
+		t.Fatalf("authorize without resource status=%d location=%s", resp.StatusCode, location)
+	}
+
+	for name, resources := range map[string][]string{
+		"missing":   nil,
+		"duplicate": {ts.URL + "/mcp/rpc", ts.URL + "/mcp/rpc"},
+		"wrong":     {ts.URL + "/mcp"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			form := url.Values{"grant_type": {"authorization_code"}, "code": {"invalid"}, "redirect_uri": {redirectURI}, "client_id": {clientID}, "code_verifier": {"invalid"}}
+			if resources != nil {
+				form["resource"] = resources
+			}
+			response, err := http.Post(ts.URL+"/oauth/token", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+			if err != nil {
+				t.Fatalf("token request: %v", err)
+			}
+			defer response.Body.Close()
+			var out map[string]any
+			if err := json.NewDecoder(response.Body).Decode(&out); err != nil {
+				t.Fatalf("decode token error: %v", err)
+			}
+			if response.StatusCode != http.StatusBadRequest || out["error"] != oauth.ErrInvalidTarget {
+				t.Fatalf("status=%d body=%+v", response.StatusCode, out)
+			}
+		})
+	}
+}
+
+func TestOAuth_MalformedFormReturnsInvalidRequest(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServerWithMCP(t, "full")
+	defer cleanup()
+
+	authorizeReq, err := http.NewRequest(http.MethodPost, ts.URL+"/oauth/authorize", strings.NewReader("client_id=%"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorizeReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	authorizeResp, err := http.DefaultClient.Do(authorizeReq)
+	if err != nil {
+		t.Fatalf("authorize malformed form: %v", err)
+	}
+	defer authorizeResp.Body.Close()
+	var authorizeOut map[string]any
+	if err := json.NewDecoder(authorizeResp.Body).Decode(&authorizeOut); err != nil {
+		t.Fatalf("decode authorize error: %v", err)
+	}
+	if authorizeResp.StatusCode != http.StatusBadRequest || authorizeOut["error"] != oauth.ErrInvalidRequest {
+		t.Fatalf("authorize malformed form status=%d body=%+v", authorizeResp.StatusCode, authorizeOut)
+	}
+
+	tokenResp, err := http.Post(ts.URL+"/oauth/token", "application/x-www-form-urlencoded", strings.NewReader("grant_type=%"))
+	if err != nil {
+		t.Fatalf("token malformed form: %v", err)
+	}
+	defer tokenResp.Body.Close()
+	var tokenOut map[string]any
+	if err := json.NewDecoder(tokenResp.Body).Decode(&tokenOut); err != nil {
+		t.Fatalf("decode token error: %v", err)
+	}
+	if tokenResp.StatusCode != http.StatusBadRequest || tokenOut["error"] != oauth.ErrInvalidRequest {
+		t.Fatalf("token malformed form status=%d body=%+v", tokenResp.StatusCode, tokenOut)
 	}
 }
 
@@ -521,6 +646,7 @@ func TestOAuth_RefreshTokenFlow(t *testing.T) {
 	status2, refreshResp := exchangeToken(t, ts.URL, url.Values{
 		"grant_type":    {"refresh_token"},
 		"refresh_token": {firstRefreshToken},
+		"client_id":     {clientID},
 	})
 	if status2 != http.StatusOK {
 		t.Fatalf("refresh exchange status=%d body=%+v", status2, refreshResp)
@@ -551,6 +677,7 @@ func TestOAuth_RefreshTokenFlow(t *testing.T) {
 	status3, reuseResp := exchangeToken(t, ts.URL, url.Values{
 		"grant_type":    {"refresh_token"},
 		"refresh_token": {firstRefreshToken},
+		"client_id":     {clientID},
 	})
 	if status3 != http.StatusBadRequest || reuseResp["error"] != "invalid_grant" {
 		t.Fatalf("expected reused refresh token to be rejected, got status=%d body=%+v", status3, reuseResp)
@@ -601,16 +728,25 @@ func TestOAuth_RevokedAccessTokenRejectedByMCP(t *testing.T) {
 		t.Fatalf("expected 200 from revoking a nonexistent token, got %d", garbageRevokeResp.StatusCode)
 	}
 
-	mcpReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp", strings.NewReader(`{"tool":"projects.list","input":{}}`))
+	mcpReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp/rpc", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
 	mcpReq.Header.Set("Content-Type", "application/json")
+	mcpReq.Header.Set("Accept", "application/json, text/event-stream")
 	mcpReq.Header.Set("Authorization", "Bearer "+accessToken)
 	mcpResp, err := http.DefaultClient.Do(mcpReq)
 	if err != nil {
 		t.Fatalf("mcp call with revoked token: %v", err)
 	}
 	defer mcpResp.Body.Close()
-	if mcpResp.StatusCode != http.StatusUnauthorized {
-		t.Fatalf("expected 401 for revoked access token on legacy /mcp, got %d", mcpResp.StatusCode)
+	body, err := io.ReadAll(mcpResp.Body)
+	if err != nil {
+		t.Fatalf("read revoked-token response: %v", err)
+	}
+	if mcpResp.StatusCode != http.StatusUnauthorized || len(body) != 0 {
+		t.Fatalf("revoked-token status=%d body=%q, want empty 401", mcpResp.StatusCode, body)
+	}
+	wantChallenge := `Bearer error="invalid_token", resource_metadata="` + ts.URL + `/.well-known/oauth-protected-resource/mcp/rpc"`
+	if got := mcpResp.Header.Get("WWW-Authenticate"); got != wantChallenge {
+		t.Fatalf("WWW-Authenticate=%q, want %q", got, wantChallenge)
 	}
 }
 
@@ -816,6 +952,7 @@ func TestOAuth_ConsentSubmitRejectsCrossOriginPost(t *testing.T) {
 		"code_challenge_method": {"S256"},
 		"state":                 {"s1"},
 		"action":                {"approve"},
+		"resource":              {ts.URL + "/mcp/rpc"},
 	}
 	req, err := http.NewRequest(http.MethodPost, ts.URL+"/oauth/authorize", strings.NewReader(form.Encode()))
 	if err != nil {
@@ -847,6 +984,7 @@ func postConsentApprove(t *testing.T, client *http.Client, baseURL, clientID, re
 		"code_challenge_method": {"S256"},
 		"state":                 {state},
 		"action":                {"approve"},
+		"resource":              {baseURL + "/mcp/rpc"},
 	}
 	req, err := http.NewRequest(http.MethodPost, baseURL+"/oauth/authorize", strings.NewReader(form.Encode()))
 	if err != nil {

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -16,6 +16,7 @@ import (
 	"scrumboy/internal/httpapi/ratelimit"
 	"scrumboy/internal/mailer"
 	"scrumboy/internal/oidc"
+	"scrumboy/internal/publicorigin"
 	"scrumboy/internal/store"
 	"scrumboy/internal/version"
 )
@@ -79,6 +80,7 @@ type Options struct {
 	// overrides the request-derived origin for reset links (see resetBaseURL)
 	// and is the canonical OAuth discovery issuer.
 	PublicBaseURL string
+	PublicOrigin  *publicorigin.Resolver
 
 	// TrustProxy (SCRUMBOY_TRUST_PROXY). When true, clientIP honors
 	// X-Forwarded-For for authentication and OAuth rate-limit IP keys. Default
@@ -128,6 +130,7 @@ type Server struct {
 
 	publicBaseURL string // SCRUMBOY_PUBLIC_BASE_URL; reset-link origin and canonical OAuth issuer when set
 	trustProxy    bool   // SCRUMBOY_TRUST_PROXY; gates forwarded client IP and OAuth origin signals
+	publicOrigin  *publicorigin.Resolver
 
 	webFS               fs.FS
 	fileSrv             http.Handler
@@ -177,10 +180,9 @@ type storeAPI interface {
 	// OAuth 2.1 authorization server (RFC 7591/6749/7636/7009) for MCP clients.
 	CreateOAuthClient(ctx context.Context, clientID, clientName, redirectURI string) (store.OAuthClient, error)
 	GetOAuthClient(ctx context.Context, clientID string) (store.OAuthClient, error)
-	CreateOAuthAuthCode(ctx context.Context, clientID string, userID int64, redirectURI, codeChallenge, codeChallengeMethod string) (string, error)
-	ConsumeOAuthAuthCode(ctx context.Context, rawCode string) (store.OAuthAuthCode, error)
-	IssueOAuthTokenPair(ctx context.Context, clientID string, userID int64) (store.OAuthTokenPair, error)
-	ConsumeOAuthRefreshToken(ctx context.Context, rawToken string) (clientID string, userID int64, err error)
+	CreateOAuthAuthCode(ctx context.Context, clientID string, userID int64, redirectURI, codeChallenge, codeChallengeMethod, resource string) (string, error)
+	RedeemOAuthAuthCodeAndIssue(ctx context.Context, rawCode, expectedClientID, expectedRedirectURI, expectedResource, codeVerifier string) (store.OAuthTokenPair, error)
+	ConsumeOAuthRefreshTokenAndIssue(ctx context.Context, rawToken, expectedClientID, expectedResource string) (store.OAuthTokenPair, error)
 	RevokeOAuthToken(ctx context.Context, rawToken, hint string) error
 
 	GetUserByOIDCIdentity(ctx context.Context, issuer, subject string) (store.User, error)
@@ -463,6 +465,11 @@ func NewServer(st storeAPI, opts Options) *Server {
 	if opts.EncryptionKey != nil {
 		encKey = opts.EncryptionKey
 	}
+	publicBaseURL := config.NormalizeBaseURL(opts.PublicBaseURL)
+	publicOrigin := opts.PublicOrigin
+	if publicOrigin == nil {
+		publicOrigin = publicorigin.New(publicBaseURL, opts.TrustProxy)
+	}
 
 	return &Server{
 		store:                       st,
@@ -497,8 +504,9 @@ func NewServer(st storeAPI, opts Options) *Server {
 		totpLimiter:                 totpLimiter,
 		recoveryCodeLimiter:         recoveryCodeLimiter,
 		smtpConfigured:              smtpConfigured,
-		publicBaseURL:               config.NormalizeBaseURL(opts.PublicBaseURL),
+		publicBaseURL:               publicBaseURL,
 		trustProxy:                  opts.TrustProxy,
+		publicOrigin:                publicOrigin,
 		webFS:                       webFS,
 		fileSrv:                     http.FileServer(http.FS(webFS)),
 		indexHTML:                   indexHTML,
@@ -551,7 +559,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.URL.Path == "/.well-known/oauth-protected-resource" {
+	if r.URL.Path == "/.well-known/oauth-protected-resource" || r.URL.Path == publicorigin.MCPResourceMetadataPath {
 		s.handleOAuthProtectedResourceMetadata(w, r)
 		return
 	}

--- a/internal/httpapi/web/modules/voice/mcp-client.test.ts
+++ b/internal/httpapi/web/modules/voice/mcp-client.test.ts
@@ -13,9 +13,14 @@ function stubFetch(response: Response): ReturnType<typeof vi.fn> {
 
 describe('voice MCP client', () => {
   it('returns data from valid legacy MCP envelopes', async () => {
-    stubFetch(new Response(JSON.stringify({ ok: true, data: { value: 1 }, meta: {} }), { status: 200 }));
+    const fetchMock = stubFetch(new Response(JSON.stringify({ ok: true, data: { value: 1 }, meta: {} }), { status: 200 }));
 
     await expect(callMcpTool('todos.get', { projectSlug: 'alpha', localId: 1 })).resolves.toEqual({ value: 1 });
+    expect(fetchMock).toHaveBeenCalledWith('/mcp', expect.objectContaining({
+      method: 'POST',
+      credentials: 'same-origin',
+      body: JSON.stringify({ tool: 'todos.get', input: { projectSlug: 'alpha', localId: 1 } }),
+    }));
   });
 
   it('throws server MCP errors with the server message', async () => {

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -164,7 +164,10 @@ func (a *Adapter) resolveRequestAuth(r *http.Request, allowOAuth bool) requestAu
 
 	u, err := a.store.GetUserBySessionToken(ctx, c.Value)
 	if err != nil {
-		return requestAuthResult{Ctx: ctx}
+		if errors.Is(err, store.ErrNotFound) {
+			return requestAuthResult{Ctx: ctx}
+		}
+		return requestAuthResult{Ctx: ctx, Err: err}
 	}
 
 	ctx = store.WithUserID(ctx, u.ID)

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"scrumboy/internal/publicorigin"
 	"scrumboy/internal/store"
 )
 
@@ -16,7 +17,7 @@ type storeAPI interface {
 	CountUsers(ctx context.Context) (int, error)
 	GetUserBySessionToken(ctx context.Context, token string) (store.User, error)
 	GetUserByAPIToken(ctx context.Context, rawToken string) (store.User, error)
-	GetUserByOAuthAccessToken(ctx context.Context, rawToken string) (store.User, error)
+	GetUserByOAuthAccessToken(ctx context.Context, rawToken, expectedResource string) (store.User, error)
 	ListProjects(ctx context.Context) ([]store.ProjectListEntry, error)
 	GetProjectContextBySlug(ctx context.Context, slug string, mode store.Mode) (store.ProjectContext, error)
 	CreateTodo(ctx context.Context, projectID int64, in store.CreateTodoInput, mode store.Mode) (store.Todo, error)
@@ -52,13 +53,15 @@ type storeAPI interface {
 }
 
 type Options struct {
-	Mode string
+	Mode         string
+	PublicOrigin *publicorigin.Resolver
 }
 
 type Adapter struct {
-	store storeAPI
-	mode  string
-	tools toolRegistry
+	store        storeAPI
+	mode         string
+	tools        toolRegistry
+	publicOrigin *publicorigin.Resolver
 }
 
 func New(st storeAPI, opts Options) *Adapter {
@@ -66,11 +69,16 @@ func New(st storeAPI, opts Options) *Adapter {
 	if mode != "full" && mode != "anonymous" {
 		mode = "full"
 	}
+	resolver := opts.PublicOrigin
+	if resolver == nil {
+		resolver = publicorigin.New("", false)
+	}
 
 	a := &Adapter{
-		store: st,
-		mode:  mode,
-		tools: make(toolRegistry),
+		store:        st,
+		mode:         mode,
+		tools:        make(toolRegistry),
+		publicOrigin: resolver,
 	}
 	a.registerTools()
 	return a
@@ -102,6 +110,7 @@ func parseBearerAuthorization(headerValue string) (ok bool, credential string) {
 // requestAuthResult is the outcome of MCP credential-to-actor resolution.
 type requestAuthResult struct {
 	Ctx              context.Context
+	Authenticated    bool
 	BearerAuthFailed bool
 	Err              error // non-nil store failure (caller should map to 500)
 }
@@ -111,7 +120,7 @@ type requestAuthResult struct {
 // present, but it does not authorize access to any specific resource. MCP
 // tools may gate capability/UX early; store methods remain the authority for
 // resource authorization.
-func (a *Adapter) resolveRequestAuth(r *http.Request) requestAuthResult {
+func (a *Adapter) resolveRequestAuth(r *http.Request, allowOAuth bool) requestAuthResult {
 	ctx := r.Context()
 
 	// Anonymous mode intentionally establishes no actor, matching the HTTP API
@@ -126,11 +135,15 @@ func (a *Adapter) resolveRequestAuth(r *http.Request) requestAuthResult {
 			return requestAuthResult{Ctx: ctx, BearerAuthFailed: true}
 		}
 		u, err := a.store.GetUserByAPIToken(ctx, cred)
-		if errors.Is(err, store.ErrNotFound) {
+		if allowOAuth && errors.Is(err, store.ErrNotFound) {
 			// OAuth-issued access tokens (RFC 6749) live in a separate table
 			// from manually-created API tokens; fall back to that lookup
 			// before giving up. This never falls back to the session cookie.
-			u, err = a.store.GetUserByOAuthAccessToken(ctx, cred)
+			resource, resourceErr := a.publicOrigin.MCPResource(r)
+			if resourceErr != nil {
+				return requestAuthResult{Ctx: ctx, Err: resourceErr}
+			}
+			u, err = a.store.GetUserByOAuthAccessToken(ctx, cred, resource)
 		}
 		if err != nil {
 			if errors.Is(err, store.ErrNotFound) {
@@ -141,7 +154,7 @@ func (a *Adapter) resolveRequestAuth(r *http.Request) requestAuthResult {
 		ctx = store.WithUserID(ctx, u.ID)
 		ctx = store.WithUserEmail(ctx, u.Email)
 		ctx = store.WithUserName(ctx, u.Name)
-		return requestAuthResult{Ctx: ctx}
+		return requestAuthResult{Ctx: ctx, Authenticated: true}
 	}
 
 	c, err := r.Cookie("scrumboy_session")
@@ -157,7 +170,7 @@ func (a *Adapter) resolveRequestAuth(r *http.Request) requestAuthResult {
 	ctx = store.WithUserID(ctx, u.ID)
 	ctx = store.WithUserEmail(ctx, u.Email)
 	ctx = store.WithUserName(ctx, u.Name)
-	return requestAuthResult{Ctx: ctx}
+	return requestAuthResult{Ctx: ctx, Authenticated: true}
 }
 
 // authState reports whether authenticated MCP tools are usable for this

--- a/internal/mcp/auth_policy.go
+++ b/internal/mcp/auth_policy.go
@@ -1,0 +1,21 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+)
+
+type oauthBearerPolicyKey struct{}
+
+// WithoutOAuthBearer returns a request whose authentication boundary accepts
+// cookies and static API tokens, but never OAuth access tokens. Internal
+// adapters use this when they delegate tool execution to /mcp/rpc without
+// becoming additional OAuth protected resources themselves.
+func WithoutOAuthBearer(r *http.Request) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), oauthBearerPolicyKey{}, false))
+}
+
+func oauthBearerAllowed(r *http.Request) bool {
+	allowed, present := r.Context().Value(oauthBearerPolicyKey{}).(bool)
+	return !present || allowed
+}

--- a/internal/mcp/auth_store_error_test.go
+++ b/internal/mcp/auth_store_error_test.go
@@ -1,0 +1,109 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+type authFaultStore struct {
+	storeAPI
+	sessionUser  store.User
+	sessionErr   error
+	apiErr       error
+	oauthErr     error
+	sessionCalls int
+}
+
+func (s *authFaultStore) GetUserBySessionToken(context.Context, string) (store.User, error) {
+	s.sessionCalls++
+	return s.sessionUser, s.sessionErr
+}
+
+func (s *authFaultStore) GetUserByAPIToken(context.Context, string) (store.User, error) {
+	return store.User{}, s.apiErr
+}
+
+func (s *authFaultStore) GetUserByOAuthAccessToken(context.Context, string, string) (store.User, error) {
+	return store.User{}, s.oauthErr
+}
+
+func authFaultRequest(t *testing.T, st storeAPI, bearer string, withCookie bool) *httptest.ResponseRecorder {
+	t.Helper()
+	adapter := New(st, Options{Mode: "full"})
+	body := `{"jsonrpc":"2.0","id":1,"method":"ping"}`
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/mcp/rpc", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	if withCookie {
+		req.AddCookie(&http.Cookie{Name: "scrumboy_session", Value: "session-value"})
+	}
+	rec := httptest.NewRecorder()
+	adapter.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestJSONRPCAuthenticationStoreFailures(t *testing.T) {
+	backendErr := errors.New("authentication store unavailable")
+
+	t.Run("session backend failure", func(t *testing.T) {
+		st := &authFaultStore{sessionErr: backendErr}
+		rec := authFaultRequest(t, st, "", true)
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status=%d, want 500", rec.Code)
+		}
+		if challenge := rec.Header().Get("WWW-Authenticate"); challenge != "" {
+			t.Fatalf("500 challenge=%q, want empty", challenge)
+		}
+	})
+
+	t.Run("missing session", func(t *testing.T) {
+		st := &authFaultStore{sessionErr: store.ErrNotFound}
+		rec := authFaultRequest(t, st, "", true)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status=%d, want 401", rec.Code)
+		}
+		if challenge := rec.Header().Get("WWW-Authenticate"); challenge == "" {
+			t.Fatal("missing session must follow the normal unauthenticated challenge path")
+		}
+	})
+
+	t.Run("static token backend failure", func(t *testing.T) {
+		st := &authFaultStore{apiErr: backendErr}
+		rec := authFaultRequest(t, st, "static-token", false)
+		if rec.Code != http.StatusInternalServerError || rec.Header().Get("WWW-Authenticate") != "" {
+			t.Fatalf("status=%d challenge=%q, want 500 without challenge", rec.Code, rec.Header().Get("WWW-Authenticate"))
+		}
+	})
+
+	t.Run("OAuth token backend failure", func(t *testing.T) {
+		st := &authFaultStore{apiErr: store.ErrNotFound, oauthErr: backendErr}
+		rec := authFaultRequest(t, st, "oauth-token", false)
+		if rec.Code != http.StatusInternalServerError || rec.Header().Get("WWW-Authenticate") != "" {
+			t.Fatalf("status=%d challenge=%q, want 500 without challenge", rec.Code, rec.Header().Get("WWW-Authenticate"))
+		}
+	})
+
+	t.Run("invalid bearer does not reach valid cookie", func(t *testing.T) {
+		st := &authFaultStore{
+			sessionUser: store.User{ID: 1, Email: "user@example.com", Name: "User"},
+			apiErr:      store.ErrNotFound,
+			oauthErr:    store.ErrNotFound,
+		}
+		rec := authFaultRequest(t, st, "invalid-token", true)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status=%d, want 401", rec.Code)
+		}
+		if st.sessionCalls != 0 {
+			t.Fatalf("session lookup calls=%d, want 0", st.sessionCalls)
+		}
+	})
+}

--- a/internal/mcp/http_handler.go
+++ b/internal/mcp/http_handler.go
@@ -11,7 +11,7 @@ import (
 // resolveAndValidateAuth runs MCP auth resolution and writes JSON errors when auth cannot proceed.
 // On success, ok is true and ctx is ready for tool handlers. On failure, ok is false (response already sent).
 func (a *Adapter) resolveAndValidateAuth(w http.ResponseWriter, r *http.Request) (ctx context.Context, ok bool) {
-	authRes := a.resolveRequestAuth(r)
+	authRes := a.resolveRequestAuth(r, false)
 	if authRes.Err != nil {
 		writeError(w, newAdapterError(http.StatusInternalServerError, CodeInternal, "internal error", map[string]any{"detail": authRes.Err.Error()}))
 		return nil, false
@@ -26,7 +26,11 @@ func (a *Adapter) resolveAndValidateAuth(w http.ResponseWriter, r *http.Request)
 func (a *Adapter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-store")
 
-	if r.URL.Path == "/mcp/rpc" || r.URL.Path == "/mcp/rpc/" {
+	if r.URL.Path == "/mcp/rpc/" {
+		http.Redirect(w, r, "/mcp/rpc", http.StatusPermanentRedirect)
+		return
+	}
+	if r.URL.Path == "/mcp/rpc" {
 		a.serveJSONRPC(w, r)
 		return
 	}

--- a/internal/mcp/jsonrpc_auth_test.go
+++ b/internal/mcp/jsonrpc_auth_test.go
@@ -1,0 +1,132 @@
+package mcp_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+func rawJSONRPC(t *testing.T, client *http.Client, baseURL, bearer string) (*http.Response, []byte) {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-11-25",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "auth-test", "version": "1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal JSON-RPC request: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/mcp/rpc", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new JSON-RPC request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do JSON-RPC request: %v", err)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read JSON-RPC response: %v", err)
+	}
+	return resp, raw
+}
+
+func TestJSONRPCAuthenticationChallenge(t *testing.T) {
+	ts, _, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	for name, bearer := range map[string]string{"missing": "", "invalid bearer": "not-a-token"} {
+		t.Run(name, func(t *testing.T) {
+			resp, body := rawJSONRPC(t, newStatelessClient(ts), ts.URL, bearer)
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401", resp.StatusCode)
+			}
+			want := `Bearer resource_metadata="` + ts.URL + `/.well-known/oauth-protected-resource/mcp/rpc"`
+			if bearer != "" {
+				want = `Bearer error="invalid_token", resource_metadata="` + ts.URL + `/.well-known/oauth-protected-resource/mcp/rpc"`
+			}
+			if got := resp.Header.Get("WWW-Authenticate"); got != want {
+				t.Fatalf("WWW-Authenticate = %q, want %q", got, want)
+			}
+			if len(body) != 0 {
+				t.Fatalf("401 body = %q, want empty", body)
+			}
+			if got := resp.Header.Get("Content-Type"); got != "" {
+				t.Fatalf("401 Content-Type = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestJSONRPCAuthenticationMethods(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+	cookieClient := newCookieClient(t, ts)
+	bootstrapUser(t, cookieClient, ts.URL)
+
+	t.Run("cookie", func(t *testing.T) {
+		resp, body := rawJSONRPC(t, cookieClient, ts.URL, "")
+		if resp.StatusCode != http.StatusOK || !bytes.Contains(body, []byte(`"result"`)) {
+			t.Fatalf("cookie response status=%d body=%s", resp.StatusCode, body)
+		}
+	})
+
+	st := store.New(sqlDB, nil)
+	user, err := st.GetUserByEmail(context.Background(), "owner@example.com")
+	if err != nil {
+		t.Fatalf("GetUserByEmail: %v", err)
+	}
+	_, token, _, err := st.CreateUserAPIToken(context.Background(), user.ID, nil)
+	if err != nil {
+		t.Fatalf("CreateUserAPIToken: %v", err)
+	}
+	t.Run("static bearer", func(t *testing.T) {
+		resp, body := rawJSONRPC(t, newStatelessClient(ts), ts.URL, token)
+		if resp.StatusCode != http.StatusOK || !bytes.Contains(body, []byte(`"result"`)) {
+			t.Fatalf("static bearer response status=%d body=%s", resp.StatusCode, body)
+		}
+	})
+
+	oauthClient, err := st.CreateOAuthClient(context.Background(), "wrong-resource-client", "Wrong Resource", "http://127.0.0.1/callback")
+	if err != nil {
+		t.Fatalf("CreateOAuthClient: %v", err)
+	}
+	wrongResourcePair, err := st.IssueOAuthTokenPair(context.Background(), oauthClient.ID, user.ID, "https://other.example/mcp/rpc")
+	if err != nil {
+		t.Fatalf("IssueOAuthTokenPair: %v", err)
+	}
+	t.Run("wrong-resource OAuth bearer", func(t *testing.T) {
+		resp, body := rawJSONRPC(t, newStatelessClient(ts), ts.URL, wrongResourcePair.AccessToken)
+		if resp.StatusCode != http.StatusUnauthorized || len(body) != 0 {
+			t.Fatalf("status=%d body=%q, want empty 401", resp.StatusCode, body)
+		}
+		if got := resp.Header.Get("WWW-Authenticate"); got != `Bearer error="invalid_token", resource_metadata="`+ts.URL+`/.well-known/oauth-protected-resource/mcp/rpc"` {
+			t.Fatalf("WWW-Authenticate = %q", got)
+		}
+	})
+
+	t.Run("invalid bearer does not fall back to cookie", func(t *testing.T) {
+		resp, body := rawJSONRPC(t, cookieClient, ts.URL, "invalid-token")
+		if resp.StatusCode != http.StatusUnauthorized || len(body) != 0 {
+			t.Fatalf("status=%d body=%q, want empty 401", resp.StatusCode, body)
+		}
+		if got := resp.Header.Get("WWW-Authenticate"); got != `Bearer error="invalid_token", resource_metadata="`+ts.URL+`/.well-known/oauth-protected-resource/mcp/rpc"` {
+			t.Fatalf("WWW-Authenticate = %q", got)
+		}
+	})
+}

--- a/internal/mcp/jsonrpc_handler.go
+++ b/internal/mcp/jsonrpc_handler.go
@@ -196,11 +196,11 @@ func (a *Adapter) serveJSONRPC(w http.ResponseWriter, r *http.Request) {
 			if fail.HasID {
 				writeJSONRPCError(w, fail.ID, fail.Code, fail.Message)
 			} else {
-				writeJSONRPCError(w, nil, fail.Code, fail.Message)
+				writeJSONRPCErrorStatus(w, http.StatusBadRequest, nil, fail.Code, fail.Message)
 			}
 			return
 		}
-		writeJSONRPCError(w, nil, jsonRPCInvalidRequest, err.Error())
+		writeJSONRPCErrorStatus(w, http.StatusBadRequest, nil, jsonRPCInvalidRequest, err.Error())
 		return
 	}
 	if req.IsReply {
@@ -209,7 +209,11 @@ func (a *Adapter) serveJSONRPC(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !req.HasID {
-		if req.Method != "initialize" && !validMCPProtocolHeader(r.Header.Values("MCP-Protocol-Version")) {
+		if isMCPRequestOnlyMethod(req.Method) {
+			writeJSONRPCErrorStatus(w, http.StatusBadRequest, nil, jsonRPCInvalidRequest, "method requires a request id")
+			return
+		}
+		if !validMCPProtocolHeader(r.Header.Values("MCP-Protocol-Version")) {
 			writeEmptyStatus(w, http.StatusBadRequest)
 			return
 		}
@@ -234,6 +238,15 @@ func (a *Adapter) serveJSONRPC(w http.ResponseWriter, r *http.Request) {
 		a.handleJSONRPCToolsCall(w, r, req)
 	default:
 		writeJSONRPCError(w, req.ID, jsonRPCMethodNotFound, "method not found")
+	}
+}
+
+func isMCPRequestOnlyMethod(method string) bool {
+	switch method {
+	case "initialize", "ping", "tools/list", "tools/call":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -496,12 +509,20 @@ func writeJSONRPCErrorWithData(w http.ResponseWriter, id json.RawMessage, code i
 }
 
 func writeJSONRPCError(w http.ResponseWriter, id json.RawMessage, code int, message string) {
-	writeJSONRPCResponse(w, jsonRPCResponse{JSONRPC: "2.0", ID: id, Error: &jsonRPCError{Code: code, Message: message}})
+	writeJSONRPCErrorStatus(w, http.StatusOK, id, code, message)
+}
+
+func writeJSONRPCErrorStatus(w http.ResponseWriter, status int, id json.RawMessage, code int, message string) {
+	writeJSONRPCResponseStatus(w, status, jsonRPCResponse{JSONRPC: "2.0", ID: id, Error: &jsonRPCError{Code: code, Message: message}})
 }
 
 func writeJSONRPCResponse(w http.ResponseWriter, response jsonRPCResponse) {
+	writeJSONRPCResponseStatus(w, http.StatusOK, response)
+}
+
+func writeJSONRPCResponseStatus(w http.ResponseWriter, status int, response jsonRPCResponse) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(response)
 }
 

--- a/internal/mcp/jsonrpc_handler.go
+++ b/internal/mcp/jsonrpc_handler.go
@@ -1,27 +1,74 @@
 package mcp
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
+	"mime"
 	"net/http"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"scrumboy/internal/publicorigin"
 )
 
-const mcpProtocolVersion = "2024-11-05"
+const (
+	mcpLatestProtocolVersion  = "2025-11-25"
+	mcpDefaultProtocolVersion = "2025-03-26"
+	maxJSONRPCBodyBytes       = 1 << 20
+)
 
-// JSON-RPC 2.0 wire types.
+var supportedMCPProtocolVersions = map[string]bool{
+	"2025-03-26": true,
+	"2025-06-18": true,
+	"2025-11-25": true,
+}
 
 type jsonRPCRequest struct {
-	JSONRPC string          `json:"jsonrpc"`
-	ID      any             `json:"id,omitempty"`
-	Method  string          `json:"method"`
-	Params  json.RawMessage `json:"params,omitempty"`
+	JSONRPC string
+	ID      json.RawMessage
+	HasID   bool
+	Method  string
+	Params  json.RawMessage
+	IsReply bool
+}
+
+// jsonRPCParseFailure is a structurally invalid JSON-RPC object (-32600).
+// Malformed JSON remains a separate -32700 path in serveJSONRPC and must not
+// be routed through this type.
+type jsonRPCParseFailure struct {
+	ID      json.RawMessage
+	HasID   bool
+	Code    int
+	Message string
+}
+
+func (e *jsonRPCParseFailure) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+func invalidJSONRPCRequest(req *jsonRPCRequest, message string) error {
+	fail := &jsonRPCParseFailure{
+		Code:    jsonRPCInvalidRequest,
+		Message: message,
+	}
+	if req != nil && req.HasID {
+		fail.ID = append(json.RawMessage(nil), req.ID...)
+		fail.HasID = true
+	}
+	return fail
 }
 
 type jsonRPCResponse struct {
-	JSONRPC string        `json:"jsonrpc"`
-	ID      any           `json:"id"`
-	Result  any           `json:"result,omitempty"`
-	Error   *jsonRPCError `json:"error,omitempty"`
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *jsonRPCError   `json:"error,omitempty"`
 }
 
 type jsonRPCError struct {
@@ -38,12 +85,10 @@ const (
 	jsonRPCInternalError  = -32603
 )
 
-// MCP initialize handshake types.
-
 type mcpInitializeParams struct {
 	ProtocolVersion string         `json:"protocolVersion"`
 	Capabilities    map[string]any `json:"capabilities"`
-	ClientInfo      mcpClientInfo  `json:"clientInfo"`
+	ClientInfo      *mcpClientInfo `json:"clientInfo"`
 }
 
 type mcpClientInfo struct {
@@ -71,126 +116,287 @@ type mcpServerInfo struct {
 	Version string `json:"version"`
 }
 
-// serveJSONRPC handles POST /mcp/rpc with JSON-RPC 2.0 framing.
-// This is the spec-compliant MCP endpoint; the legacy /mcp endpoint is unchanged.
 func (a *Adapter) serveJSONRPC(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-store")
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	allowed, err := a.publicOrigin.OriginAllowed(r)
+	if err != nil {
+		writeEmptyStatus(w, http.StatusServiceUnavailable)
+		return
+	}
+	if !allowed {
+		writeEmptyStatus(w, http.StatusForbidden)
+		return
+	}
+
+	if a.mode != "anonymous" {
+		authRes := a.resolveRequestAuth(r, oauthBearerAllowed(r))
+		if authRes.Err != nil {
+			if errors.Is(authRes.Err, publicorigin.ErrUnavailable) {
+				writeEmptyStatus(w, http.StatusServiceUnavailable)
+			} else {
+				writeEmptyStatus(w, http.StatusInternalServerError)
+			}
+			return
+		}
+		if !authRes.Authenticated || authRes.BearerAuthFailed {
+			metadataURL, err := a.publicOrigin.MCPResourceMetadataURL(r)
+			if err != nil {
+				writeEmptyStatus(w, http.StatusServiceUnavailable)
+				return
+			}
+			challenge := `Bearer resource_metadata="` + metadataURL + `"`
+			if authRes.BearerAuthFailed {
+				challenge = `Bearer error="invalid_token", resource_metadata="` + metadataURL + `"`
+			}
+			w.Header().Set("WWW-Authenticate", challenge)
+			writeEmptyStatus(w, http.StatusUnauthorized)
+			return
+		}
+		r = r.WithContext(authRes.Ctx)
+	}
 
 	if r.Method != http.MethodPost {
-		writeJSONRPCError(w, nil, jsonRPCInvalidRequest, "only POST is accepted")
+		w.Header().Set("Allow", http.MethodPost)
+		writeEmptyStatus(w, http.StatusMethodNotAllowed)
+		return
+	}
+	if !acceptsJSONAndSSE(r.Header.Values("Accept")) {
+		writeEmptyStatus(w, http.StatusNotAcceptable)
+		return
+	}
+	if !isJSONContentType(r.Header.Values("Content-Type")) {
+		writeEmptyStatus(w, http.StatusUnsupportedMediaType)
 		return
 	}
 
-	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	body, tooLarge, err := readJSONRPCBody(r.Body)
 	if err != nil {
-		writeJSONRPCError(w, nil, jsonRPCParseError, "failed to read body")
+		writeEmptyStatus(w, http.StatusBadRequest)
 		return
 	}
-
-	var req jsonRPCRequest
-	if err := json.Unmarshal(body, &req); err != nil {
+	if tooLarge {
+		writeEmptyStatus(w, http.StatusRequestEntityTooLarge)
+		return
+	}
+	if !utf8.Valid(body) || !json.Valid(body) {
 		writeJSONRPCError(w, nil, jsonRPCParseError, "invalid JSON")
 		return
 	}
-
-	if req.JSONRPC != "2.0" {
-		writeJSONRPCError(w, req.ID, jsonRPCInvalidRequest, "jsonrpc must be \"2.0\"")
-		return
-	}
-	if req.Method == "" {
-		writeJSONRPCError(w, req.ID, jsonRPCInvalidRequest, "method is required")
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		writeEmptyStatus(w, http.StatusBadRequest)
 		return
 	}
 
-	isNotification := req.ID == nil
+	req, err := parseJSONRPCMessage(trimmed)
+	if err != nil {
+		var fail *jsonRPCParseFailure
+		if errors.As(err, &fail) {
+			if fail.HasID {
+				writeJSONRPCError(w, fail.ID, fail.Code, fail.Message)
+			} else {
+				writeJSONRPCError(w, nil, fail.Code, fail.Message)
+			}
+			return
+		}
+		writeJSONRPCError(w, nil, jsonRPCInvalidRequest, err.Error())
+		return
+	}
+	if req.IsReply {
+		writeEmptyStatus(w, http.StatusBadRequest)
+		return
+	}
+
+	if !req.HasID {
+		if req.Method != "initialize" && !validMCPProtocolHeader(r.Header.Values("MCP-Protocol-Version")) {
+			writeEmptyStatus(w, http.StatusBadRequest)
+			return
+		}
+		writeEmptyStatus(w, http.StatusAccepted)
+		return
+	}
+	if req.Method != "initialize" && !validMCPProtocolHeader(r.Header.Values("MCP-Protocol-Version")) {
+		writeEmptyStatus(w, http.StatusBadRequest)
+		return
+	}
 
 	switch req.Method {
 	case "initialize":
-		a.handleJSONRPCInitialize(w, &req)
+		a.handleJSONRPCInitialize(w, req)
 	case "notifications/initialized", "initialized":
-		if !isNotification {
-			writeJSONRPCError(w, req.ID, jsonRPCInvalidRequest, "initialized must be a notification (no id)")
-			return
-		}
-		// Spec: notifications get no response body.
-		w.WriteHeader(http.StatusNoContent)
+		writeJSONRPCError(w, req.ID, jsonRPCInvalidRequest, "initialized must be a notification (no id)")
+	case "ping":
+		writeJSONRPCResult(w, req.ID, map[string]any{})
 	case "tools/list":
-		a.handleJSONRPCToolsList(w, &req)
+		a.handleJSONRPCToolsList(w, req)
 	case "tools/call":
-		a.handleJSONRPCToolsCall(w, r, &req)
+		a.handleJSONRPCToolsCall(w, r, req)
 	default:
 		writeJSONRPCError(w, req.ID, jsonRPCMethodNotFound, "method not found")
 	}
 }
 
-func (a *Adapter) handleJSONRPCInitialize(w http.ResponseWriter, req *jsonRPCRequest) {
-	if req.ID == nil {
-		writeJSONRPCError(w, nil, jsonRPCInvalidRequest, "initialize must be a request (requires id)")
-		return
+func parseJSONRPCMessage(body []byte) (*jsonRPCRequest, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil || fields == nil {
+		return nil, invalidJSONRPCRequest(nil, "JSON-RPC message must be an object")
 	}
-
-	var params mcpInitializeParams
-	if req.Params != nil {
-		if err := json.Unmarshal(req.Params, &params); err != nil {
-			writeJSONRPCError(w, req.ID, jsonRPCInvalidParams, "invalid initialize params")
-			return
+	var req jsonRPCRequest
+	if raw, ok := fields["jsonrpc"]; !ok || json.Unmarshal(raw, &req.JSONRPC) != nil || req.JSONRPC != "2.0" {
+		return nil, invalidJSONRPCRequest(nil, `jsonrpc must be "2.0"`)
+	}
+	if raw, ok := fields["id"]; ok {
+		if !validJSONRPCID(raw) {
+			return nil, invalidJSONRPCRequest(nil, "id must be a string, number, or null")
+		}
+		req.ID = append(json.RawMessage(nil), raw...)
+		req.HasID = true
+	}
+	if raw, ok := fields["method"]; ok {
+		if json.Unmarshal(raw, &req.Method) != nil || req.Method == "" {
+			return nil, invalidJSONRPCRequest(&req, "method must be a non-empty string")
 		}
 	}
-
-	result := mcpInitializeResult{
-		ProtocolVersion: mcpProtocolVersion,
-		Capabilities: mcpCapabilities{
-			Tools: &mcpToolsCapability{ListChanged: false},
-		},
-		ServerInfo: mcpServerInfo{
-			Name:    "scrumboy",
-			Version: "1.0.0",
-		},
-		Instructions: "Scrumboy MCP server. Use tools/list to discover available tools.",
+	if raw, ok := fields["params"]; ok {
+		trimmedParams := bytes.TrimSpace(raw)
+		if len(trimmedParams) == 0 || (trimmedParams[0] != '{' && trimmedParams[0] != '[') {
+			return nil, invalidJSONRPCRequest(&req, "params must be an object or array")
+		}
+		req.Params = append(json.RawMessage(nil), raw...)
 	}
+	_, hasResult := fields["result"]
+	_, hasError := fields["error"]
+	if req.Method == "" && req.HasID && hasResult != hasError {
+		req.IsReply = true
+		return &req, nil
+	}
+	if req.Method == "" {
+		return nil, invalidJSONRPCRequest(&req, "method is required")
+	}
+	if hasResult || hasError {
+		return nil, invalidJSONRPCRequest(&req, "request must not contain result or error")
+	}
+	return &req, nil
+}
 
+func validJSONRPCID(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if bytes.Equal(trimmed, []byte("null")) {
+		return true
+	}
+	if len(trimmed) == 0 {
+		return false
+	}
+	if trimmed[0] == '"' {
+		var value string
+		return json.Unmarshal(trimmed, &value) == nil
+	}
+	var number json.Number
+	return json.Unmarshal(trimmed, &number) == nil
+}
+
+func readJSONRPCBody(body io.Reader) ([]byte, bool, error) {
+	data, err := io.ReadAll(io.LimitReader(body, maxJSONRPCBodyBytes+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if len(data) > maxJSONRPCBodyBytes {
+		return nil, true, nil
+	}
+	return data, false, nil
+}
+
+func isJSONContentType(values []string) bool {
+	if len(values) != 1 || strings.Contains(values[0], ",") {
+		return false
+	}
+	mediaType, params, err := mime.ParseMediaType(values[0])
+	if err != nil || !strings.EqualFold(mediaType, "application/json") {
+		return false
+	}
+	charset := params["charset"]
+	return charset == "" || strings.EqualFold(charset, "utf-8")
+}
+
+func acceptsJSONAndSSE(values []string) bool {
+	if len(values) == 0 {
+		return true
+	}
+	hasJSON, hasSSE := false, false
+	for _, field := range values {
+		for _, item := range strings.Split(field, ",") {
+			mediaType, params, err := mime.ParseMediaType(strings.TrimSpace(item))
+			if err != nil {
+				return false
+			}
+			if q, ok := params["q"]; ok {
+				quality, err := strconv.ParseFloat(q, 64)
+				if err != nil || quality < 0 || quality > 1 {
+					return false
+				}
+				if quality == 0 {
+					continue
+				}
+			}
+			switch strings.ToLower(mediaType) {
+			case "*/*":
+				return true
+			case "application/json":
+				hasJSON = true
+			case "text/event-stream":
+				hasSSE = true
+			}
+		}
+	}
+	return hasJSON && hasSSE
+}
+
+func validMCPProtocolHeader(values []string) bool {
+	if len(values) == 0 {
+		return supportedMCPProtocolVersions[mcpDefaultProtocolVersion]
+	}
+	if len(values) != 1 || strings.Contains(values[0], ",") {
+		return false
+	}
+	return supportedMCPProtocolVersions[strings.TrimSpace(values[0])]
+}
+
+func (a *Adapter) handleJSONRPCInitialize(w http.ResponseWriter, req *jsonRPCRequest) {
+	var params mcpInitializeParams
+	if len(req.Params) == 0 || bytes.Equal(bytes.TrimSpace(req.Params), []byte("null")) || json.Unmarshal(req.Params, &params) != nil || params.ProtocolVersion == "" || params.Capabilities == nil || params.ClientInfo == nil || strings.TrimSpace(params.ClientInfo.Name) == "" || strings.TrimSpace(params.ClientInfo.Version) == "" {
+		writeJSONRPCError(w, req.ID, jsonRPCInvalidParams, "initialize requires protocolVersion, capabilities, clientInfo.name, and clientInfo.version")
+		return
+	}
+	selected := params.ProtocolVersion
+	if !supportedMCPProtocolVersions[selected] {
+		selected = mcpLatestProtocolVersion
+	}
+	result := mcpInitializeResult{
+		ProtocolVersion: selected,
+		Capabilities:    mcpCapabilities{Tools: &mcpToolsCapability{ListChanged: false}},
+		ServerInfo:      mcpServerInfo{Name: "scrumboy", Version: "1.0.0"},
+		Instructions:    "Scrumboy MCP server. Use tools/list to discover available tools.",
+	}
 	writeJSONRPCResult(w, req.ID, result)
 }
 
-func writeJSONRPCResult(w http.ResponseWriter, id any, result any) {
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(jsonRPCResponse{
-		JSONRPC: "2.0",
-		ID:      id,
-		Result:  result,
-	})
-}
-
 func (a *Adapter) handleJSONRPCToolsList(w http.ResponseWriter, req *jsonRPCRequest) {
-	if req.ID == nil {
-		writeJSONRPCError(w, nil, jsonRPCInvalidRequest, "tools/list must be a request (requires id)")
-		return
-	}
-	writeJSONRPCResult(w, req.ID, map[string]any{
-		"tools": a.toolCatalog(),
-	})
+	writeJSONRPCResult(w, req.ID, map[string]any{"tools": a.toolCatalog()})
 }
 
-// tools/call params shape per MCP spec.
 type toolsCallParams struct {
 	Name      string         `json:"name"`
 	Arguments map[string]any `json:"arguments"`
 }
 
-// MCP text content block for tool results.
 type mcpTextContent struct {
 	Type string `json:"type"`
 	Text string `json:"text"`
 }
 
 func (a *Adapter) handleJSONRPCToolsCall(w http.ResponseWriter, r *http.Request, req *jsonRPCRequest) {
-	if req.ID == nil {
-		writeJSONRPCError(w, nil, jsonRPCInvalidRequest, "tools/call must be a request (requires id)")
-		return
-	}
-
-	if req.Params == nil {
+	if len(req.Params) == 0 {
 		writeJSONRPCError(w, req.ID, jsonRPCInvalidParams, "missing params")
 		return
 	}
@@ -203,57 +409,38 @@ func (a *Adapter) handleJSONRPCToolsCall(w http.ResponseWriter, r *http.Request,
 		writeJSONRPCError(w, req.ID, jsonRPCInvalidParams, "missing params.name")
 		return
 	}
-
 	handler, ok := a.tools[params.Name]
 	if !ok {
 		writeJSONRPCToolErrorResult(w, req.ID, "tool not found")
 		return
 	}
-
 	args := params.Arguments
 	if args == nil {
 		args = map[string]any{}
 	}
-
 	if err := validateRequiredFields(params.Name, args); err != "" {
 		writeJSONRPCToolErrorResult(w, req.ID, err)
 		return
 	}
-
-	authRes := a.resolveRequestAuth(r)
-	if authRes.Err != nil {
-		writeJSONRPCToolErrorResult(w, req.ID, "internal error")
-		return
-	}
-	if authRes.BearerAuthFailed {
-		writeJSONRPCToolErrorResult(w, req.ID, "authentication required")
-		return
-	}
-
-	data, _, toolErr := handler(authRes.Ctx, args)
+	data, _, toolErr := handler(r.Context(), args)
 	if toolErr != nil {
 		writeJSONRPCToolErrorResult(w, req.ID, toolErr.Message)
 		return
 	}
-
 	writeJSONRPCToolSuccessResult(w, req.ID, data)
 }
 
-// requiredFieldNamesFromSchema extracts the "required" keyword from a JSON Schema object.
-// Accepts []string (in-memory catalog) and []any (e.g. after JSON round-trip).
 func requiredFieldNamesFromSchema(schema map[string]any) []string {
 	raw := schema["required"]
-	switch v := raw.(type) {
+	switch value := raw.(type) {
 	case []string:
-		return v
+		return value
 	case []any:
-		out := make([]string, 0, len(v))
-		for _, el := range v {
-			s, ok := el.(string)
-			if !ok || s == "" {
-				continue
+		out := make([]string, 0, len(value))
+		for _, element := range value {
+			if field, ok := element.(string); ok && field != "" {
+				out = append(out, field)
 			}
-			out = append(out, s)
 		}
 		return out
 	default:
@@ -261,22 +448,16 @@ func requiredFieldNamesFromSchema(schema map[string]any) []string {
 	}
 }
 
-// validateRequiredFields checks that required fields from the tool catalog are present.
-// Returns an error message string, or "" if valid.
 func validateRequiredFields(toolName string, args map[string]any) string {
-	def, ok := toolCatalogDefinitions()[toolName]
+	definition, ok := toolCatalogDefinitions()[toolName]
 	if !ok {
 		return ""
 	}
-	schema, ok := def.InputSchema.(map[string]any)
+	schema, ok := definition.InputSchema.(map[string]any)
 	if !ok {
 		return ""
 	}
-	required := requiredFieldNamesFromSchema(schema)
-	if len(required) == 0 {
-		return ""
-	}
-	for _, field := range required {
+	for _, field := range requiredFieldNamesFromSchema(schema) {
 		if _, exists := args[field]; !exists {
 			return "missing required field: " + field
 		}
@@ -284,53 +465,47 @@ func validateRequiredFields(toolName string, args map[string]any) string {
 	return ""
 }
 
-func toolResultText(v any) string {
-	b, err := json.Marshal(v)
+func toolResultText(value any) string {
+	encoded, err := json.Marshal(value)
 	if err != nil {
 		return "{}"
 	}
-	return string(b)
+	return string(encoded)
 }
 
-func writeJSONRPCToolSuccessResult(w http.ResponseWriter, id any, data any) {
+func writeJSONRPCResult(w http.ResponseWriter, id json.RawMessage, result any) {
+	writeJSONRPCResponse(w, jsonRPCResponse{JSONRPC: "2.0", ID: id, Result: result})
+}
+
+func writeJSONRPCToolSuccessResult(w http.ResponseWriter, id json.RawMessage, data any) {
 	writeJSONRPCResult(w, id, map[string]any{
-		"content": []mcpTextContent{
-			{Type: "text", Text: toolResultText(data)},
-		},
+		"content":           []mcpTextContent{{Type: "text", Text: toolResultText(data)}},
 		"structuredContent": data,
 	})
 }
 
-func writeJSONRPCToolErrorResult(w http.ResponseWriter, id any, message string) {
+func writeJSONRPCToolErrorResult(w http.ResponseWriter, id json.RawMessage, message string) {
 	writeJSONRPCResult(w, id, map[string]any{
-		"content": []mcpTextContent{
-			{Type: "text", Text: message},
-		},
+		"content": []mcpTextContent{{Type: "text", Text: message}},
 		"isError": true,
 	})
 }
 
-func writeJSONRPCErrorWithData(w http.ResponseWriter, id any, code int, message string, data any) {
-	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(jsonRPCResponse{
-		JSONRPC: "2.0",
-		ID:      id,
-		Error: &jsonRPCError{
-			Code:    code,
-			Message: message,
-			Data:    data,
-		},
-	})
+func writeJSONRPCErrorWithData(w http.ResponseWriter, id json.RawMessage, code int, message string, data any) {
+	writeJSONRPCResponse(w, jsonRPCResponse{JSONRPC: "2.0", ID: id, Error: &jsonRPCError{Code: code, Message: message, Data: data}})
 }
 
-func writeJSONRPCError(w http.ResponseWriter, id any, code int, message string) {
+func writeJSONRPCError(w http.ResponseWriter, id json.RawMessage, code int, message string) {
+	writeJSONRPCResponse(w, jsonRPCResponse{JSONRPC: "2.0", ID: id, Error: &jsonRPCError{Code: code, Message: message}})
+}
+
+func writeJSONRPCResponse(w http.ResponseWriter, response jsonRPCResponse) {
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(jsonRPCResponse{
-		JSONRPC: "2.0",
-		ID:      id,
-		Error: &jsonRPCError{
-			Code:    code,
-			Message: message,
-		},
-	})
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func writeEmptyStatus(w http.ResponseWriter, status int) {
+	w.Header().Del("Content-Type")
+	w.WriteHeader(status)
 }

--- a/internal/mcp/jsonrpc_notification_test.go
+++ b/internal/mcp/jsonrpc_notification_test.go
@@ -1,0 +1,53 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"scrumboy/internal/publicorigin"
+)
+
+func TestJSONRPCRequestOnlyMethodsRequireID(t *testing.T) {
+	toolCalls := 0
+	adapter := &Adapter{
+		mode:         "anonymous",
+		publicOrigin: publicorigin.New("", false),
+		tools: toolRegistry{
+			"test.sideEffect": func(context.Context, any) (any, map[string]any, *adapterError) {
+				toolCalls++
+				return map[string]any{"ok": true}, nil, nil
+			},
+		},
+	}
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "initialize", body: `{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}`},
+		{name: "ping", body: `{"jsonrpc":"2.0","method":"ping"}`},
+		{name: "tools/list", body: `{"jsonrpc":"2.0","method":"tools/list"}`},
+		{name: "tools/call", body: `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"test.sideEffect","arguments":{}}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/mcp/rpc", bytes.NewBufferString(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Accept", "application/json, text/event-stream")
+			req.Header.Set("MCP-Protocol-Version", "2025-11-25")
+			rec := httptest.NewRecorder()
+
+			adapter.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s, want 400", rec.Code, rec.Body.String())
+			}
+		})
+	}
+	if toolCalls != 0 {
+		t.Fatalf("tools/call without id executed %d side effects, want 0", toolCalls)
+	}
+}

--- a/internal/mcp/jsonrpc_parse_test.go
+++ b/internal/mcp/jsonrpc_parse_test.go
@@ -1,0 +1,57 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestParseJSONRPCMessage_NullIDPreservedOnStructuralError(t *testing.T) {
+	_, err := parseJSONRPCMessage([]byte(`{"jsonrpc":"2.0","id":null,"method":123}`))
+	var fail *jsonRPCParseFailure
+	if !errors.As(err, &fail) {
+		t.Fatalf("error=%v, want jsonRPCParseFailure", err)
+	}
+	if !fail.HasID {
+		t.Fatal("expected HasID for null id")
+	}
+	if !bytes.Equal(bytes.TrimSpace(fail.ID), []byte("null")) {
+		t.Fatalf("ID=%s, want null", fail.ID)
+	}
+	if fail.Code != jsonRPCInvalidRequest {
+		t.Fatalf("code=%d, want %d", fail.Code, jsonRPCInvalidRequest)
+	}
+}
+
+func TestParseJSONRPCMessage_InvalidIDHasNoRecoverableID(t *testing.T) {
+	_, err := parseJSONRPCMessage([]byte(`{"jsonrpc":"2.0","id":{"bad":true},"method":"ping"}`))
+	var fail *jsonRPCParseFailure
+	if !errors.As(err, &fail) {
+		t.Fatalf("error=%v, want jsonRPCParseFailure", err)
+	}
+	if fail.HasID {
+		t.Fatalf("invalid id must not be recoverable; ID=%s", fail.ID)
+	}
+	if fail.Code != jsonRPCInvalidRequest {
+		t.Fatalf("code=%d, want %d", fail.Code, jsonRPCInvalidRequest)
+	}
+}
+
+func TestParseJSONRPCMessage_ParamsNullRejected(t *testing.T) {
+	_, err := parseJSONRPCMessage([]byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":null}`))
+	var fail *jsonRPCParseFailure
+	if !errors.As(err, &fail) {
+		t.Fatalf("error=%v, want jsonRPCParseFailure", err)
+	}
+	if fail.Code != jsonRPCInvalidRequest {
+		t.Fatalf("code=%d, want %d", fail.Code, jsonRPCInvalidRequest)
+	}
+	if !fail.HasID {
+		t.Fatal("expected recoverable id")
+	}
+	var id any
+	if err := json.Unmarshal(fail.ID, &id); err != nil || id != float64(1) {
+		t.Fatalf("ID=%s decoded=%v", fail.ID, id)
+	}
+}

--- a/internal/mcp/jsonrpc_test.go
+++ b/internal/mcp/jsonrpc_test.go
@@ -17,15 +17,29 @@ func doJSONRPC(t *testing.T, client *http.Client, baseURL string, body any) (*ht
 		t.Fatalf("encode jsonrpc body: %v", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, baseURL+"/mcp/rpc", &buf)
-	if err != nil {
-		t.Fatalf("new jsonrpc request: %v", err)
+	bodyBytes := append([]byte(nil), buf.Bytes()...)
+	do := func(session *http.Cookie) *http.Response {
+		req, err := http.NewRequest(http.MethodPost, baseURL+"/mcp/rpc", bytes.NewReader(bodyBytes))
+		if err != nil {
+			t.Fatalf("new jsonrpc request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("MCP-Protocol-Version", "2025-11-25")
+		if session != nil {
+			req.AddCookie(session)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("do jsonrpc request: %v", err)
+		}
+		return resp
 	}
-	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("do jsonrpc request: %v", err)
+	resp := do(nil)
+	if resp.StatusCode == http.StatusUnauthorized {
+		resp.Body.Close()
+		session := ensureJSONRPCTestSession(t, client, baseURL)
+		resp = do(session)
 	}
 	defer resp.Body.Close()
 
@@ -45,6 +59,46 @@ func doJSONRPC(t *testing.T, client *http.Client, baseURL string, body any) (*ht
 	return resp, out
 }
 
+func ensureJSONRPCTestSession(t *testing.T, client *http.Client, baseURL string) *http.Cookie {
+	t.Helper()
+	post := func(path string, payload map[string]any) *http.Response {
+		var body bytes.Buffer
+		if err := json.NewEncoder(&body).Encode(payload); err != nil {
+			t.Fatalf("encode auth payload: %v", err)
+		}
+		req, err := http.NewRequest(http.MethodPost, baseURL+path, &body)
+		if err != nil {
+			t.Fatalf("new auth request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Scrumboy", "1")
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("authenticate JSON-RPC test client: %v", err)
+		}
+		return resp
+	}
+	payload := map[string]any{"email": "owner@example.com", "password": "password123", "name": "Owner"}
+	resp := post("/api/auth/bootstrap", payload)
+	if resp.StatusCode != http.StatusCreated {
+		resp.Body.Close()
+		resp = post("/api/auth/login", map[string]any{"email": payload["email"], "password": payload["password"]})
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		t.Fatalf("test authentication status = %d", resp.StatusCode)
+	}
+	for _, cookie := range resp.Cookies() {
+		if cookie.Name == "scrumboy_session" {
+			return cookie
+		}
+	}
+	// A client with a cookie jar may have retained the session without
+	// exposing it on a second login response. In that case the retry can rely
+	// on the jar and does not need an explicit Cookie header.
+	return nil
+}
+
 func TestJSONRPC_InitializeHandshake(t *testing.T) {
 	ts, _, cleanup := newTestServer(t, "full")
 	defer cleanup()
@@ -55,7 +109,7 @@ func TestJSONRPC_InitializeHandshake(t *testing.T) {
 		"id":      1,
 		"method":  "initialize",
 		"params": map[string]any{
-			"protocolVersion": "2024-11-05",
+			"protocolVersion": "2025-11-25",
 			"capabilities":    map[string]any{},
 			"clientInfo": map[string]any{
 				"name":    "test-client",
@@ -78,8 +132,8 @@ func TestJSONRPC_InitializeHandshake(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected result object, got %v", out["result"])
 	}
-	if result["protocolVersion"] != "2024-11-05" {
-		t.Fatalf("expected protocolVersion 2024-11-05, got %v", result["protocolVersion"])
+	if result["protocolVersion"] != "2025-11-25" {
+		t.Fatalf("expected protocolVersion 2025-11-25, got %v", result["protocolVersion"])
 	}
 	serverInfo, ok := result["serverInfo"].(map[string]any)
 	if !ok {
@@ -97,7 +151,7 @@ func TestJSONRPC_InitializeHandshake(t *testing.T) {
 	}
 }
 
-func TestJSONRPC_InitializeMinimalParams(t *testing.T) {
+func TestJSONRPC_InitializeRequiresLifecycleFields(t *testing.T) {
 	ts, _, cleanup := newTestServer(t, "full")
 	defer cleanup()
 
@@ -108,12 +162,75 @@ func TestJSONRPC_InitializeMinimalParams(t *testing.T) {
 		"method":  "initialize",
 	})
 
-	if out["error"] != nil {
-		t.Fatalf("initialize with no params should succeed, got error: %v", out["error"])
+	errObj, ok := out["error"].(map[string]any)
+	if !ok || errObj["code"] != float64(-32602) {
+		t.Fatalf("initialize without lifecycle fields = %+v, want InvalidParams", out)
 	}
-	result := out["result"].(map[string]any)
-	if result["protocolVersion"] != "2024-11-05" {
-		t.Fatalf("unexpected protocolVersion: %v", result["protocolVersion"])
+}
+
+func TestJSONRPC_InitializeRequiresClientInfoVersion(t *testing.T) {
+	ts, _, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newStatelessClient(ts)
+	cases := []map[string]any{
+		{
+			"protocolVersion": "2025-11-25",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "Example client"},
+		},
+		{
+			"protocolVersion": "2025-11-25",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "Example client", "version": " "},
+		},
+	}
+	for _, params := range cases {
+		_, out := doJSONRPC(t, client, ts.URL, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "initialize",
+			"params":  params,
+		})
+		errObj, ok := out["error"].(map[string]any)
+		if !ok || errObj["code"] != float64(-32602) {
+			t.Fatalf("initialize missing/blank version = %+v, want InvalidParams", out)
+		}
+	}
+}
+
+func TestJSONRPC_PingReturnsEmptyResult(t *testing.T) {
+	ts, _, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newStatelessClient(ts)
+	ids := []any{"ping-1", 7, 0}
+	for _, id := range ids {
+		resp, out := doJSONRPC(t, client, ts.URL, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      id,
+			"method":  "ping",
+		})
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("ping id=%v status=%d, want 200", id, resp.StatusCode)
+		}
+		if out["error"] != nil {
+			t.Fatalf("ping id=%v unexpected error: %v", id, out["error"])
+		}
+		result, ok := out["result"].(map[string]any)
+		if !ok || len(result) != 0 {
+			t.Fatalf("ping id=%v result=%v, want {}", id, out["result"])
+		}
+		switch want := id.(type) {
+		case string:
+			if out["id"] != want {
+				t.Fatalf("ping id=%v echoed %v", id, out["id"])
+			}
+		case int:
+			if out["id"] != float64(want) {
+				t.Fatalf("ping id=%v echoed %v", id, out["id"])
+			}
+		}
 	}
 }
 
@@ -127,8 +244,8 @@ func TestJSONRPC_InitializedNotification(t *testing.T) {
 		"method":  "notifications/initialized",
 	})
 
-	if resp.StatusCode != http.StatusNoContent {
-		t.Fatalf("expected 204 for notification, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("expected 202 for notification, got %d", resp.StatusCode)
 	}
 	if out != nil {
 		t.Fatalf("expected no body for notification, got %v", out)
@@ -145,8 +262,8 @@ func TestJSONRPC_InitializedAltName(t *testing.T) {
 		"method":  "initialized",
 	})
 
-	if resp.StatusCode != http.StatusNoContent {
-		t.Fatalf("expected 204 for 'initialized' notification, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("expected 202 for 'initialized' notification, got %d", resp.StatusCode)
 	}
 }
 
@@ -191,7 +308,7 @@ func TestJSONRPC_UnknownMethodReturnsError(t *testing.T) {
 }
 
 func TestJSONRPC_InvalidJSONReturnsParseError(t *testing.T) {
-	ts, _, cleanup := newTestServer(t, "full")
+	ts, _, cleanup := newTestServer(t, "anonymous")
 	defer cleanup()
 
 	client := newStatelessClient(ts)
@@ -218,6 +335,101 @@ func TestJSONRPC_InvalidJSONReturnsParseError(t *testing.T) {
 	}
 }
 
+func TestJSONRPC_InvalidParamsTypeReturnsInvalidRequest(t *testing.T) {
+	ts, _, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newStatelessClient(ts)
+	for _, params := range []any{123, nil} {
+		_, out := doJSONRPC(t, client, ts.URL, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      7,
+			"method":  "tools/list",
+			"params":  params,
+		})
+		errObj, ok := out["error"].(map[string]any)
+		if !ok || errObj["code"] != float64(-32600) {
+			t.Fatalf("params=%v response=%+v, want InvalidRequest", params, out)
+		}
+		if out["result"] != nil {
+			t.Fatalf("params=%v unexpectedly succeeded: %+v", params, out)
+		}
+	}
+}
+
+func TestJSONRPC_NotificationWithInvalidParamsRejected(t *testing.T) {
+	ts, _, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newStatelessClient(ts)
+	for _, params := range []any{123, nil} {
+		resp, out := doJSONRPC(t, client, ts.URL, map[string]any{
+			"jsonrpc": "2.0",
+			"method":  "notifications/initialized",
+			"params":  params,
+		})
+		if resp.StatusCode == http.StatusAccepted {
+			t.Fatalf("params=%v accepted as notification; want reject", params)
+		}
+		errObj, ok := out["error"].(map[string]any)
+		if !ok || errObj["code"] != float64(-32600) {
+			t.Fatalf("params=%v response=%+v, want InvalidRequest", params, out)
+		}
+	}
+}
+
+func TestJSONRPC_StructuralErrorPreservesRecoverableID(t *testing.T) {
+	ts, _, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newStatelessClient(ts)
+	cases := []struct {
+		id   any
+		want any
+	}{
+		{"request-42", "request-42"},
+		{7, float64(7)},
+		{0, float64(0)},
+	}
+	for _, tc := range cases {
+		raw, err := json.Marshal(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      tc.id,
+			"method":  123,
+		})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/mcp/rpc", bytes.NewReader(raw))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("MCP-Protocol-Version", "2025-11-25")
+		session := ensureJSONRPCTestSession(t, client, ts.URL)
+		if session != nil {
+			req.AddCookie(session)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			resp.Body.Close()
+			t.Fatalf("decode: %v", err)
+		}
+		resp.Body.Close()
+		errObj, ok := out["error"].(map[string]any)
+		if !ok || errObj["code"] != float64(-32600) {
+			t.Fatalf("id=%v response=%+v, want InvalidRequest", tc.id, out)
+		}
+		if out["id"] != tc.want {
+			t.Fatalf("id=%v echoed %v, want %v", tc.id, out["id"], tc.want)
+		}
+	}
+}
+
 func TestJSONRPC_MissingVersionReturnsInvalidRequest(t *testing.T) {
 	ts, _, cleanup := newTestServer(t, "full")
 	defer cleanup()
@@ -234,27 +446,21 @@ func TestJSONRPC_MissingVersionReturnsInvalidRequest(t *testing.T) {
 	}
 }
 
-func TestJSONRPC_GetMethodRejected(t *testing.T) {
+func TestJSONRPC_UnauthenticatedGetChallenges(t *testing.T) {
 	ts, _, cleanup := newTestServer(t, "full")
 	defer cleanup()
 
-	client := newStatelessClient(ts)
 	resp, err := http.Get(ts.URL + "/mcp/rpc")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
 
-	_ = client // use ts.Client() transport via http.Get on ts.URL
-
-	var out map[string]any
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		t.Fatalf("decode: %v", err)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("GET status = %d, want 401", resp.StatusCode)
 	}
-
-	errObj := out["error"].(map[string]any)
-	if errObj["code"].(float64) != -32600 {
-		t.Fatalf("expected InvalidRequest code for GET, got %v", errObj["code"])
+	if got := resp.Header.Get("WWW-Authenticate"); got != `Bearer resource_metadata="`+ts.URL+`/.well-known/oauth-protected-resource/mcp/rpc"` {
+		t.Fatalf("WWW-Authenticate = %q", got)
 	}
 }
 
@@ -841,7 +1047,7 @@ func TestJSONRPC_ToolsCall_WithoutID(t *testing.T) {
 	defer cleanup()
 
 	client := newStatelessClient(ts)
-	_, out := doJSONRPC(t, client, ts.URL, map[string]any{
+	resp, out := doJSONRPC(t, client, ts.URL, map[string]any{
 		"jsonrpc": "2.0",
 		"method":  "tools/call",
 		"params": map[string]any{
@@ -850,12 +1056,8 @@ func TestJSONRPC_ToolsCall_WithoutID(t *testing.T) {
 		},
 	})
 
-	errObj, ok := out["error"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected error for tools/call without id, got %v", out)
-	}
-	if errObj["code"].(float64) != -32600 {
-		t.Fatalf("expected InvalidRequest code, got %v", errObj["code"])
+	if resp.StatusCode != http.StatusAccepted || out != nil {
+		t.Fatalf("tools/call notification status=%d body=%v, want empty 202", resp.StatusCode, out)
 	}
 }
 
@@ -863,33 +1065,10 @@ func TestJSONRPC_ToolsCall_ErrorMapping_AuthRequired(t *testing.T) {
 	ts, _, cleanup := newTestServer(t, "full")
 	defer cleanup()
 
-	client := newStatelessClient(ts)
 	bootstrapUser(t, newCookieClient(t, ts), ts.URL)
-
-	_, out := doJSONRPC(t, client, ts.URL, map[string]any{
-		"jsonrpc": "2.0",
-		"id":      1,
-		"method":  "tools/call",
-		"params": map[string]any{
-			"name":      "projects.list",
-			"arguments": map[string]any{},
-		},
-	})
-
-	if out["error"] != nil {
-		t.Fatalf("expected tool result error, got %v", out["error"])
-	}
-	result := out["result"].(map[string]any)
-	if result["isError"] != true {
-		t.Fatalf("expected isError=true, got %v", result["isError"])
-	}
-	content := result["content"].([]any)
-	item := content[0].(map[string]any)
-	if item["text"] != "Sign-in required for this tool" {
-		t.Fatalf("expected auth error message, got %v", item["text"])
-	}
-	if out["ok"] != nil {
-		t.Fatal("JSON-RPC response must not contain legacy ok field")
+	resp, body := rawJSONRPC(t, newStatelessClient(ts), ts.URL, "")
+	if resp.StatusCode != http.StatusUnauthorized || len(body) != 0 {
+		t.Fatalf("status=%d body=%q, want empty 401", resp.StatusCode, body)
 	}
 }
 

--- a/internal/mcp/jsonrpc_test.go
+++ b/internal/mcp/jsonrpc_test.go
@@ -362,19 +362,32 @@ func TestJSONRPC_NotificationWithInvalidParamsRejected(t *testing.T) {
 	defer cleanup()
 
 	client := newStatelessClient(ts)
-	for _, params := range []any{123, nil} {
-		resp, out := doJSONRPC(t, client, ts.URL, map[string]any{
-			"jsonrpc": "2.0",
-			"method":  "notifications/initialized",
-			"params":  params,
+	for _, tc := range []struct {
+		name   string
+		method string
+		params any
+	}{
+		{name: "known scalar", method: "notifications/initialized", params: 123},
+		{name: "known null", method: "notifications/initialized", params: nil},
+		{name: "unknown scalar", method: "notifications/example", params: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, out := doJSONRPC(t, client, ts.URL, map[string]any{
+				"jsonrpc": "2.0",
+				"method":  tc.method,
+				"params":  tc.params,
+			})
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status=%d, want 400", resp.StatusCode)
+			}
+			errObj, ok := out["error"].(map[string]any)
+			if !ok || errObj["code"] != float64(-32600) {
+				t.Fatalf("response=%+v, want InvalidRequest", out)
+			}
+			if id, present := out["id"]; !present || id != nil {
+				t.Fatalf("id=%v present=%v, want explicit null", id, present)
+			}
 		})
-		if resp.StatusCode == http.StatusAccepted {
-			t.Fatalf("params=%v accepted as notification; want reject", params)
-		}
-		errObj, ok := out["error"].(map[string]any)
-		if !ok || errObj["code"] != float64(-32600) {
-			t.Fatalf("params=%v response=%+v, want InvalidRequest", params, out)
-		}
 	}
 }
 
@@ -1056,8 +1069,12 @@ func TestJSONRPC_ToolsCall_WithoutID(t *testing.T) {
 		},
 	})
 
-	if resp.StatusCode != http.StatusAccepted || out != nil {
-		t.Fatalf("tools/call notification status=%d body=%v, want empty 202", resp.StatusCode, out)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("tools/call without id status=%d body=%v, want 400", resp.StatusCode, out)
+	}
+	errObj, ok := out["error"].(map[string]any)
+	if !ok || errObj["code"] != float64(-32600) {
+		t.Fatalf("tools/call without id body=%v, want InvalidRequest", out)
 	}
 }
 

--- a/internal/mcp/jsonrpc_transport_test.go
+++ b/internal/mcp/jsonrpc_transport_test.go
@@ -1,0 +1,222 @@
+package mcp_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func rpcHTTP(t *testing.T, client *http.Client, method, target string, body []byte, headers http.Header) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(method, target, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new RPC request: %v", err)
+	}
+	for key, values := range headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("RPC request: %v", err)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read RPC response: %v", err)
+	}
+	return resp, raw
+}
+
+func standardRPCHeaders() http.Header {
+	return http.Header{
+		"Content-Type": {"application/json"},
+		"Accept":       {"application/json, text/event-stream"},
+	}
+}
+
+func initializeBody(version string) []byte {
+	body, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "init",
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": version,
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "transport-test", "version": "1"},
+		},
+	})
+	return body
+}
+
+func TestJSONRPCTransportMethodOriginAndCanonicalPath(t *testing.T) {
+	ts, _, cleanup := newTestServer(t, "full")
+	defer cleanup()
+	cookieClient := newCookieClient(t, ts)
+	bootstrapUser(t, cookieClient, ts.URL)
+
+	for _, method := range []string{http.MethodGet, http.MethodDelete, http.MethodPut} {
+		resp, body := rpcHTTP(t, cookieClient, method, ts.URL+"/mcp/rpc", nil, nil)
+		if resp.StatusCode != http.StatusMethodNotAllowed || resp.Header.Get("Allow") != http.MethodPost || len(body) != 0 {
+			t.Errorf("%s status=%d Allow=%q body=%q", method, resp.StatusCode, resp.Header.Get("Allow"), body)
+		}
+	}
+
+	badOrigin := standardRPCHeaders()
+	badOrigin.Set("Origin", "https://attacker.example")
+	resp, body := rpcHTTP(t, newStatelessClient(ts), http.MethodPost, ts.URL+"/mcp/rpc", initializeBody("2025-11-25"), badOrigin)
+	if resp.StatusCode != http.StatusForbidden || len(body) != 0 || resp.Header.Get("WWW-Authenticate") != "" {
+		t.Fatalf("invalid Origin status=%d challenge=%q body=%q", resp.StatusCode, resp.Header.Get("WWW-Authenticate"), body)
+	}
+
+	goodOrigin := standardRPCHeaders()
+	goodOrigin.Set("Origin", ts.URL)
+	resp, body = rpcHTTP(t, cookieClient, http.MethodPost, ts.URL+"/mcp/rpc", initializeBody("2025-11-25"), goodOrigin)
+	if resp.StatusCode != http.StatusOK || !bytes.Contains(body, []byte(`"result"`)) {
+		t.Fatalf("same-origin request status=%d body=%s", resp.StatusCode, body)
+	}
+
+	noRedirect := newStatelessClient(ts)
+	noRedirect.CheckRedirect = func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }
+	resp, body = rpcHTTP(t, noRedirect, http.MethodPost, ts.URL+"/mcp/rpc/", initializeBody("2025-11-25"), standardRPCHeaders())
+	if resp.StatusCode != http.StatusPermanentRedirect || resp.Header.Get("Location") != "/mcp/rpc" || len(body) != 0 {
+		t.Fatalf("trailing-slash status=%d location=%q body=%q", resp.StatusCode, resp.Header.Get("Location"), body)
+	}
+}
+
+func TestJSONRPCTransportMediaAndMessageClassification(t *testing.T) {
+	ts, _, cleanup := newTestServer(t, "full")
+	defer cleanup()
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	body := initializeBody("2025-11-25")
+
+	for name, headers := range map[string]http.Header{
+		"wrong content type": {"Content-Type": {"text/plain"}, "Accept": {"application/json, text/event-stream"}},
+		"wrong charset":      {"Content-Type": {"application/json; charset=iso-8859-1"}, "Accept": {"application/json, text/event-stream"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp, raw := rpcHTTP(t, client, http.MethodPost, ts.URL+"/mcp/rpc", body, headers)
+			if resp.StatusCode != http.StatusUnsupportedMediaType || len(raw) != 0 {
+				t.Fatalf("status=%d body=%q", resp.StatusCode, raw)
+			}
+		})
+	}
+	for name, accept := range map[string]string{"JSON only": "application/json", "SSE only": "text/event-stream", "quality zero": "application/json, text/event-stream;q=0"} {
+		t.Run(name, func(t *testing.T) {
+			headers := http.Header{"Content-Type": {"application/json"}, "Accept": {accept}}
+			resp, raw := rpcHTTP(t, client, http.MethodPost, ts.URL+"/mcp/rpc", body, headers)
+			if resp.StatusCode != http.StatusNotAcceptable || len(raw) != 0 {
+				t.Fatalf("status=%d body=%q", resp.StatusCode, raw)
+			}
+		})
+	}
+
+	for name, message := range map[string]string{
+		"initialized": `{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		"unknown":     `{"jsonrpc":"2.0","method":"notifications/example","params":{}}`,
+	} {
+		t.Run(name+" notification", func(t *testing.T) {
+			resp, raw := rpcHTTP(t, client, http.MethodPost, ts.URL+"/mcp/rpc", []byte(message), standardRPCHeaders())
+			if resp.StatusCode != http.StatusAccepted || len(raw) != 0 || resp.Header.Get("Content-Type") != "" {
+				t.Fatalf("status=%d content-type=%q body=%q", resp.StatusCode, resp.Header.Get("Content-Type"), raw)
+			}
+		})
+	}
+
+	for name, message := range map[string]string{
+		"unsolicited response": `{"jsonrpc":"2.0","id":1,"result":{}}`,
+		"batch":                `[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp, raw := rpcHTTP(t, client, http.MethodPost, ts.URL+"/mcp/rpc", []byte(message), standardRPCHeaders())
+			if resp.StatusCode != http.StatusBadRequest || len(raw) != 0 {
+				t.Fatalf("status=%d body=%q", resp.StatusCode, raw)
+			}
+		})
+	}
+
+	oversized := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list","padding":"` + strings.Repeat("x", (1<<20)+1) + `"}`)
+	resp, raw := rpcHTTP(t, client, http.MethodPost, ts.URL+"/mcp/rpc", oversized, standardRPCHeaders())
+	if resp.StatusCode != http.StatusRequestEntityTooLarge || len(raw) != 0 {
+		t.Fatalf("oversized status=%d body=%q", resp.StatusCode, raw)
+	}
+
+	resp, raw = rpcHTTP(t, client, http.MethodPost, ts.URL+"/mcp/rpc", []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"} {}`), standardRPCHeaders())
+	if resp.StatusCode != http.StatusOK || !bytes.Contains(raw, []byte(`"code":-32700`)) {
+		t.Fatalf("trailing JSON status=%d body=%s", resp.StatusCode, raw)
+	}
+}
+
+func TestJSONRPCProtocolVersionNegotiation(t *testing.T) {
+	ts, _, cleanup := newTestServer(t, "full")
+	defer cleanup()
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+
+	for requested, want := range map[string]string{
+		"2025-03-26": "2025-03-26",
+		"2025-06-18": "2025-06-18",
+		"2025-11-25": "2025-11-25",
+		"2024-11-05": "2025-11-25",
+		"future":     "2025-11-25",
+	} {
+		t.Run(requested, func(t *testing.T) {
+			resp, raw := rpcHTTP(t, client, http.MethodPost, ts.URL+"/mcp/rpc", initializeBody(requested), standardRPCHeaders())
+			if resp.StatusCode != http.StatusOK || resp.Header.Get("Content-Type") != "application/json" {
+				t.Fatalf("status=%d content-type=%q body=%s", resp.StatusCode, resp.Header.Get("Content-Type"), raw)
+			}
+			var out struct {
+				Result struct {
+					ProtocolVersion string `json:"protocolVersion"`
+				} `json:"result"`
+			}
+			if err := json.Unmarshal(raw, &out); err != nil || out.Result.ProtocolVersion != want {
+				t.Fatalf("response=%s err=%v want protocolVersion=%s", raw, err, want)
+			}
+			if resp.Header.Get("Mcp-Session-Id") != "" {
+				t.Fatalf("stateless transport emitted session id %q", resp.Header.Get("Mcp-Session-Id"))
+			}
+		})
+	}
+
+	request := []byte(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	for name, values := range map[string][]string{
+		"unsupported": {"2024-11-05"},
+		"malformed":   {"not-a-version"},
+		"duplicate":   {"2025-11-25", "2025-06-18"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			headers := standardRPCHeaders()
+			for _, value := range values {
+				headers.Add("MCP-Protocol-Version", value)
+			}
+			resp, raw := rpcHTTP(t, client, http.MethodPost, ts.URL+"/mcp/rpc", request, headers)
+			if resp.StatusCode != http.StatusBadRequest || len(raw) != 0 {
+				t.Fatalf("status=%d body=%q", resp.StatusCode, raw)
+			}
+		})
+	}
+
+	resp, raw := rpcHTTP(t, client, http.MethodPost, ts.URL+"/mcp/rpc", request, standardRPCHeaders())
+	if resp.StatusCode != http.StatusOK || !bytes.Contains(raw, []byte(`"result"`)) {
+		t.Fatalf("missing protocol header fallback status=%d body=%s", resp.StatusCode, raw)
+	}
+}
+
+func TestJSONRPCPreservesLargeNumericID(t *testing.T) {
+	ts, _, cleanup := newTestServer(t, "full")
+	defer cleanup()
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	const id = "9007199254740993123456789"
+	request := []byte(`{"jsonrpc":"2.0","id":` + id + `,"method":"tools/list"}`)
+	resp, raw := rpcHTTP(t, client, http.MethodPost, ts.URL+"/mcp/rpc", request, standardRPCHeaders())
+	if resp.StatusCode != http.StatusOK || !bytes.Contains(raw, []byte(`"id":`+id)) {
+		t.Fatalf("status=%d response=%s", resp.StatusCode, raw)
+	}
+}

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"scrumboy/internal/db"
 )
@@ -229,6 +230,9 @@ func TestApplyCreatesCurrentSchemaLandmarks(t *testing.T) {
 		{table: "todos", column: "import_metadata"},
 		{table: "project_walls", column: "edges"},
 		{table: "users", column: "two_factor_enabled"},
+		{table: "oauth_auth_codes", column: "resource"},
+		{table: "oauth_access_tokens", column: "resource"},
+		{table: "oauth_refresh_tokens", column: "resource"},
 	} {
 		if !columnExists(t, sqlDB, tc.table, tc.column) {
 			t.Fatalf("expected column %s.%s to exist", tc.table, tc.column)
@@ -252,6 +256,67 @@ func TestApplyCreatesCurrentSchemaLandmarks(t *testing.T) {
 		if !triggerExists(t, sqlDB, trigger) {
 			t.Fatalf("expected trigger %s to exist", trigger)
 		}
+	}
+}
+
+func TestMigration057InvalidatesUnboundArtifactsAndPreservesClients(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openRawTestDB(t)
+	if _, err := sqlDB.ExecContext(ctx, `CREATE TABLE schema_migrations (version TEXT PRIMARY KEY, applied_at INTEGER NOT NULL)`); err != nil {
+		t.Fatalf("create schema_migrations: %v", err)
+	}
+	for _, version := range embeddedMigrationVersions(t) {
+		if version == "057_bind_oauth_tokens_to_mcp_resource.sql" {
+			break
+		}
+		if err := applyOne(ctx, sqlDB, version); err != nil {
+			t.Fatalf("apply %s: %v", version, err)
+		}
+	}
+
+	now := time.Now().UTC().UnixMilli()
+	if _, err := sqlDB.ExecContext(ctx, `INSERT INTO users(id, email, created_at, name, system_role) VALUES (1, 'owner@example.com', ?, 'Owner', 'owner')`, now); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx, `INSERT INTO oauth_clients(id, client_name, redirect_uri, created_at) VALUES ('client-1', 'Client', 'http://127.0.0.1/callback', ?)`, now); err != nil {
+		t.Fatalf("insert client: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx, `INSERT INTO oauth_auth_codes(code_hash, client_id, user_id, redirect_uri, code_challenge, code_challenge_method, created_at, expires_at) VALUES ('code', 'client-1', 1, 'http://127.0.0.1/callback', 'challenge', 'S256', ?, ?)`, now, now+60000); err != nil {
+		t.Fatalf("insert code: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx, `INSERT INTO oauth_access_tokens(token_hash, client_id, user_id, created_at, expires_at) VALUES ('access', 'client-1', 1, ?, ?)`, now, now+60000); err != nil {
+		t.Fatalf("insert access token: %v", err)
+	}
+	if _, err := sqlDB.ExecContext(ctx, `INSERT INTO oauth_refresh_tokens(token_hash, client_id, user_id, created_at, expires_at) VALUES ('refresh', 'client-1', 1, ?, ?)`, now, now+60000); err != nil {
+		t.Fatalf("insert refresh token: %v", err)
+	}
+
+	if err := applyOne(ctx, sqlDB, "057_bind_oauth_tokens_to_mcp_resource.sql"); err != nil {
+		t.Fatalf("apply migration 057: %v", err)
+	}
+	for _, table := range []string{"oauth_auth_codes", "oauth_access_tokens", "oauth_refresh_tokens"} {
+		var count int
+		if err := sqlDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Fatalf("%s retained %d unbound artifacts", table, count)
+		}
+		if !columnExists(t, sqlDB, table, "resource") {
+			t.Fatalf("%s.resource is missing", table)
+		}
+	}
+	for _, table := range []string{"users", "oauth_clients"} {
+		var count int
+		if err := sqlDB.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if count != 1 {
+			t.Fatalf("%s count = %d, want 1", table, count)
+		}
+	}
+	if got := pragmaInt(t, sqlDB, "foreign_keys"); got != 1 {
+		t.Fatalf("foreign_keys = %d, want 1", got)
 	}
 }
 

--- a/internal/migrate/migrations/057_bind_oauth_tokens_to_mcp_resource.sql
+++ b/internal/migrate/migrations/057_bind_oauth_tokens_to_mcp_resource.sql
@@ -1,0 +1,48 @@
+-- Migration 057: bind OAuth grants and tokens to the canonical MCP resource.
+-- Existing artifacts were issued without a resource indicator. They are
+-- intentionally discarded rather than retroactively granted an audience.
+
+DROP TABLE oauth_auth_codes;
+DROP TABLE oauth_access_tokens;
+DROP TABLE oauth_refresh_tokens;
+
+CREATE TABLE oauth_auth_codes (
+  code_hash TEXT PRIMARY KEY,
+  client_id TEXT NOT NULL REFERENCES oauth_clients(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  redirect_uri TEXT NOT NULL,
+  code_challenge TEXT NOT NULL,
+  code_challenge_method TEXT NOT NULL,
+  resource TEXT NOT NULL CHECK(resource <> ''),
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  consumed_at INTEGER
+);
+
+CREATE INDEX idx_oauth_auth_codes_expires_at ON oauth_auth_codes(expires_at);
+
+CREATE TABLE oauth_access_tokens (
+  token_hash TEXT PRIMARY KEY,
+  client_id TEXT NOT NULL REFERENCES oauth_clients(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  resource TEXT NOT NULL CHECK(resource <> ''),
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  revoked_at INTEGER
+);
+
+CREATE INDEX idx_oauth_access_tokens_user_id ON oauth_access_tokens(user_id);
+CREATE INDEX idx_oauth_access_tokens_expires_at ON oauth_access_tokens(expires_at);
+
+CREATE TABLE oauth_refresh_tokens (
+  token_hash TEXT PRIMARY KEY,
+  client_id TEXT NOT NULL REFERENCES oauth_clients(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  resource TEXT NOT NULL CHECK(resource <> ''),
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  revoked_at INTEGER
+);
+
+CREATE INDEX idx_oauth_refresh_tokens_user_id ON oauth_refresh_tokens(user_id);
+CREATE INDEX idx_oauth_refresh_tokens_expires_at ON oauth_refresh_tokens(expires_at);

--- a/internal/oauth/errors.go
+++ b/internal/oauth/errors.go
@@ -16,6 +16,7 @@ const (
 	ErrAccessDenied         = "access_denied"
 	ErrUnsupportedResponse  = "unsupported_response_type"
 	ErrServerError          = "server_error"
+	ErrInvalidTarget        = "invalid_target"
 )
 
 // Error codes from RFC 7591 §3.2.2 (dynamic client registration).

--- a/internal/publicorigin/resolver.go
+++ b/internal/publicorigin/resolver.go
@@ -1,0 +1,316 @@
+package publicorigin
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const (
+	MCPResourcePath         = "/mcp/rpc"
+	MCPResourceMetadataPath = "/.well-known/oauth-protected-resource/mcp/rpc"
+)
+
+// ErrUnavailable means no public origin can be derived from inputs the
+// server is configured to trust. Callers must fail closed rather than guess.
+var ErrUnavailable = errors.New("no trustworthy public origin for this request")
+
+// Resolver constructs public OAuth/MCP URLs from the same trusted inputs.
+type Resolver struct {
+	publicBaseURL string
+	trustProxy    bool
+}
+
+func New(publicBaseURL string, trustProxy bool) *Resolver {
+	return &Resolver{publicBaseURL: strings.TrimSpace(publicBaseURL), trustProxy: trustProxy}
+}
+
+// ConfiguredOrigin validates and canonicalizes a configured public base URL
+// using the same OAuth-safe rules as Resolver.Origin.
+func ConfiguredOrigin(base string) (string, error) {
+	return configuredOrigin(strings.TrimSpace(base))
+}
+
+// Origin returns the trusted, canonical public origin for r. Scheme and host
+// are lowercased; an explicit port is preserved exactly.
+func (r *Resolver) Origin(req *http.Request) (string, error) {
+	if r != nil && r.publicBaseURL != "" {
+		return configuredOrigin(r.publicBaseURL)
+	}
+	authority, hostname, ok := ParseHTTPAuthority(req.Host)
+	if req.TLS != nil && ok {
+		return "https://" + canonicalAuthority(authority, hostname), nil
+	}
+	if r != nil && r.trustProxy {
+		if origin, ok := forwardedOrigin(req); ok {
+			return origin, nil
+		}
+	}
+	if ok && IsLoopbackHostname(hostname) {
+		return "http://" + canonicalAuthority(authority, hostname), nil
+	}
+	return "", ErrUnavailable
+}
+
+func (r *Resolver) MCPResource(req *http.Request) (string, error) {
+	origin, err := r.Origin(req)
+	if err != nil {
+		return "", err
+	}
+	return origin + MCPResourcePath, nil
+}
+
+func (r *Resolver) MCPResourceMetadataURL(req *http.Request) (string, error) {
+	origin, err := r.Origin(req)
+	if err != nil {
+		return "", err
+	}
+	return origin + MCPResourceMetadataPath, nil
+}
+
+// ValidateMCPResource accepts only the canonical MCP resource. It
+// canonicalizes scheme and hostname case, but deliberately does not normalize
+// ports, paths, escaping, queries, fragments, or trailing slashes.
+func (r *Resolver) ValidateMCPResource(req *http.Request, raw string) (string, error) {
+	got, err := canonicalAbsoluteMCPResource(raw)
+	if err != nil {
+		return "", err
+	}
+	want, err := r.MCPResource(req)
+	if err != nil {
+		return "", err
+	}
+	if got != want {
+		return "", errors.New("resource does not identify this MCP server")
+	}
+	return want, nil
+}
+
+// OriginAllowed validates a supplied Origin header against the same trusted
+// public origin. Requests without Origin are allowed for non-browser clients.
+func (r *Resolver) OriginAllowed(req *http.Request) (bool, error) {
+	values := req.Header.Values("Origin")
+	if len(values) == 0 {
+		return true, nil
+	}
+	if len(values) != 1 || strings.Contains(values[0], ",") {
+		return false, nil
+	}
+	got, err := canonicalAbsoluteOrigin(values[0])
+	if err != nil {
+		return false, nil
+	}
+	want, err := r.Origin(req)
+	if err != nil {
+		return false, err
+	}
+	return got == want, nil
+}
+
+func configuredOrigin(base string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil || !u.IsAbs() || u.Opaque != "" || u.Host == "" || u.User != nil || u.Path != "" || u.RawPath != "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || strings.ContainsAny(base, "?#%") {
+		return "", ErrUnavailable
+	}
+	scheme := strings.ToLower(u.Scheme)
+	authority, hostname, ok := ParseHTTPAuthority(u.Host)
+	if !ok {
+		return "", ErrUnavailable
+	}
+	switch scheme {
+	case "https":
+	case "http":
+		if !IsLoopbackHostname(hostname) {
+			return "", ErrUnavailable
+		}
+	default:
+		return "", ErrUnavailable
+	}
+	return scheme + "://" + canonicalAuthority(authority, hostname), nil
+}
+
+func canonicalAbsoluteMCPResource(raw string) (string, error) {
+	if raw == "" || strings.ContainsAny(raw, "?#%") || containsSpaceOrControl(raw) {
+		return "", errors.New("invalid resource URI")
+	}
+	u, err := url.Parse(raw)
+	if err != nil || !u.IsAbs() || u.Opaque != "" || u.Host == "" || u.User != nil || u.Path != MCPResourcePath || u.RawPath != "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+		return "", errors.New("invalid resource URI")
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "https" && scheme != "http" {
+		return "", errors.New("unsupported resource URI scheme")
+	}
+	authority, hostname, ok := ParseHTTPAuthority(u.Host)
+	if !ok {
+		return "", errors.New("invalid resource URI authority")
+	}
+	return scheme + "://" + canonicalAuthority(authority, hostname) + MCPResourcePath, nil
+}
+
+func canonicalAbsoluteOrigin(raw string) (string, error) {
+	if raw == "" || strings.ContainsAny(raw, "?#%") || containsSpaceOrControl(raw) {
+		return "", errors.New("invalid origin")
+	}
+	u, err := url.Parse(raw)
+	if err != nil || !u.IsAbs() || u.Opaque != "" || u.Host == "" || u.User != nil || u.Path != "" || u.RawPath != "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+		return "", errors.New("invalid origin")
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "https" && scheme != "http" {
+		return "", errors.New("unsupported origin scheme")
+	}
+	authority, hostname, ok := ParseHTTPAuthority(u.Host)
+	if !ok {
+		return "", errors.New("invalid origin authority")
+	}
+	return scheme + "://" + canonicalAuthority(authority, hostname), nil
+}
+
+func forwardedOrigin(req *http.Request) (string, bool) {
+	proto, ok := forwardedScheme(req)
+	if !ok || proto != "https" {
+		return "", false
+	}
+	hostValues := req.Header.Values("X-Forwarded-Host")
+	if len(hostValues) != 1 {
+		return "", false
+	}
+	authority, hostname, ok := ParseHTTPAuthority(hostValues[0])
+	if !ok {
+		return "", false
+	}
+	return "https://" + canonicalAuthority(authority, hostname), true
+}
+
+func forwardedScheme(req *http.Request) (string, bool) {
+	protoValues := req.Header.Values("X-Forwarded-Proto")
+	if len(protoValues) > 0 {
+		if len(protoValues) != 1 {
+			return "", false
+		}
+		proto := strings.ToLower(strings.TrimSpace(protoValues[0]))
+		if proto == "" || strings.Contains(proto, ",") {
+			return "", false
+		}
+		return proto, true
+	}
+	cfValues := req.Header.Values("CF-Visitor")
+	if len(cfValues) != 1 {
+		return "", false
+	}
+	var visitor struct {
+		Scheme string `json:"scheme"`
+	}
+	if err := json.Unmarshal([]byte(cfValues[0]), &visitor); err != nil {
+		return "", false
+	}
+	proto := strings.ToLower(strings.TrimSpace(visitor.Scheme))
+	if proto == "" || strings.Contains(proto, ",") {
+		return "", false
+	}
+	return proto, true
+}
+
+func canonicalAuthority(authority, hostname string) string {
+	host := strings.ToLower(hostname)
+	if strings.HasPrefix(authority, "[") {
+		closeBracket := strings.IndexByte(authority, ']')
+		return "[" + host + "]" + authority[closeBracket+1:]
+	}
+	if colon := strings.LastIndexByte(authority, ':'); colon >= 0 {
+		return host + authority[colon:]
+	}
+	return host
+}
+
+func containsSpaceOrControl(raw string) bool {
+	for _, char := range raw {
+		if unicode.IsControl(char) || unicode.IsSpace(char) {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseHTTPAuthority validates an HTTP authority consisting of a hostname and
+// an optional explicit port. The returned hostname omits IPv6 brackets.
+func ParseHTTPAuthority(raw string) (authority, hostname string, ok bool) {
+	if raw == "" || containsSpaceOrControl(raw) || strings.ContainsAny(raw, `,/?#@%\`) {
+		return "", "", false
+	}
+	if raw[0] == '[' {
+		closeBracket := strings.IndexByte(raw, ']')
+		if closeBracket <= 1 {
+			return "", "", false
+		}
+		hostname = raw[1:closeBracket]
+		if ip := net.ParseIP(hostname); ip == nil || !strings.Contains(hostname, ":") {
+			return "", "", false
+		}
+		remainder := raw[closeBracket+1:]
+		if remainder == "" {
+			return raw, hostname, true
+		}
+		if remainder[0] != ':' || !validPort(remainder[1:]) {
+			return "", "", false
+		}
+		return raw, hostname, true
+	}
+	if strings.ContainsAny(raw, "[]") || strings.Count(raw, ":") > 1 {
+		return "", "", false
+	}
+	hostname = raw
+	if colon := strings.LastIndexByte(raw, ':'); colon >= 0 {
+		hostname = raw[:colon]
+		if !validPort(raw[colon+1:]) {
+			return "", "", false
+		}
+	}
+	if hostname == "" || !validRegName(hostname) {
+		return "", "", false
+	}
+	return raw, hostname, true
+}
+
+func validPort(raw string) bool {
+	if raw == "" {
+		return false
+	}
+	for i := range raw {
+		if raw[i] < '0' || raw[i] > '9' {
+			return false
+		}
+	}
+	port, err := strconv.Atoi(raw)
+	return err == nil && port >= 1 && port <= 65535
+}
+
+func validRegName(raw string) bool {
+	for i := range raw {
+		char := raw[i]
+		if char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' || char >= '0' && char <= '9' {
+			continue
+		}
+		switch char {
+		case '-', '.', '_', '~', '!', '$', '&', '\'', '(', ')', '*', '+', ';', '=':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func IsLoopbackHostname(hostname string) bool {
+	if strings.EqualFold(hostname, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(hostname)
+	return ip != nil && ip.IsLoopback()
+}

--- a/internal/publicorigin/resolver_test.go
+++ b/internal/publicorigin/resolver_test.go
@@ -1,0 +1,113 @@
+package publicorigin
+
+import (
+	"crypto/tls"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResolverOriginTrustLadder(t *testing.T) {
+	t.Run("configured origin wins and canonicalizes case", func(t *testing.T) {
+		resolver := New("HTTPS://VEGA.EXAMPLE.COM:8443", false)
+		req := httptest.NewRequest("GET", "http://attacker.example/", nil)
+		got, err := resolver.Origin(req)
+		if err != nil || got != "https://vega.example.com:8443" {
+			t.Fatalf("Origin() = %q, %v", got, err)
+		}
+	})
+
+	t.Run("direct TLS uses validated host", func(t *testing.T) {
+		resolver := New("", false)
+		req := httptest.NewRequest("GET", "https://VEGA.EXAMPLE.COM:443/", nil)
+		req.TLS = &tls.ConnectionState{}
+		got, err := resolver.Origin(req)
+		if err != nil || got != "https://vega.example.com:443" {
+			t.Fatalf("Origin() = %q, %v", got, err)
+		}
+	})
+
+	t.Run("trusted proxy requires forwarded HTTPS and host", func(t *testing.T) {
+		resolver := New("", true)
+		req := httptest.NewRequest("GET", "http://backend:8080/", nil)
+		req.Header.Set("X-Forwarded-Proto", "https")
+		req.Header.Set("X-Forwarded-Host", "VEGA.EXAMPLE.COM")
+		got, err := resolver.Origin(req)
+		if err != nil || got != "https://vega.example.com" {
+			t.Fatalf("Origin() = %q, %v", got, err)
+		}
+	})
+
+	t.Run("loopback HTTP is allowed", func(t *testing.T) {
+		resolver := New("", false)
+		req := httptest.NewRequest("GET", "http://LOCALHOST:8080/", nil)
+		got, err := resolver.Origin(req)
+		if err != nil || got != "http://localhost:8080" {
+			t.Fatalf("Origin() = %q, %v", got, err)
+		}
+	})
+
+	t.Run("untrusted non-loopback HTTP fails closed", func(t *testing.T) {
+		resolver := New("", false)
+		req := httptest.NewRequest("GET", "http://vega.example.com/", nil)
+		if _, err := resolver.Origin(req); err == nil {
+			t.Fatal("Origin() unexpectedly trusted plaintext non-loopback request")
+		}
+	})
+}
+
+func TestValidateMCPResourceNarrowCanonicalization(t *testing.T) {
+	resolver := New("https://vega.example.com", false)
+	req := httptest.NewRequest("GET", "http://ignored.invalid/", nil)
+
+	accepted := []string{
+		"https://vega.example.com/mcp/rpc",
+		"HTTPS://VEGA.EXAMPLE.COM/mcp/rpc",
+	}
+	for _, raw := range accepted {
+		got, err := resolver.ValidateMCPResource(req, raw)
+		if err != nil || got != "https://vega.example.com/mcp/rpc" {
+			t.Errorf("ValidateMCPResource(%q) = %q, %v", raw, got, err)
+		}
+	}
+
+	rejected := []string{
+		"/mcp/rpc",
+		"https://vega.example.com/mcp/rpc/",
+		"https://vega.example.com/MCP/rpc",
+		"https://vega.example.com/mcp/%72pc",
+		"https://vega.example.com/mcp/rpc?x=1",
+		"https://vega.example.com/mcp/rpc#fragment",
+		"https://user@vega.example.com/mcp/rpc",
+		"https://vega.example.com:443/mcp/rpc",
+		"https://other.example.com/mcp/rpc",
+		"https://vega.example.com/mcp/../mcp/rpc",
+	}
+	for _, raw := range rejected {
+		if got, err := resolver.ValidateMCPResource(req, raw); err == nil {
+			t.Errorf("ValidateMCPResource(%q) = %q, expected rejection", raw, got)
+		}
+	}
+}
+
+func TestOriginAllowed(t *testing.T) {
+	resolver := New("https://vega.example.com", false)
+	for _, tc := range []struct {
+		origin string
+		want   bool
+	}{
+		{"", true},
+		{"HTTPS://VEGA.EXAMPLE.COM", true},
+		{"https://vega.example.com:443", false},
+		{"https://other.example.com", false},
+		{"null", false},
+	} {
+		req := httptest.NewRequest("POST", "http://ignored.invalid/mcp/rpc", nil)
+		if tc.origin != "" {
+			req.Header.Set("Origin", tc.origin)
+		}
+		got, err := resolver.OriginAllowed(req)
+		if err != nil || got != tc.want {
+			t.Errorf("OriginAllowed(%q) = %v, %v, want %v", tc.origin, got, err, tc.want)
+		}
+	}
+}

--- a/internal/store/oauth.go
+++ b/internal/store/oauth.go
@@ -33,6 +33,13 @@ type OAuthAuthCode struct {
 	RedirectURI         string
 	CodeChallenge       string
 	CodeChallengeMethod string
+	Resource            string
+}
+
+type OAuthRefreshGrant struct {
+	ClientID string
+	UserID   int64
+	Resource string
 }
 
 // OAuthTokenPair is a freshly minted access+refresh token pair.
@@ -91,8 +98,8 @@ WHERE id = ?
 
 // CreateOAuthAuthCode issues a new single-use authorization code (plaintext
 // returned once) with a 60s TTL, bound to the presented PKCE code_challenge.
-func (s *Store) CreateOAuthAuthCode(ctx context.Context, clientID string, userID int64, redirectURI, codeChallenge, codeChallengeMethod string) (plaintext string, err error) {
-	if clientID == "" || userID <= 0 || redirectURI == "" || codeChallenge == "" {
+func (s *Store) CreateOAuthAuthCode(ctx context.Context, clientID string, userID int64, redirectURI, codeChallenge, codeChallengeMethod, resource string) (plaintext string, err error) {
+	if clientID == "" || userID <= 0 || redirectURI == "" || codeChallenge == "" || resource == "" {
 		return "", fmt.Errorf("%w: missing required auth code fields", ErrValidation)
 	}
 	secret, err := oauth.GenerateOpaqueSecret()
@@ -103,50 +110,108 @@ func (s *Store) CreateOAuthAuthCode(ctx context.Context, clientID string, userID
 	nowMs := time.Now().UTC().UnixMilli()
 	expiresMs := time.Now().UTC().Add(authCodeTTL).UnixMilli()
 	_, err = s.db.ExecContext(ctx, `
-INSERT INTO oauth_auth_codes(code_hash, client_id, user_id, redirect_uri, code_challenge, code_challenge_method, created_at, expires_at, consumed_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
-`, codeHash, clientID, userID, redirectURI, codeChallenge, codeChallengeMethod, nowMs, expiresMs)
+INSERT INTO oauth_auth_codes(code_hash, client_id, user_id, redirect_uri, code_challenge, code_challenge_method, resource, created_at, expires_at, consumed_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+`, codeHash, clientID, userID, redirectURI, codeChallenge, codeChallengeMethod, resource, nowMs, expiresMs)
 	if err != nil {
 		return "", fmt.Errorf("insert oauth auth code: %w", err)
 	}
 	return secret, nil
 }
 
-// ConsumeOAuthAuthCode atomically redeems a not-yet-consumed, not-yet-expired
-// authorization code: single-use is enforced by the conditional UPDATE below,
-// not merely by an in-memory check, so a replayed code can never redeem twice
-// even under concurrent requests.
-func (s *Store) ConsumeOAuthAuthCode(ctx context.Context, rawCode string) (OAuthAuthCode, error) {
+// newOAuthTokenSecrets mints opaque access/refresh secrets. Tests may override
+// it to force deterministic hashes (e.g. collision rollback coverage).
+var newOAuthTokenSecrets = defaultNewOAuthTokenSecrets
+
+func defaultNewOAuthTokenSecrets() (accessSecret, refreshSecret string, err error) {
+	accessSecret, err = oauth.GenerateOpaqueSecret()
+	if err != nil {
+		return "", "", err
+	}
+	refreshSecret, err = oauth.GenerateOpaqueSecret()
+	if err != nil {
+		return "", "", err
+	}
+	return accessSecret, refreshSecret, nil
+}
+
+// RedeemOAuthAuthCode validates every request-bound property before consuming a
+// code. Failed client, redirect, resource, or PKCE comparisons do not burn an
+// otherwise valid grant. Prefer RedeemOAuthAuthCodeAndIssue on production token
+// exchange paths so consume and token insert share one transaction.
+func (s *Store) RedeemOAuthAuthCode(ctx context.Context, rawCode, expectedClientID, expectedRedirectURI, expectedResource, codeVerifier string) (OAuthAuthCode, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OAuthAuthCode{}, fmt.Errorf("begin redeem oauth auth code tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	ac, err := s.redeemOAuthAuthCodeTx(ctx, tx, rawCode, expectedClientID, expectedRedirectURI, expectedResource, codeVerifier)
+	if err != nil {
+		return OAuthAuthCode{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return OAuthAuthCode{}, fmt.Errorf("commit redeem oauth auth code tx: %w", err)
+	}
+	return ac, nil
+}
+
+// RedeemOAuthAuthCodeAndIssue validates and consumes an authorization code and
+// mints a new access/refresh pair in a single database transaction. Invalid
+// client, redirect, resource, or PKCE comparisons do not burn the grant; if
+// token insertion fails after a successful consume, the whole transaction rolls
+// back so the code remains redeemable.
+func (s *Store) RedeemOAuthAuthCodeAndIssue(ctx context.Context, rawCode, expectedClientID, expectedRedirectURI, expectedResource, codeVerifier string) (OAuthTokenPair, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OAuthTokenPair{}, fmt.Errorf("begin redeem auth code and issue tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	ac, err := s.redeemOAuthAuthCodeTx(ctx, tx, rawCode, expectedClientID, expectedRedirectURI, expectedResource, codeVerifier)
+	if err != nil {
+		return OAuthTokenPair{}, err
+	}
+	pair, err := s.issueOAuthTokenPairTx(ctx, tx, ac.ClientID, ac.UserID, ac.Resource)
+	if err != nil {
+		return OAuthTokenPair{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return OAuthTokenPair{}, fmt.Errorf("commit redeem auth code and issue tx: %w", err)
+	}
+	return pair, nil
+}
+
+func (s *Store) redeemOAuthAuthCodeTx(ctx context.Context, tx *sql.Tx, rawCode, expectedClientID, expectedRedirectURI, expectedResource, codeVerifier string) (OAuthAuthCode, error) {
 	rawCode = strings.TrimSpace(rawCode)
-	if rawCode == "" {
+	if rawCode == "" || expectedClientID == "" || expectedRedirectURI == "" || expectedResource == "" || codeVerifier == "" {
 		return OAuthAuthCode{}, ErrNotFound
 	}
 	codeHash := hashToken(rawCode)
 	nowMs := time.Now().UTC().UnixMilli()
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return OAuthAuthCode{}, fmt.Errorf("begin consume auth code tx: %w", err)
-	}
-	defer tx.Rollback()
-
 	var ac OAuthAuthCode
-	err = tx.QueryRowContext(ctx, `
-SELECT client_id, user_id, redirect_uri, code_challenge, code_challenge_method
+	err := tx.QueryRowContext(ctx, `
+SELECT client_id, user_id, redirect_uri, code_challenge, code_challenge_method, resource
 FROM oauth_auth_codes
 WHERE code_hash = ? AND consumed_at IS NULL AND expires_at > ?
-`, codeHash, nowMs).Scan(&ac.ClientID, &ac.UserID, &ac.RedirectURI, &ac.CodeChallenge, &ac.CodeChallengeMethod)
+`, codeHash, nowMs).Scan(&ac.ClientID, &ac.UserID, &ac.RedirectURI, &ac.CodeChallenge, &ac.CodeChallengeMethod, &ac.Resource)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return OAuthAuthCode{}, ErrNotFound
 		}
 		return OAuthAuthCode{}, fmt.Errorf("select oauth auth code: %w", err)
 	}
+	if ac.ClientID != expectedClientID || ac.RedirectURI != expectedRedirectURI || ac.Resource != expectedResource || !oauth.VerifyPKCE(ac.CodeChallengeMethod, codeVerifier, ac.CodeChallenge) {
+		return OAuthAuthCode{}, ErrNotFound
+	}
 
 	res, err := tx.ExecContext(ctx, `
 UPDATE oauth_auth_codes SET consumed_at = ?
 WHERE code_hash = ? AND consumed_at IS NULL AND expires_at > ?
-`, nowMs, codeHash, nowMs)
+  AND client_id = ? AND redirect_uri = ? AND resource = ?
+  AND code_challenge = ? AND code_challenge_method = ?
+`, nowMs, codeHash, nowMs, ac.ClientID, ac.RedirectURI, ac.Resource, ac.CodeChallenge, ac.CodeChallengeMethod)
 	if err != nil {
 		return OAuthAuthCode{}, fmt.Errorf("consume oauth auth code: %w", err)
 	}
@@ -158,24 +223,34 @@ WHERE code_hash = ? AND consumed_at IS NULL AND expires_at > ?
 		// Consumed concurrently between the SELECT and UPDATE above.
 		return OAuthAuthCode{}, ErrNotFound
 	}
-	if err := tx.Commit(); err != nil {
-		return OAuthAuthCode{}, fmt.Errorf("commit consume auth code tx: %w", err)
-	}
 	return ac, nil
 }
 
 // IssueOAuthTokenPair mints a new access token (1h TTL) and refresh token (30d
-// TTL) for a client/user pair, e.g. after a successful authorization_code or
-// refresh_token grant.
-func (s *Store) IssueOAuthTokenPair(ctx context.Context, clientID string, userID int64) (OAuthTokenPair, error) {
-	if clientID == "" || userID <= 0 {
-		return OAuthTokenPair{}, fmt.Errorf("%w: missing client id or user id", ErrValidation)
+// TTL) for a client/user pair. Production authorization_code and refresh_token
+// exchanges use the combined redeem/consume-and-issue methods instead.
+func (s *Store) IssueOAuthTokenPair(ctx context.Context, clientID string, userID int64, resource string) (OAuthTokenPair, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OAuthTokenPair{}, fmt.Errorf("begin issue token pair tx: %w", err)
 	}
-	accessSecret, err := oauth.GenerateOpaqueSecret()
+	defer tx.Rollback()
+
+	pair, err := s.issueOAuthTokenPairTx(ctx, tx, clientID, userID, resource)
 	if err != nil {
 		return OAuthTokenPair{}, err
 	}
-	refreshSecret, err := oauth.GenerateOpaqueSecret()
+	if err := tx.Commit(); err != nil {
+		return OAuthTokenPair{}, fmt.Errorf("commit issue token pair tx: %w", err)
+	}
+	return pair, nil
+}
+
+func (s *Store) issueOAuthTokenPairTx(ctx context.Context, tx *sql.Tx, clientID string, userID int64, resource string) (OAuthTokenPair, error) {
+	if clientID == "" || userID <= 0 || resource == "" {
+		return OAuthTokenPair{}, fmt.Errorf("%w: missing client id, user id, or resource", ErrValidation)
+	}
+	accessSecret, refreshSecret, err := newOAuthTokenSecrets()
 	if err != nil {
 		return OAuthTokenPair{}, err
 	}
@@ -185,26 +260,17 @@ func (s *Store) IssueOAuthTokenPair(ctx context.Context, clientID string, userID
 	accessExpiresMs := now.Add(accessTokenTTL).UnixMilli()
 	refreshExpiresMs := now.Add(refreshTokenTTL).UnixMilli()
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return OAuthTokenPair{}, fmt.Errorf("begin issue token pair tx: %w", err)
-	}
-	defer tx.Rollback()
-
 	if _, err := tx.ExecContext(ctx, `
-INSERT INTO oauth_access_tokens(token_hash, client_id, user_id, created_at, expires_at, revoked_at)
-VALUES (?, ?, ?, ?, ?, NULL)
-`, hashToken(accessSecret), clientID, userID, nowMs, accessExpiresMs); err != nil {
+INSERT INTO oauth_access_tokens(token_hash, client_id, user_id, resource, created_at, expires_at, revoked_at)
+VALUES (?, ?, ?, ?, ?, ?, NULL)
+`, hashToken(accessSecret), clientID, userID, resource, nowMs, accessExpiresMs); err != nil {
 		return OAuthTokenPair{}, fmt.Errorf("insert oauth access token: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, `
-INSERT INTO oauth_refresh_tokens(token_hash, client_id, user_id, created_at, expires_at, revoked_at)
-VALUES (?, ?, ?, ?, ?, NULL)
-`, hashToken(refreshSecret), clientID, userID, nowMs, refreshExpiresMs); err != nil {
+INSERT INTO oauth_refresh_tokens(token_hash, client_id, user_id, resource, created_at, expires_at, revoked_at)
+VALUES (?, ?, ?, ?, ?, ?, NULL)
+`, hashToken(refreshSecret), clientID, userID, resource, nowMs, refreshExpiresMs); err != nil {
 		return OAuthTokenPair{}, fmt.Errorf("insert oauth refresh token: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return OAuthTokenPair{}, fmt.Errorf("commit issue token pair tx: %w", err)
 	}
 
 	return OAuthTokenPair{
@@ -214,60 +280,97 @@ VALUES (?, ?, ?, ?, ?, NULL)
 	}, nil
 }
 
-// ConsumeOAuthRefreshToken validates and revokes (rotates away from) a
-// refresh token, returning the client/user it was issued to so a new token
-// pair can be minted. Revocation happens unconditionally on first successful
-// use, which is what makes reuse of an already-rotated token fail.
-func (s *Store) ConsumeOAuthRefreshToken(ctx context.Context, rawToken string) (clientID string, userID int64, err error) {
+// ConsumeOAuthRefreshToken validates and revokes (rotates away from) a refresh
+// token. Prefer ConsumeOAuthRefreshTokenAndIssue on production refresh paths so
+// revoke and token insert share one transaction.
+func (s *Store) ConsumeOAuthRefreshToken(ctx context.Context, rawToken, expectedClientID, expectedResource string) (grant OAuthRefreshGrant, err error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OAuthRefreshGrant{}, fmt.Errorf("begin consume oauth refresh token tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	grant, err = s.consumeOAuthRefreshTokenTx(ctx, tx, rawToken, expectedClientID, expectedResource)
+	if err != nil {
+		return OAuthRefreshGrant{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return OAuthRefreshGrant{}, fmt.Errorf("commit consume oauth refresh token tx: %w", err)
+	}
+	return grant, nil
+}
+
+// ConsumeOAuthRefreshTokenAndIssue validates and revokes a refresh token and
+// mints a new access/refresh pair in a single database transaction. Invalid
+// client or resource comparisons do not revoke the grant; if token insertion
+// fails after a successful revoke, the whole transaction rolls back so the
+// refresh token remains usable.
+func (s *Store) ConsumeOAuthRefreshTokenAndIssue(ctx context.Context, rawToken, expectedClientID, expectedResource string) (OAuthTokenPair, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return OAuthTokenPair{}, fmt.Errorf("begin consume refresh and issue tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	grant, err := s.consumeOAuthRefreshTokenTx(ctx, tx, rawToken, expectedClientID, expectedResource)
+	if err != nil {
+		return OAuthTokenPair{}, err
+	}
+	pair, err := s.issueOAuthTokenPairTx(ctx, tx, grant.ClientID, grant.UserID, grant.Resource)
+	if err != nil {
+		return OAuthTokenPair{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return OAuthTokenPair{}, fmt.Errorf("commit consume refresh and issue tx: %w", err)
+	}
+	return pair, nil
+}
+
+func (s *Store) consumeOAuthRefreshTokenTx(ctx context.Context, tx *sql.Tx, rawToken, expectedClientID, expectedResource string) (grant OAuthRefreshGrant, err error) {
 	rawToken = strings.TrimSpace(rawToken)
-	if rawToken == "" {
-		return "", 0, ErrNotFound
+	if rawToken == "" || expectedClientID == "" || expectedResource == "" {
+		return OAuthRefreshGrant{}, ErrNotFound
 	}
 	tokenHash := hashToken(rawToken)
 	nowMs := time.Now().UTC().UnixMilli()
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return "", 0, fmt.Errorf("begin consume refresh token tx: %w", err)
-	}
-	defer tx.Rollback()
-
 	err = tx.QueryRowContext(ctx, `
-SELECT client_id, user_id
+SELECT client_id, user_id, resource
 FROM oauth_refresh_tokens
 WHERE token_hash = ? AND revoked_at IS NULL AND expires_at > ?
-`, tokenHash, nowMs).Scan(&clientID, &userID)
+`, tokenHash, nowMs).Scan(&grant.ClientID, &grant.UserID, &grant.Resource)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return "", 0, ErrNotFound
+			return OAuthRefreshGrant{}, ErrNotFound
 		}
-		return "", 0, fmt.Errorf("select oauth refresh token: %w", err)
+		return OAuthRefreshGrant{}, fmt.Errorf("select oauth refresh token: %w", err)
+	}
+	if grant.ClientID != expectedClientID || grant.Resource != expectedResource {
+		return OAuthRefreshGrant{}, ErrNotFound
 	}
 
 	res, err := tx.ExecContext(ctx, `
 UPDATE oauth_refresh_tokens SET revoked_at = ?
-WHERE token_hash = ? AND revoked_at IS NULL
-`, nowMs, tokenHash)
+WHERE token_hash = ? AND revoked_at IS NULL AND expires_at > ?
+  AND client_id = ? AND resource = ?
+`, nowMs, tokenHash, nowMs, grant.ClientID, grant.Resource)
 	if err != nil {
-		return "", 0, fmt.Errorf("revoke oauth refresh token: %w", err)
+		return OAuthRefreshGrant{}, fmt.Errorf("revoke oauth refresh token: %w", err)
 	}
 	if n, err := res.RowsAffected(); err != nil {
-		return "", 0, fmt.Errorf("revoke oauth refresh token rows: %w", err)
+		return OAuthRefreshGrant{}, fmt.Errorf("revoke oauth refresh token rows: %w", err)
 	} else if n == 0 {
-		return "", 0, ErrNotFound
+		return OAuthRefreshGrant{}, ErrNotFound
 	}
-	if err := tx.Commit(); err != nil {
-		return "", 0, fmt.Errorf("commit consume refresh token tx: %w", err)
-	}
-	return clientID, userID, nil
+	return grant, nil
 }
 
 // GetUserByOAuthAccessToken returns the user for an active (non-revoked,
 // non-expired) OAuth access token. Mirrors GetUserByAPIToken's shape exactly
 // so internal/mcp/adapter.go can use it as a drop-in fallback lookup.
-func (s *Store) GetUserByOAuthAccessToken(ctx context.Context, rawToken string) (User, error) {
+func (s *Store) GetUserByOAuthAccessToken(ctx context.Context, rawToken, expectedResource string) (User, error) {
 	rawToken = strings.TrimSpace(rawToken)
-	if rawToken == "" {
+	if rawToken == "" || expectedResource == "" {
 		return User{}, ErrNotFound
 	}
 	tokenHash := hashToken(rawToken)
@@ -285,9 +388,10 @@ SELECT u.id, u.email, u.name, u.is_bootstrap, u.system_role, u.created_at, u.two
 FROM oauth_access_tokens t
 JOIN users u ON u.id = t.user_id
 WHERE t.token_hash = ?
+	AND t.resource = ?
   AND t.revoked_at IS NULL
   AND t.expires_at > ?
-`, tokenHash, nowMs).Scan(&u.ID, &u.Email, &u.Name, &isBootstrap, &systemRoleStr, &createdAt, &twoFactorEnabled)
+`, tokenHash, expectedResource, nowMs).Scan(&u.ID, &u.Email, &u.Name, &isBootstrap, &systemRoleStr, &createdAt, &twoFactorEnabled)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return User{}, ErrNotFound

--- a/internal/store/oauth_binding_test.go
+++ b/internal/store/oauth_binding_test.go
@@ -1,0 +1,268 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+const testMCPResource = "https://scrumboy.example/mcp/rpc"
+
+func pkceChallenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func newOAuthGrantFixture(t *testing.T) (*Store, OAuthClient, User, func()) {
+	t.Helper()
+	st, cleanup := newTestStore(t)
+	ctx := context.Background()
+	user, err := st.BootstrapUser(ctx, "owner@example.com", "password123", "Owner")
+	if err != nil {
+		cleanup()
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	client, err := st.CreateOAuthClient(ctx, "client-1", "Client", "http://127.0.0.1/callback")
+	if err != nil {
+		cleanup()
+		t.Fatalf("CreateOAuthClient: %v", err)
+	}
+	return st, client, user, cleanup
+}
+
+func TestRedeemOAuthAuthCodeFailedValidationDoesNotBurnGrant(t *testing.T) {
+	st, client, user, cleanup := newOAuthGrantFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+	const verifier = "a-valid-pkce-verifier"
+	code, err := st.CreateOAuthAuthCode(ctx, client.ID, user.ID, client.RedirectURI, pkceChallenge(verifier), "S256", testMCPResource)
+	if err != nil {
+		t.Fatalf("CreateOAuthAuthCode: %v", err)
+	}
+
+	invalid := []struct {
+		clientID, redirectURI, resource, verifier string
+	}{
+		{"other-client", client.RedirectURI, testMCPResource, verifier},
+		{client.ID, "http://127.0.0.1/other", testMCPResource, verifier},
+		{client.ID, client.RedirectURI, "https://other.example/mcp/rpc", verifier},
+		{client.ID, client.RedirectURI, testMCPResource, "wrong-verifier"},
+	}
+	for _, attempt := range invalid {
+		if _, err := st.RedeemOAuthAuthCode(ctx, code, attempt.clientID, attempt.redirectURI, attempt.resource, attempt.verifier); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("invalid redemption error = %v, want ErrNotFound", err)
+		}
+	}
+
+	grant, err := st.RedeemOAuthAuthCode(ctx, code, client.ID, client.RedirectURI, testMCPResource, verifier)
+	if err != nil {
+		t.Fatalf("valid redemption after invalid attempts: %v", err)
+	}
+	if grant.Resource != testMCPResource || grant.ClientID != client.ID || grant.UserID != user.ID {
+		t.Fatalf("redeemed grant = %+v", grant)
+	}
+	if _, err := st.RedeemOAuthAuthCode(ctx, code, client.ID, client.RedirectURI, testMCPResource, verifier); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("replay error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestConsumeOAuthRefreshTokenFailedValidationDoesNotBurnGrant(t *testing.T) {
+	st, client, user, cleanup := newOAuthGrantFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+	pair, err := st.IssueOAuthTokenPair(ctx, client.ID, user.ID, testMCPResource)
+	if err != nil {
+		t.Fatalf("IssueOAuthTokenPair: %v", err)
+	}
+
+	if _, err := st.ConsumeOAuthRefreshToken(ctx, pair.RefreshToken, "other-client", testMCPResource); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("wrong-client error = %v, want ErrNotFound", err)
+	}
+	if _, err := st.ConsumeOAuthRefreshToken(ctx, pair.RefreshToken, client.ID, "https://other.example/mcp/rpc"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("wrong-resource error = %v, want ErrNotFound", err)
+	}
+	grant, err := st.ConsumeOAuthRefreshToken(ctx, pair.RefreshToken, client.ID, testMCPResource)
+	if err != nil {
+		t.Fatalf("valid refresh after invalid attempts: %v", err)
+	}
+	if grant.Resource != testMCPResource || grant.ClientID != client.ID || grant.UserID != user.ID {
+		t.Fatalf("refresh grant = %+v", grant)
+	}
+}
+
+func TestOAuthAccessTokenRequiresExpectedResource(t *testing.T) {
+	st, client, user, cleanup := newOAuthGrantFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+	pair, err := st.IssueOAuthTokenPair(ctx, client.ID, user.ID, testMCPResource)
+	if err != nil {
+		t.Fatalf("IssueOAuthTokenPair: %v", err)
+	}
+	if _, err := st.GetUserByOAuthAccessToken(ctx, pair.AccessToken, "https://other.example/mcp/rpc"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("wrong-resource lookup error = %v, want ErrNotFound", err)
+	}
+	got, err := st.GetUserByOAuthAccessToken(ctx, pair.AccessToken, testMCPResource)
+	if err != nil || got.ID != user.ID {
+		t.Fatalf("canonical-resource lookup = user %+v, err %v", got, err)
+	}
+}
+
+func TestConcurrentOAuthRedemptionAllowsExactlyOneSuccess(t *testing.T) {
+	st, client, user, cleanup := newOAuthGrantFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+	const verifier = "another-valid-verifier"
+	code, err := st.CreateOAuthAuthCode(ctx, client.ID, user.ID, client.RedirectURI, pkceChallenge(verifier), "S256", testMCPResource)
+	if err != nil {
+		t.Fatalf("CreateOAuthAuthCode: %v", err)
+	}
+	pair, err := st.IssueOAuthTokenPair(ctx, client.ID, user.ID, testMCPResource)
+	if err != nil {
+		t.Fatalf("IssueOAuthTokenPair: %v", err)
+	}
+
+	for name, redeem := range map[string]func() error{
+		"authorization code": func() error {
+			_, err := st.RedeemOAuthAuthCodeAndIssue(ctx, code, client.ID, client.RedirectURI, testMCPResource, verifier)
+			return err
+		},
+		"refresh token": func() error {
+			_, err := st.ConsumeOAuthRefreshTokenAndIssue(ctx, pair.RefreshToken, client.ID, testMCPResource)
+			return err
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			const attempts = 8
+			start := make(chan struct{})
+			errs := make(chan error, attempts)
+			var wg sync.WaitGroup
+			for range attempts {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-start
+					errs <- redeem()
+				}()
+			}
+			close(start)
+			wg.Wait()
+			close(errs)
+			successes := 0
+			for err := range errs {
+				if err == nil {
+					successes++
+					continue
+				}
+				if !errors.Is(err, ErrNotFound) {
+					t.Fatalf("redemption error = %v, want ErrNotFound", err)
+				}
+			}
+			if successes != 1 {
+				t.Fatalf("successful redemptions = %d, want 1", successes)
+			}
+		})
+	}
+}
+
+func TestRedeemOAuthAuthCodeAndIssueRollsBackWhenTokenInsertFails(t *testing.T) {
+	st, client, user, cleanup := newOAuthGrantFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+	const verifier = "rollback-verifier"
+	code, err := st.CreateOAuthAuthCode(ctx, client.ID, user.ID, client.RedirectURI, pkceChallenge(verifier), "S256", testMCPResource)
+	if err != nil {
+		t.Fatalf("CreateOAuthAuthCode: %v", err)
+	}
+
+	const collidingAccess = "deterministic-access-secret-for-collision"
+	const collidingRefresh = "deterministic-refresh-secret-for-collision"
+	nowMs := time.Now().UTC().UnixMilli()
+	if _, err := st.db.ExecContext(ctx, `
+INSERT INTO oauth_access_tokens(token_hash, client_id, user_id, resource, created_at, expires_at, revoked_at)
+VALUES (?, ?, ?, ?, ?, ?, NULL)
+`, hashToken(collidingAccess), client.ID, user.ID, testMCPResource, nowMs, nowMs+3600_000); err != nil {
+		t.Fatalf("pre-insert colliding access token: %v", err)
+	}
+
+	prev := newOAuthTokenSecrets
+	newOAuthTokenSecrets = func() (string, string, error) {
+		return collidingAccess, collidingRefresh, nil
+	}
+	t.Cleanup(func() { newOAuthTokenSecrets = prev })
+
+	if _, err := st.RedeemOAuthAuthCodeAndIssue(ctx, code, client.ID, client.RedirectURI, testMCPResource, verifier); err == nil {
+		t.Fatal("expected token insert collision to fail redemption")
+	}
+
+	var consumedAt any
+	if err := st.db.QueryRowContext(ctx, `
+SELECT consumed_at FROM oauth_auth_codes WHERE code_hash = ?
+`, hashToken(code)).Scan(&consumedAt); err != nil {
+		t.Fatalf("lookup auth code: %v", err)
+	}
+	if consumedAt != nil {
+		t.Fatalf("authorization code was consumed after rolled-back issue; consumed_at=%v", consumedAt)
+	}
+
+	newOAuthTokenSecrets = defaultNewOAuthTokenSecrets
+	pair, err := st.RedeemOAuthAuthCodeAndIssue(ctx, code, client.ID, client.RedirectURI, testMCPResource, verifier)
+	if err != nil {
+		t.Fatalf("redemption after restoring secret generator: %v", err)
+	}
+	if pair.AccessToken == "" || pair.RefreshToken == "" {
+		t.Fatalf("issued pair incomplete: %+v", pair)
+	}
+}
+
+func TestConsumeOAuthRefreshTokenAndIssueRollsBackWhenTokenInsertFails(t *testing.T) {
+	st, client, user, cleanup := newOAuthGrantFixture(t)
+	defer cleanup()
+	ctx := context.Background()
+	pair, err := st.IssueOAuthTokenPair(ctx, client.ID, user.ID, testMCPResource)
+	if err != nil {
+		t.Fatalf("IssueOAuthTokenPair: %v", err)
+	}
+
+	const collidingAccess = "deterministic-access-secret-for-refresh-collision"
+	const collidingRefresh = "deterministic-refresh-secret-for-refresh-collision"
+	nowMs := time.Now().UTC().UnixMilli()
+	if _, err := st.db.ExecContext(ctx, `
+INSERT INTO oauth_access_tokens(token_hash, client_id, user_id, resource, created_at, expires_at, revoked_at)
+VALUES (?, ?, ?, ?, ?, ?, NULL)
+`, hashToken(collidingAccess), client.ID, user.ID, testMCPResource, nowMs, nowMs+3600_000); err != nil {
+		t.Fatalf("pre-insert colliding access token: %v", err)
+	}
+
+	prev := newOAuthTokenSecrets
+	newOAuthTokenSecrets = func() (string, string, error) {
+		return collidingAccess, collidingRefresh, nil
+	}
+	t.Cleanup(func() { newOAuthTokenSecrets = prev })
+
+	if _, err := st.ConsumeOAuthRefreshTokenAndIssue(ctx, pair.RefreshToken, client.ID, testMCPResource); err == nil {
+		t.Fatal("expected token insert collision to fail refresh rotation")
+	}
+
+	var revokedAt any
+	if err := st.db.QueryRowContext(ctx, `
+SELECT revoked_at FROM oauth_refresh_tokens WHERE token_hash = ?
+`, hashToken(pair.RefreshToken)).Scan(&revokedAt); err != nil {
+		t.Fatalf("lookup refresh token: %v", err)
+	}
+	if revokedAt != nil {
+		t.Fatalf("refresh token was revoked after rolled-back issue; revoked_at=%v", revokedAt)
+	}
+
+	newOAuthTokenSecrets = defaultNewOAuthTokenSecrets
+	rotated, err := st.ConsumeOAuthRefreshTokenAndIssue(ctx, pair.RefreshToken, client.ID, testMCPResource)
+	if err != nil {
+		t.Fatalf("refresh after restoring secret generator: %v", err)
+	}
+	if rotated.AccessToken == "" || rotated.RefreshToken == "" {
+		t.Fatalf("rotated pair incomplete: %+v", rotated)
+	}
+}

--- a/internal/store/oauth_reaper_test.go
+++ b/internal/store/oauth_reaper_test.go
@@ -15,6 +15,7 @@ func TestDeleteExpiredOAuthArtifacts(t *testing.T) {
 	st, cleanup := newTestStore(t)
 	defer cleanup()
 	ctx := context.Background()
+	const resource = "https://scrumboy.example/mcp/rpc"
 
 	u, err := st.BootstrapUser(ctx, "owner@example.com", "password123", "Owner")
 	if err != nil {
@@ -26,38 +27,41 @@ func TestDeleteExpiredOAuthArtifacts(t *testing.T) {
 	}
 
 	// A live, unconsumed, unexpired auth code: must survive.
-	if _, err := st.CreateOAuthAuthCode(ctx, client.ID, u.ID, client.RedirectURI, "challenge", "S256"); err != nil {
+	if _, err := st.CreateOAuthAuthCode(ctx, client.ID, u.ID, client.RedirectURI, "challenge", "S256", resource); err != nil {
 		t.Fatalf("CreateOAuthAuthCode: %v", err)
 	}
 	// A live, unrevoked, unexpired token pair: must survive.
-	livePair, err := st.IssueOAuthTokenPair(ctx, client.ID, u.ID)
+	livePair, err := st.IssueOAuthTokenPair(ctx, client.ID, u.ID, resource)
 	if err != nil {
 		t.Fatalf("IssueOAuthTokenPair (live): %v", err)
 	}
 
 	// A consumed auth code and a rotated-away (revoked) token pair: must be
 	// swept even though neither is expired yet.
-	consumedCode, err := st.CreateOAuthAuthCode(ctx, client.ID, u.ID, client.RedirectURI, "challenge2", "S256")
+	consumedCode, err := st.CreateOAuthAuthCode(ctx, client.ID, u.ID, client.RedirectURI, "challenge2", "S256", resource)
 	if err != nil {
 		t.Fatalf("CreateOAuthAuthCode: %v", err)
 	}
-	if _, err := st.ConsumeOAuthAuthCode(ctx, consumedCode); err != nil {
-		t.Fatalf("ConsumeOAuthAuthCode: %v", err)
+	if _, err := st.RedeemOAuthAuthCode(ctx, consumedCode, client.ID, client.RedirectURI, resource, "verifier"); err == nil {
+		t.Fatal("RedeemOAuthAuthCode unexpectedly accepted mismatched PKCE")
 	}
-	rotatedPair, err := st.IssueOAuthTokenPair(ctx, client.ID, u.ID)
+	if _, err := st.db.ExecContext(ctx, `UPDATE oauth_auth_codes SET consumed_at = ? WHERE code_hash = ?`, time.Now().UTC().UnixMilli(), hashToken(consumedCode)); err != nil {
+		t.Fatalf("mark auth code consumed: %v", err)
+	}
+	rotatedPair, err := st.IssueOAuthTokenPair(ctx, client.ID, u.ID, resource)
 	if err != nil {
 		t.Fatalf("IssueOAuthTokenPair (to rotate): %v", err)
 	}
 	if err := st.RevokeOAuthToken(ctx, rotatedPair.AccessToken, "access_token"); err != nil {
 		t.Fatalf("RevokeOAuthToken: %v", err)
 	}
-	if _, _, err := st.ConsumeOAuthRefreshToken(ctx, rotatedPair.RefreshToken); err != nil {
+	if _, err := st.ConsumeOAuthRefreshToken(ctx, rotatedPair.RefreshToken, client.ID, resource); err != nil {
 		t.Fatalf("ConsumeOAuthRefreshToken: %v", err)
 	}
 
 	// An expired-but-never-consumed code and an expired-but-never-revoked
 	// token pair: must be swept for being past expires_at.
-	expiredCode, err := st.CreateOAuthAuthCode(ctx, client.ID, u.ID, client.RedirectURI, "challenge3", "S256")
+	expiredCode, err := st.CreateOAuthAuthCode(ctx, client.ID, u.ID, client.RedirectURI, "challenge3", "S256", resource)
 	if err != nil {
 		t.Fatalf("CreateOAuthAuthCode: %v", err)
 	}
@@ -65,7 +69,7 @@ func TestDeleteExpiredOAuthArtifacts(t *testing.T) {
 	if _, err := st.db.ExecContext(ctx, `UPDATE oauth_auth_codes SET expires_at = ? WHERE code_hash = ?`, pastMs, hashToken(expiredCode)); err != nil {
 		t.Fatalf("backdate auth code: %v", err)
 	}
-	expiredPair, err := st.IssueOAuthTokenPair(ctx, client.ID, u.ID)
+	expiredPair, err := st.IssueOAuthTokenPair(ctx, client.ID, u.ID, resource)
 	if err != nil {
 		t.Fatalf("IssueOAuthTokenPair (to expire): %v", err)
 	}
@@ -88,7 +92,7 @@ func TestDeleteExpiredOAuthArtifacts(t *testing.T) {
 	// The live token pair must still resolve, and re-sweeping finds nothing
 	// further left to delete (checked before consuming the live refresh
 	// token below, since that would itself create a freshly-revoked row).
-	if _, err := st.GetUserByOAuthAccessToken(ctx, livePair.AccessToken); err != nil {
+	if _, err := st.GetUserByOAuthAccessToken(ctx, livePair.AccessToken, resource); err != nil {
 		t.Fatalf("expected live access token to still resolve, got: %v", err)
 	}
 	deletedAgain, err := st.DeleteExpiredOAuthArtifacts(ctx)
@@ -99,7 +103,7 @@ func TestDeleteExpiredOAuthArtifacts(t *testing.T) {
 		t.Fatalf("expected second sweep to find nothing left to delete, got %d", deletedAgain)
 	}
 
-	if _, _, err := st.ConsumeOAuthRefreshToken(ctx, livePair.RefreshToken); err != nil {
+	if _, err := st.ConsumeOAuthRefreshToken(ctx, livePair.RefreshToken, client.ID, resource); err != nil {
 		t.Fatalf("expected live refresh token to still be consumable, got: %v", err)
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.21.0"
+const Version = "3.22.0"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
Normalize Scrumboy's MCP implementation to align with the official Model Context Protocol specification while preserving backward compatibility for existing clients.