### PR TITLE
security: apply least-privilege workflow permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -4,10 +4,14 @@ on:
     branches:
       - 'security/trivy' # Triggers exclusively on your test branch
 
+permissions:
+  contents: read
+
 jobs:
   trivy:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write # Required for SARIF uploads to the Security Tab
     steps:
       # Pinned to the immutable commit for v6.1.0


### PR DESCRIPTION
adding top-level permissions to docker-publish, and trivy configs, keeping write access limited.