### PR TITLE
Security/openssf

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @markrai @tungstendev9

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,60 @@
+name: OpenSSF Scorecard
+
+on:
+  # For the Branch-Protection check. Only the default branch is supported.
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # Weekly scan to keep the Maintained check and published results fresh.
+  schedule:
+    - cron: "20 7 * * 1"
+  push:
+    branches: [main]
+
+# Declare default permissions as read-only.
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Do not cancel an in-progress security scan on the default branch.
+  cancel-in-progress: false
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    # publish_results only works from the default branch.
+    if: github.event.repository.default_branch == github.ref_name
+    permissions:
+      # Needed to upload the results to the code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to the OpenSSF REST API so the repository can display
+          # the Scorecard badge. https://github.com/ossf/scorecard-action#publishing-results
+          publish_results: true
+
+      # Upload the results as a short-retention artifact for the Actions tab.
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code-scanning dashboard.
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          sarif_file: results.sarif

--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,3 @@
-Scrumboy - Copyright (C) 2026 Scrumboy Contributors
-This program is free software released under the GNU Affero General Public License v3.
-See the full license text below.
-
----
-
 GNU AFFERO GENERAL PUBLIC LICENSE
 Version 3, 19 November 2007
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
   <img src="https://img.shields.io/badge/version-v3.22.4-blue" alt="version" />
-  <img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" />
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
-  <a href="SECURITY.md"><img src="https://snyk.io/test/github/markrai/scrumboy/badge.svg" alt="Snyk Security" /></a>
+  <a href="SECURITY.md"><img src="https://img.shields.io/badge/Snyk-monitored-8A2BE2?logo=snyk&logoColor=white" alt="snyk monitored" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/markrai/scrumboy"><img src="https://api.scorecard.dev/projects/github.com/markrai/scrumboy/badge" alt="OpenSSF Scorecard" /></a>
 </p>
 
 #### Self-hosted project management & issue-tracking solution + instant shareable & customizable boards + realtime collaboration, automation, API access and MCP-compatible client support

--- a/internal/mcp/jsonrpc_fuzz_test.go
+++ b/internal/mcp/jsonrpc_fuzz_test.go
@@ -1,0 +1,77 @@
+package mcp
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func FuzzParseJSONRPCMessage(f *testing.F) {
+	seeds := []string{
+		`{"jsonrpc":"2.0","id":1,"method":"ping"}`,
+		`{"jsonrpc":"2.0","id":"abc","method":"initialize","params":{}}`,
+		`{"jsonrpc":"2.0","id":null,"method":"ping"}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":[1,2]}`,
+		`{"jsonrpc":"2.0","id":1,"result":{}}`,
+		`{"jsonrpc":"2.0","id":null,"method":123}`,
+		`{"jsonrpc":"2.0","id":{"bad":true},"method":"ping"}`,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":null}`,
+		`{"jsonrpc":"1.0","id":1,"method":"ping"}`,
+		`{"id":1,"method":"ping"}`,
+		`{"jsonrpc":"2.0","id":1}`,
+		`{"jsonrpc":"2.0","id":1,"method":"ping","result":{}}`,
+		`[]`,
+		`"hello"`,
+		``,
+		`{`,
+	}
+	for _, seed := range seeds {
+		f.Add([]byte(seed))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > maxJSONRPCBodyBytes {
+			return
+		}
+
+		req, err := parseJSONRPCMessage(data)
+
+		if err != nil {
+			if req != nil {
+				t.Fatalf("error result returned non-nil request: %q", data)
+			}
+			var fail *jsonRPCParseFailure
+			if !errors.As(err, &fail) {
+				t.Fatalf("error is not *jsonRPCParseFailure: %T for %q", err, data)
+			}
+			return
+		}
+
+		if req == nil {
+			t.Fatalf("nil request without error: %q", data)
+		}
+		if req.JSONRPC != "2.0" {
+			t.Fatalf("accepted request with jsonrpc=%q: %q", req.JSONRPC, data)
+		}
+		if req.IsReply {
+			if !req.HasID {
+				t.Fatalf("reply without id: %q", data)
+			}
+			if req.Method != "" {
+				t.Fatalf("reply carried method %q: %q", req.Method, data)
+			}
+		} else if req.Method == "" {
+			t.Fatalf("accepted non-reply request without method: %q", data)
+		}
+		if req.HasID && !validJSONRPCID(req.ID) {
+			t.Fatalf("accepted request with invalid id %q: %q", req.ID, data)
+		}
+		if len(req.Params) > 0 {
+			trimmed := bytes.TrimSpace(req.Params)
+			if len(trimmed) == 0 || (trimmed[0] != '{' && trimmed[0] != '[') {
+				t.Fatalf("accepted params that are not object or array: %q", req.Params)
+			}
+		}
+	})
+}

--- a/internal/oidc/oidc_fuzz_test.go
+++ b/internal/oidc/oidc_fuzz_test.go
@@ -1,0 +1,60 @@
+package oidc
+
+import (
+	"strings"
+	"testing"
+)
+
+func FuzzSanitizeReturnTo(f *testing.F) {
+	seeds := []string{
+		"",
+		"/",
+		"/dashboard",
+		"/board?slug=abc",
+		"/oauth/authorize?response_type=code&redirect_uri=https%3A%2F%2Fclient.example%2Fcallback&return_to=https://attacker.example&state=a%2Bb",
+		"//evil.com",
+		"https://evil.com",
+		"/foo\\bar",
+		"%2f%2f",
+		"/%2f%2fevil.example/path",
+		"/../../etc/passwd",
+		"/foo/./bar",
+		"/foo\nbar",
+		"/foo\x00bar",
+		"/foo#bar",
+		"dashboard",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		got := SanitizeReturnTo(raw)
+
+		if got == "" {
+			t.Fatalf("SanitizeReturnTo(%q) returned empty string", raw)
+		}
+		if !strings.HasPrefix(got, "/") {
+			t.Fatalf("SanitizeReturnTo(%q) = %q does not start with '/'", raw, got)
+		}
+		if strings.HasPrefix(got, "//") {
+			t.Fatalf("SanitizeReturnTo(%q) = %q is scheme-relative", raw, got)
+		}
+		if strings.ContainsAny(got, "\\\r\n\x00") || strings.Contains(got, "#") {
+			t.Fatalf("SanitizeReturnTo(%q) = %q retained a rejected character", raw, got)
+		}
+
+		path := got
+		if idx := strings.IndexByte(got, '?'); idx >= 0 {
+			path = got[:idx]
+		}
+		if strings.Contains(path, "://") {
+			t.Fatalf("SanitizeReturnTo(%q) = %q has absolute-URL path", raw, got)
+		}
+		for _, seg := range strings.Split(path, "/") {
+			if seg == "." || seg == ".." {
+				t.Fatalf("SanitizeReturnTo(%q) = %q retained dot segment", raw, got)
+			}
+		}
+	})
+}

--- a/internal/publicorigin/authority_fuzz_test.go
+++ b/internal/publicorigin/authority_fuzz_test.go
@@ -1,0 +1,87 @@
+package publicorigin
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func FuzzParseHTTPAuthority(f *testing.F) {
+	seeds := []string{
+		"example.com",
+		"example.com:8443",
+		"example.com:1",
+		"example.com:65535",
+		"127.0.0.1:8080",
+		"localhost",
+		"[::1]",
+		"[::1]:8080",
+		"[2001:db8::1]:443",
+		"",
+		" example.com",
+		"example.com ",
+		"example\x00.com",
+		"https://evil.example",
+		"evil.example/path",
+		"user@evil.example",
+		"evil.example?query",
+		"evil.example#fragment",
+		"host1.example,host2.example",
+		"evil%2f.example",
+		"evil.example:",
+		"evil.example:0",
+		"evil.example:65536",
+		"evil.example:bad",
+		"::1",
+		"[::1",
+		"::1]",
+		"[]",
+		"[::1]extra",
+		"[::1]:0",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		authority, hostname, ok := ParseHTTPAuthority(raw)
+
+		if !ok {
+			if authority != "" || hostname != "" {
+				t.Fatalf("ParseHTTPAuthority(%q) rejected but returned (%q, %q)", raw, authority, hostname)
+			}
+			return
+		}
+
+		if authority != raw {
+			t.Fatalf("ParseHTTPAuthority(%q) returned authority %q, want == input", raw, authority)
+		}
+		if hostname == "" {
+			t.Fatalf("ParseHTTPAuthority(%q) accepted with empty hostname", raw)
+		}
+		if !strings.Contains(raw, hostname) {
+			t.Fatalf("ParseHTTPAuthority(%q) hostname %q not contained in input", raw, hostname)
+		}
+
+		authority2, hostname2, ok2 := ParseHTTPAuthority(raw)
+		if !ok2 || authority2 != authority || hostname2 != hostname {
+			t.Fatalf("ParseHTTPAuthority(%q) not deterministic: (%q,%q,%v) vs (%q,%q,%v)",
+				raw, authority, hostname, ok, authority2, hostname2, ok2)
+		}
+
+		var portPart string
+		if strings.HasPrefix(authority, "[") {
+			if idx := strings.IndexByte(authority, ']'); idx >= 0 {
+				portPart = authority[idx+1:]
+			}
+		} else if idx := strings.LastIndexByte(authority, ':'); idx >= 0 {
+			portPart = authority[idx:]
+		}
+		if portPart != "" {
+			port, err := strconv.Atoi(strings.TrimPrefix(portPart, ":"))
+			if err != nil || port < 1 || port > 65535 {
+				t.Fatalf("ParseHTTPAuthority(%q) accepted out-of-range port %q", raw, portPart)
+			}
+		}
+	})
+}


### PR DESCRIPTION
 - testing/fuzz JSON-RPC, OIDC return paths, and HTTP authorities
 - add the openssf scorecard badge
 - license cleanup
 - added CODEOWNERS file required to enforce mandatory approval rules
