### PR TITLE
update trigger block to accept manual run

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,6 +9,7 @@ on:
     - cron: "20 7 * * 1"
   push:
     branches: [main]
+  workflow_dispatch:
 
 # Declare default permissions as read-only.
 permissions: read-all


### PR DESCRIPTION
allows manual runs on the openssf scorecard