### PR TITLE
ci(release): serialize Windows Go tests to avoid store timeouts

### DIFF
--- a/.github/workflows/windows-exe-release.yml
+++ b/.github/workflows/windows-exe-release.yml
@@ -47,7 +47,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Test Go
-        run: go test ./... -count=1 -timeout=5m
+        run: go test ./... -count=1 -p=1 -timeout=15m
 
       - name: Prepare artifact names
         id: names


### PR DESCRIPTION
Replace the current Go test command with:
go test ./... -count=1 -p=1 -timeout=15m

