### PR TITLE
prevent release tags from silently generating latest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,18 +2,17 @@ name: Build and Push to GHCR
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
     tags:
       - 'v*'
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
   workflow_dispatch:
     inputs:
       branch:
         description: 'Branch to build as test-build; leave blank to use the selected workflow branch or a PR number'
         required: false
         default: ''
-
       pr_number:
         description: 'Pull request number to build as test-build; leave blank for a branch build'
         required: false
@@ -27,12 +26,13 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 concurrency:
-  group: docker-publish
+  group: ${{ github.workflow }}-${{ case(github.event_name == 'workflow_dispatch', 'test-build', github.ref) }}
   cancel-in-progress: true
 
 jobs:
   build-and-push:
     runs-on: ubuntu-22.04
+
     permissions:
       contents: read
       packages: write
@@ -59,17 +59,26 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ case(github.event_name != 'workflow_dispatch', github.ref, github.event.inputs.pr_number != '', format('refs/pull/{0}/head', github.event.inputs.pr_number), github.event.inputs.branch != '', github.event.inputs.branch, github.ref) }}
+          persist-credentials: false
 
-      # Required: Go binary embeds web/** at build time; Docker context must include built dist/
+      - name: Capture checked-out commit
+        id: source
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: internal/httpapi/web/package-lock.json
+
       - name: Build frontend
+        working-directory: internal/httpapi/web
         run: |
-          cd internal/httpapi/web
           npm ci
           npm run build
 
-      # Needed for the linux/arm64 image: the Go compile cross-builds natively
-      # (see Dockerfile BUILDPLATFORM), but the runtime stage's `RUN mkdir`
-      # executes in the target arch, so buildx needs QEMU on the amd64 runner.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
@@ -77,24 +86,30 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch,enable=${{ github.event_name == 'push' && github.ref_type == 'branch' }}
+            type=ref,event=pr,enable=${{ github.event_name == 'pull_request' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+            type=sha,prefix=sha-,enable=${{ github.event_name == 'push' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=raw,value=test-build,enable=${{ github.event_name == 'workflow_dispatch' }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.source.outputs.sha }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -102,9 +117,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ${{ steps.meta.outputs.tags }}
-            ${{ github.event_name == 'workflow_dispatch' && format('{0}/{1}:test-build', env.REGISTRY, env.IMAGE_NAME) || '' }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
flavor: latest=false prevents release tags from silently generating latest; the explicit latest rule becomes the only way that tag can be emitted. Docker documents both the automatic behavior and the enable attribute used to control each tag rule.

The previous global concurrency group meant a manual test-build could cancel an in-progress main image build, or vice versa. The revised group keeps all test-build runs together while separating them from production branch and release builds. GitHub confirms that runs sharing a concurrency group can cancel one another when cancel-in-progress is enabled.