### PR TITLE
Fix/user creation dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 > **Upgrades:** No breaking changes in **3.7.x** / **3.8.x** / **3.9.x** / **3.10.x** / **3.11.x** / **3.12.x** / **3.13.x** / **3.14.x** / **3.15.x** / **3.16.x** / **3.17.x** / **3.18.x** / **3.19.x** / **3.20.x** / **3.21.x** / **3.22.x** unless noted below. **3.22.0** has MCP/OAuth upgrade impact — see that release.
 
+## [3.22.7] - 2026-07-22
+
+### Fixed
+
+- **Settings Create User dialog lifecycle** - Escape / native dismiss no longer leaves an orphaned `<dialog>` in the DOM with duplicate IDs, which previously broke Cancel, password reveal, and Create (submit closed without calling `POST /api/admin/users`). Dynamic Settings dialogs now use scoped lookups and an idempotent remove-on-close teardown; Create User also clears the temporary password on close.
+- **Keybindings chord parsing** - `chordFromKeyboardEvent` null-guards missing `code`/`key` so IME or synthetic keydowns no longer throw in the capture-phase global handler.
+
 ## [3.22.6] - 2026-07-22
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.22.6-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.22.7-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/internal/httpapi/web/dist/core/keybindings.js
+++ b/internal/httpapi/web/dist/core/keybindings.js
@@ -285,19 +285,24 @@ export function chordFromKeyboardEvent(ev) {
         const order = ["ctrl", "alt", "meta", "shift"];
         return order.indexOf(a) - order.indexOf(b);
     });
+    // Some keydown events (IME composition, synthetic events, certain extensions)
+    // arrive with an undefined `code`/`key`; coerce to a safe string so the
+    // capture-phase global handler never throws.
+    const code = ev.code ?? "";
+    const key = ev.key ?? "";
     let base = null;
-    if (ev.code === "Escape")
+    if (code === "Escape")
         base = "escape";
-    else if (ev.code === "Tab")
+    else if (code === "Tab")
         base = "tab";
-    else if (ev.code === "Space")
+    else if (code === "Space")
         base = "space";
-    else if (ev.code.startsWith("Digit"))
-        base = ev.code.slice(5).toLowerCase();
-    else if (ev.code.startsWith("Key"))
-        base = ev.code.slice(3).toLowerCase();
-    else if (ev.key.length === 1)
-        base = ev.key.toLowerCase();
+    else if (code.startsWith("Digit"))
+        base = code.slice(5).toLowerCase();
+    else if (code.startsWith("Key"))
+        base = code.slice(3).toLowerCase();
+    else if (key.length === 1)
+        base = key.toLowerCase();
     if (base === null)
         return null;
     const prefix = mods.length ? `${mods.join("+")}+` : "";

--- a/internal/httpapi/web/dist/dialogs/settings.js
+++ b/internal/httpapi/web/dist/dialogs/settings.js
@@ -410,6 +410,32 @@ function bindDialogLocale(dialog, sync) {
     return release;
 }
 /**
+ * Wire uniform, orphan-free teardown for a dynamically-created dialog.
+ *
+ * Returns an idempotent `close()` that releases the locale listener, runs any
+ * caller cleanup, and removes the node from the DOM. Native dismiss paths
+ * (Escape / light-dismiss `cancel`, and the `close` event) are routed through
+ * the same `close()` so the node can never be left detached-but-present, which
+ * would otherwise duplicate element IDs and misbind handlers on reopen.
+ */
+function attachDialogClose(dialog, releaseLocale, extraCleanup) {
+    let removed = false;
+    const close = () => {
+        if (removed)
+            return;
+        removed = true;
+        extraCleanup?.();
+        releaseLocale();
+        dialog.remove();
+    };
+    dialog.addEventListener("cancel", (event) => {
+        event.preventDefault();
+        close();
+    });
+    dialog.addEventListener("close", close);
+    return close;
+}
+/**
  * Re-localize the Web Push hint without probing push capability or changing the
  * toggle/subscription state. Only the unsupported-browser hint is locale-driven;
  * all other hint states stay empty, matching the binding logic.
@@ -2172,13 +2198,10 @@ function showPasswordResetDialog(userId) {
     document.body.appendChild(dialog);
     dialog.showModal();
     const releaseLocale = bindDialogLocale(dialog);
-    const closeBtn = document.getElementById("passwordResetDialogClose");
-    const cancelBtn = document.getElementById("passwordResetCancel");
-    const form = document.getElementById("passwordResetForm");
-    const close = () => {
-        releaseLocale();
-        document.body.removeChild(dialog);
-    };
+    const closeBtn = dialog.querySelector("#passwordResetDialogClose");
+    const cancelBtn = dialog.querySelector("#passwordResetCancel");
+    const form = dialog.querySelector("#passwordResetForm");
+    const close = attachDialogClose(dialog, releaseLocale);
     if (closeBtn)
         closeBtn.addEventListener("click", close);
     if (cancelBtn)
@@ -2236,13 +2259,10 @@ function showPasswordResetFallbackDialog(resetUrl) {
     document.body.appendChild(dialog);
     dialog.showModal();
     const releaseLocale = bindDialogLocale(dialog);
-    const closeBtn = document.getElementById("passwordResetFallbackClose");
-    const copyBtn = document.getElementById("passwordResetFallbackCopy");
-    const urlInput = document.getElementById("passwordResetUrlDisplay");
-    const close = () => {
-        releaseLocale();
-        document.body.removeChild(dialog);
-    };
+    const closeBtn = dialog.querySelector("#passwordResetFallbackClose");
+    const copyBtn = dialog.querySelector("#passwordResetFallbackCopy");
+    const urlInput = dialog.querySelector("#passwordResetUrlDisplay");
+    const close = attachDialogClose(dialog, releaseLocale);
     if (closeBtn)
         closeBtn.addEventListener("click", close);
     dialog.addEventListener("click", (e) => {
@@ -2328,13 +2348,13 @@ function showCreateUserDialog() {
   `;
     document.body.appendChild(dialog);
     dialog.showModal();
-    const closeBtn = document.getElementById("createUserDialogClose");
-    const cancelBtn = document.getElementById("createUserCancel");
-    const form = document.getElementById("createUserForm");
-    const emailInput = document.getElementById("createUserEmail");
-    const nameInput = document.getElementById("createUserName");
-    const passwordInput = document.getElementById("createUserPassword");
-    const passwordToggle = document.getElementById("createUserPasswordToggle");
+    const closeBtn = dialog.querySelector("#createUserDialogClose");
+    const cancelBtn = dialog.querySelector("#createUserCancel");
+    const form = dialog.querySelector("#createUserForm");
+    const emailInput = dialog.querySelector("#createUserEmail");
+    const nameInput = dialog.querySelector("#createUserName");
+    const passwordInput = dialog.querySelector("#createUserPassword");
+    const passwordToggle = dialog.querySelector("#createUserPasswordToggle");
     const passwordIconPath = passwordToggle?.querySelector("path");
     const PATH_SHOW = "M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z";
     const PATH_HIDE = "M2 5.27L3.28 4 20 20.72 18.73 22 15.65 18.92C14.5 19.3 13.28 19.5 12 19.5 7 19.5 2.73 16.39 1 12c.69-1.76 1.79-3.31 3.19-4.54L2 5.27zM12 9a3 3 0 0 1 3 3c0 .35-.06.69-.17 1l-3.83-3.83c.31-.06.65-.17 1-.17zM12 4.5c5 0 9.27 3.11 11 7.5-.82 2.08-2.21 3.88-4 5.19L17.58 15.76C18.94 14.82 20.06 13.54 20.82 12 19.17 8.64 15.76 6.5 12 6.5c-1.09 0-2.16.18-3.16.5L7.3 5.47C8.74 4.85 10.33 4.5 12 4.5zM3.18 12C4.83 15.36 8.24 17.5 12 17.5c.69 0 1.37-.07 2-.21L11.72 15c-1.43-.15-2.57-1.29-2.72-2.72L5.6 8.87C4.61 9.72 3.78 10.78 3.18 12z";
@@ -2357,10 +2377,10 @@ function showCreateUserDialog() {
             syncPasswordToggleLabel();
         });
     }
-    const close = () => {
-        releaseLocale();
-        document.body.removeChild(dialog);
-    };
+    const close = attachDialogClose(dialog, releaseLocale, () => {
+        if (passwordInput)
+            passwordInput.value = "";
+    });
     if (closeBtn) {
         closeBtn.addEventListener("click", close);
     }
@@ -2372,7 +2392,7 @@ function showCreateUserDialog() {
             close();
         }
     });
-    if (form) {
+    if (form && emailInput && nameInput && passwordInput) {
         form.addEventListener("submit", async (e) => {
             e.preventDefault();
             const email = emailInput.value.trim();
@@ -2575,19 +2595,19 @@ async function showEnable2FADialog() {
         document.body.appendChild(dialog);
         dialog.showModal();
         const releaseLocale = bindDialogLocale(dialog);
-        const close = () => {
-            releaseLocale();
-            document.body.removeChild(dialog);
-        };
-        document.getElementById("enable2FAClose")?.addEventListener("click", close);
-        document.getElementById("enable2FACancel")?.addEventListener("click", close);
+        const form = dialog.querySelector("#enable2FAForm");
+        const codeInput = dialog.querySelector("#enable2FACode");
+        const errorEl = dialog.querySelector("#enable2FAError");
+        const close = attachDialogClose(dialog, releaseLocale, () => {
+            if (codeInput)
+                codeInput.value = "";
+        });
+        dialog.querySelector("#enable2FAClose")?.addEventListener("click", close);
+        dialog.querySelector("#enable2FACancel")?.addEventListener("click", close);
         dialog.addEventListener("click", (e) => {
             if (e.target === dialog)
                 close();
         });
-        const form = document.getElementById("enable2FAForm");
-        const codeInput = document.getElementById("enable2FACode");
-        const errorEl = document.getElementById("enable2FAError");
         const showError = (msg) => {
             if (errorEl) {
                 errorEl.textContent = msg;
@@ -2656,12 +2676,9 @@ function showRecoveryCodesDialog(codes) {
     document.body.appendChild(dialog);
     dialog.showModal();
     const releaseLocale = bindDialogLocale(dialog);
-    const close = () => {
-        releaseLocale();
-        document.body.removeChild(dialog);
-    };
-    document.getElementById("recoveryCodesClose")?.addEventListener("click", close);
-    document.getElementById("recoveryCodesDone")?.addEventListener("click", close);
+    const close = attachDialogClose(dialog, releaseLocale);
+    dialog.querySelector("#recoveryCodesClose")?.addEventListener("click", close);
+    dialog.querySelector("#recoveryCodesDone")?.addEventListener("click", close);
     dialog.addEventListener("click", (e) => {
         if (e.target === dialog)
             close();
@@ -2691,18 +2708,18 @@ function showDisable2FADialog() {
     document.body.appendChild(dialog);
     dialog.showModal();
     const releaseLocale = bindDialogLocale(dialog);
-    const close = () => {
-        releaseLocale();
-        document.body.removeChild(dialog);
-    };
-    document.getElementById("disable2FAClose")?.addEventListener("click", close);
-    document.getElementById("disable2FACancel")?.addEventListener("click", close);
+    const form = dialog.querySelector("#disable2FAForm");
+    const passwordInput = dialog.querySelector("#disable2FAPassword");
+    const close = attachDialogClose(dialog, releaseLocale, () => {
+        if (passwordInput)
+            passwordInput.value = "";
+    });
+    dialog.querySelector("#disable2FAClose")?.addEventListener("click", close);
+    dialog.querySelector("#disable2FACancel")?.addEventListener("click", close);
     dialog.addEventListener("click", (e) => {
         if (e.target === dialog)
             close();
     });
-    const form = document.getElementById("disable2FAForm");
-    const passwordInput = document.getElementById("disable2FAPassword");
     if (form && passwordInput) {
         form.addEventListener("submit", async (e) => {
             e.preventDefault();

--- a/internal/httpapi/web/modules/core/keybindings-metadata.test.ts
+++ b/internal/httpapi/web/modules/core/keybindings-metadata.test.ts
@@ -75,4 +75,26 @@ describe('keybinding metadata compatibility', () => {
       contexts: ['board'],
     });
   });
+
+  it('does not throw when a keydown event has an undefined code/key', async () => {
+    const keybindings = await import('./keybindings.js');
+
+    // IME/synthetic events can arrive without `code`/`key`; the capture-phase
+    // global handler must never throw on them.
+    const bare = { ctrlKey: false, altKey: false, metaKey: false, shiftKey: false } as unknown as KeyboardEvent;
+    expect(() => keybindings.chordFromKeyboardEvent(bare)).not.toThrow();
+    expect(keybindings.chordFromKeyboardEvent(bare)).toBeNull();
+
+    // A modifier-only event (undefined code) with a real key still resolves.
+    const withKey = {
+      code: undefined,
+      key: 'a',
+      ctrlKey: true,
+      altKey: false,
+      metaKey: false,
+      shiftKey: false,
+    } as unknown as KeyboardEvent;
+    expect(() => keybindings.chordFromKeyboardEvent(withKey)).not.toThrow();
+    expect(keybindings.chordFromKeyboardEvent(withKey)).toBe('ctrl+a');
+  });
 });

--- a/internal/httpapi/web/modules/core/keybindings.ts
+++ b/internal/httpapi/web/modules/core/keybindings.ts
@@ -318,13 +318,18 @@ export function chordFromKeyboardEvent(ev: KeyboardEvent): string | null {
     return order.indexOf(a) - order.indexOf(b);
   });
 
+  // Some keydown events (IME composition, synthetic events, certain extensions)
+  // arrive with an undefined `code`/`key`; coerce to a safe string so the
+  // capture-phase global handler never throws.
+  const code = ev.code ?? "";
+  const key = ev.key ?? "";
   let base: string | null = null;
-  if (ev.code === "Escape") base = "escape";
-  else if (ev.code === "Tab") base = "tab";
-  else if (ev.code === "Space") base = "space";
-  else if (ev.code.startsWith("Digit")) base = ev.code.slice(5).toLowerCase();
-  else if (ev.code.startsWith("Key")) base = ev.code.slice(3).toLowerCase();
-  else if (ev.key.length === 1) base = ev.key.toLowerCase();
+  if (code === "Escape") base = "escape";
+  else if (code === "Tab") base = "tab";
+  else if (code === "Space") base = "space";
+  else if (code.startsWith("Digit")) base = code.slice(5).toLowerCase();
+  else if (code.startsWith("Key")) base = code.slice(3).toLowerCase();
+  else if (key.length === 1) base = key.toLowerCase();
 
   if (base === null) return null;
   const prefix = mods.length ? `${mods.join("+")}+` : "";

--- a/internal/httpapi/web/modules/dialogs/settings-profile-users-backup-i18n.test.ts
+++ b/internal/httpapi/web/modules/dialogs/settings-profile-users-backup-i18n.test.ts
@@ -504,6 +504,71 @@ describe('settings i18n (profile / users / backup / customization)', () => {
     expect(apiFetchMock).not.toHaveBeenCalled();
   });
 
+  it('removes the Create-User dialog on Escape so reopening leaves a single live, wired dialog', async () => {
+    const owner = { id: 1, name: 'Owner', email: 'owner@example.com', systemRole: 'owner', twoFactorEnabled: false };
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/admin/users') return [{ id: 1, name: 'Owner', email: 'owner@example.com', systemRole: 'owner' }];
+      return undefined;
+    });
+    await setupSettingsView({ activeTab: 'users', user: owner });
+
+    // Open, then dismiss via the native Escape / light-dismiss `cancel` path.
+    document.getElementById('createUserBtn')?.dispatchEvent(new Event('click'));
+    await flushPromises();
+    expect(document.querySelectorAll('#createUserForm')).toHaveLength(1);
+    const firstDialog = document.querySelector('body > dialog.dialog') as HTMLDialogElement;
+    firstDialog.dispatchEvent(new Event('cancel'));
+
+    // Node must be fully removed, not just closed-and-detached.
+    expect(document.querySelectorAll('#createUserForm')).toHaveLength(0);
+    expect(document.querySelector('body > dialog.dialog')).toBeNull();
+
+    // Reopen, then dismiss via the Cancel button (the reported dead control).
+    document.getElementById('createUserBtn')?.dispatchEvent(new Event('click'));
+    await flushPromises();
+    expect(document.querySelectorAll('#createUserForm')).toHaveLength(1);
+    const secondDialog = document.querySelector('body > dialog.dialog') as HTMLDialogElement;
+    document.getElementById('createUserCancel')?.dispatchEvent(new Event('click'));
+    expect(document.querySelectorAll('#createUserForm')).toHaveLength(0);
+    expect(secondDialog.isConnected).toBe(false);
+
+    // Third open: exactly one dialog, and its own handlers are the live ones.
+    document.getElementById('createUserBtn')?.dispatchEvent(new Event('click'));
+    await flushPromises();
+    expect(document.querySelectorAll('#createUserForm')).toHaveLength(1);
+
+    const dialog = document.querySelector('body > dialog.dialog') as HTMLDialogElement;
+    const emailInput = document.getElementById('createUserEmail') as HTMLInputElement;
+    const nameInput = document.getElementById('createUserName') as HTMLInputElement;
+    const passwordInput = document.getElementById('createUserPassword') as HTMLInputElement;
+    const passwordToggle = document.getElementById('createUserPasswordToggle') as HTMLElement;
+
+    // Password reveal toggle works on the reopened dialog.
+    passwordToggle.dispatchEvent(new Event('click'));
+    expect(passwordInput.type).toBe('text');
+
+    // Submit posts to the admin endpoint with the typed values (handler bound to the live form).
+    apiFetchMock.mockClear();
+    emailInput.value = 'new@example.com';
+    nameInput.value = 'New User';
+    passwordInput.value = 'password1234';
+    const form = document.getElementById('createUserForm') as HTMLFormElement;
+    form.dispatchEvent(new Event('submit', { cancelable: true }));
+    await flushPromises();
+
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/users', {
+      method: 'POST',
+      body: JSON.stringify({
+        email: 'new@example.com',
+        name: 'New User',
+        password: 'password1234',
+      }),
+    });
+    // Successful create closes and removes the dialog too.
+    expect(document.querySelectorAll('#createUserForm')).toHaveLength(0);
+    expect(dialog.isConnected).toBe(false);
+  });
+
   // ---- Backup / Trello --------------------------------------------------
 
   it('rebuilds backup preview/warnings from stored state on locale change while preserving import mode, REPLACE input, and making no API calls', async () => {

--- a/internal/httpapi/web/modules/dialogs/settings.ts
+++ b/internal/httpapi/web/modules/dialogs/settings.ts
@@ -522,6 +522,36 @@ function bindDialogLocale(dialog: HTMLDialogElement, sync?: () => void): () => v
 }
 
 /**
+ * Wire uniform, orphan-free teardown for a dynamically-created dialog.
+ *
+ * Returns an idempotent `close()` that releases the locale listener, runs any
+ * caller cleanup, and removes the node from the DOM. Native dismiss paths
+ * (Escape / light-dismiss `cancel`, and the `close` event) are routed through
+ * the same `close()` so the node can never be left detached-but-present, which
+ * would otherwise duplicate element IDs and misbind handlers on reopen.
+ */
+function attachDialogClose(
+  dialog: HTMLDialogElement,
+  releaseLocale: () => void,
+  extraCleanup?: () => void
+): () => void {
+  let removed = false;
+  const close = () => {
+    if (removed) return;
+    removed = true;
+    extraCleanup?.();
+    releaseLocale();
+    dialog.remove();
+  };
+  dialog.addEventListener("cancel", (event) => {
+    event.preventDefault();
+    close();
+  });
+  dialog.addEventListener("close", close);
+  return close;
+}
+
+/**
  * Re-localize the Web Push hint without probing push capability or changing the
  * toggle/subscription state. Only the unsupported-browser hint is locale-driven;
  * all other hint states stay empty, matching the binding logic.
@@ -2374,14 +2404,11 @@ function showPasswordResetDialog(userId: string): void {
   (dialog as HTMLDialogElement).showModal();
   const releaseLocale = bindDialogLocale(dialog);
 
-  const closeBtn = document.getElementById("passwordResetDialogClose");
-  const cancelBtn = document.getElementById("passwordResetCancel");
-  const form = document.getElementById("passwordResetForm") as HTMLFormElement;
+  const closeBtn = dialog.querySelector<HTMLElement>("#passwordResetDialogClose");
+  const cancelBtn = dialog.querySelector<HTMLElement>("#passwordResetCancel");
+  const form = dialog.querySelector<HTMLFormElement>("#passwordResetForm");
 
-  const close = () => {
-    releaseLocale();
-    document.body.removeChild(dialog);
-  };
+  const close = attachDialogClose(dialog, releaseLocale);
 
   if (closeBtn) closeBtn.addEventListener("click", close);
   if (cancelBtn) cancelBtn.addEventListener("click", close);
@@ -2441,14 +2468,11 @@ function showPasswordResetFallbackDialog(resetUrl: string): void {
   (dialog as HTMLDialogElement).showModal();
   const releaseLocale = bindDialogLocale(dialog);
 
-  const closeBtn = document.getElementById("passwordResetFallbackClose");
-  const copyBtn = document.getElementById("passwordResetFallbackCopy");
-  const urlInput = document.getElementById("passwordResetUrlDisplay") as HTMLInputElement;
+  const closeBtn = dialog.querySelector<HTMLElement>("#passwordResetFallbackClose");
+  const copyBtn = dialog.querySelector<HTMLElement>("#passwordResetFallbackCopy");
+  const urlInput = dialog.querySelector<HTMLInputElement>("#passwordResetUrlDisplay");
 
-  const close = () => {
-    releaseLocale();
-    document.body.removeChild(dialog);
-  };
+  const close = attachDialogClose(dialog, releaseLocale);
 
   if (closeBtn) closeBtn.addEventListener("click", close);
   dialog.addEventListener("click", (e) => {
@@ -2535,13 +2559,13 @@ function showCreateUserDialog(): void {
   document.body.appendChild(dialog);
   (dialog as HTMLDialogElement).showModal();
 
-  const closeBtn = document.getElementById("createUserDialogClose");
-  const cancelBtn = document.getElementById("createUserCancel");
-  const form = document.getElementById("createUserForm") as HTMLFormElement;
-  const emailInput = document.getElementById("createUserEmail") as HTMLInputElement;
-  const nameInput = document.getElementById("createUserName") as HTMLInputElement;
-  const passwordInput = document.getElementById("createUserPassword") as HTMLInputElement;
-  const passwordToggle = document.getElementById("createUserPasswordToggle");
+  const closeBtn = dialog.querySelector<HTMLElement>("#createUserDialogClose");
+  const cancelBtn = dialog.querySelector<HTMLElement>("#createUserCancel");
+  const form = dialog.querySelector<HTMLFormElement>("#createUserForm");
+  const emailInput = dialog.querySelector<HTMLInputElement>("#createUserEmail");
+  const nameInput = dialog.querySelector<HTMLInputElement>("#createUserName");
+  const passwordInput = dialog.querySelector<HTMLInputElement>("#createUserPassword");
+  const passwordToggle = dialog.querySelector<HTMLElement>("#createUserPasswordToggle");
   const passwordIconPath = passwordToggle?.querySelector("path");
 
   const PATH_SHOW = "M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z";
@@ -2567,10 +2591,9 @@ function showCreateUserDialog(): void {
     });
   }
 
-  const close = () => {
-    releaseLocale();
-    document.body.removeChild(dialog);
-  };
+  const close = attachDialogClose(dialog, releaseLocale, () => {
+    if (passwordInput) passwordInput.value = "";
+  });
 
   if (closeBtn) {
     closeBtn.addEventListener("click", close);
@@ -2584,7 +2607,7 @@ function showCreateUserDialog(): void {
     }
   });
 
-  if (form) {
+  if (form && emailInput && nameInput && passwordInput) {
     form.addEventListener("submit", async (e) => {
       e.preventDefault();
       const email = emailInput.value.trim();
@@ -2791,20 +2814,20 @@ async function showEnable2FADialog(): Promise<void> {
     (dialog as HTMLDialogElement).showModal();
     const releaseLocale = bindDialogLocale(dialog);
 
-    const close = () => {
-      releaseLocale();
-      document.body.removeChild(dialog);
-    };
+    const form = dialog.querySelector<HTMLFormElement>("#enable2FAForm");
+    const codeInput = dialog.querySelector<HTMLInputElement>("#enable2FACode");
+    const errorEl = dialog.querySelector<HTMLElement>("#enable2FAError");
 
-    document.getElementById("enable2FAClose")?.addEventListener("click", close);
-    document.getElementById("enable2FACancel")?.addEventListener("click", close);
+    const close = attachDialogClose(dialog, releaseLocale, () => {
+      if (codeInput) codeInput.value = "";
+    });
+
+    dialog.querySelector<HTMLElement>("#enable2FAClose")?.addEventListener("click", close);
+    dialog.querySelector<HTMLElement>("#enable2FACancel")?.addEventListener("click", close);
     dialog.addEventListener("click", (e) => {
       if (e.target === dialog) close();
     });
 
-    const form = document.getElementById("enable2FAForm");
-    const codeInput = document.getElementById("enable2FACode") as HTMLInputElement;
-    const errorEl = document.getElementById("enable2FAError") as HTMLElement | null;
     const showError = (msg: string) => {
       if (errorEl) {
         errorEl.textContent = msg;
@@ -2872,13 +2895,10 @@ function showRecoveryCodesDialog(codes: string[]): void {
   (dialog as HTMLDialogElement).showModal();
   const releaseLocale = bindDialogLocale(dialog);
 
-  const close = () => {
-    releaseLocale();
-    document.body.removeChild(dialog);
-  };
+  const close = attachDialogClose(dialog, releaseLocale);
 
-  document.getElementById("recoveryCodesClose")?.addEventListener("click", close);
-  document.getElementById("recoveryCodesDone")?.addEventListener("click", close);
+  dialog.querySelector<HTMLElement>("#recoveryCodesClose")?.addEventListener("click", close);
+  dialog.querySelector<HTMLElement>("#recoveryCodesDone")?.addEventListener("click", close);
   dialog.addEventListener("click", (e) => {
     if (e.target === dialog) close();
   });
@@ -2909,19 +2929,19 @@ function showDisable2FADialog(): void {
   (dialog as HTMLDialogElement).showModal();
   const releaseLocale = bindDialogLocale(dialog);
 
-  const close = () => {
-    releaseLocale();
-    document.body.removeChild(dialog);
-  };
+  const form = dialog.querySelector<HTMLFormElement>("#disable2FAForm");
+  const passwordInput = dialog.querySelector<HTMLInputElement>("#disable2FAPassword");
 
-  document.getElementById("disable2FAClose")?.addEventListener("click", close);
-  document.getElementById("disable2FACancel")?.addEventListener("click", close);
+  const close = attachDialogClose(dialog, releaseLocale, () => {
+    if (passwordInput) passwordInput.value = "";
+  });
+
+  dialog.querySelector<HTMLElement>("#disable2FAClose")?.addEventListener("click", close);
+  dialog.querySelector<HTMLElement>("#disable2FACancel")?.addEventListener("click", close);
   dialog.addEventListener("click", (e) => {
     if (e.target === dialog) close();
   });
 
-  const form = document.getElementById("disable2FAForm");
-  const passwordInput = document.getElementById("disable2FAPassword") as HTMLInputElement;
   if (form && passwordInput) {
     form.addEventListener("submit", async (e) => {
       e.preventDefault();

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.22.6"
+const Version = "3.22.7"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
- **Settings Create User dialog lifecycle** - Escape / native dismiss no longer leaves an orphaned `<dialog>` in the DOM with duplicate IDs, which previously broke Cancel, password reveal, and Create (submit closed without calling `POST /api/admin/users`). Dynamic Settings dialogs now use scoped lookups and an idempotent remove-on-close teardown; Create User also clears the temporary password on close.
- **Keybindings chord parsing** - `chordFromKeyboardEvent` null-guards missing `code`/`key` so IME or synthetic keydowns no longer throw in the capture-phase global handler.
