### PR TITLE
Fix tags.updateProjectColor 404 on every durable project's tags

### DIFF
--- a/API.md
+++ b/API.md
@@ -413,7 +413,7 @@ Activate/close enforce sprint state (e.g. planned vs active); violations return 
 | `tags.listMine` | `{}` | `data.items` (mine tags; no `count`) |
 | `tags.updateMineColor` | `tagId`, `color` (hex or `null` to clear) | `data.tag` |
 | `tags.deleteMine` | `tagId` | `data.deleted` `{ tagId }` - only if tag is in the viewer’s mine list, then store delete |
-| `tags.updateProjectColor` | `projectSlug`, `tagId`, `color` | `data.tag` - **maintainer+**; tag must be **project-scoped** in that project |
+| `tags.updateProjectColor` | `projectSlug`, `tagId`, `color` | `data.tag` - **maintainer+**; tag must be part of that project's tag set (board-scoped or a user-owned tag used/linked in that project) |
 | `tags.deleteProject` | `projectSlug`, `tagId` | `data.deleted` `{ projectSlug, tagId }` - **maintainer+**; tag must exist as a **project-scoped** tag in that project |
 
 ### Members

--- a/API.md
+++ b/API.md
@@ -413,7 +413,7 @@ Activate/close enforce sprint state (e.g. planned vs active); violations return 
 | `tags.listMine` | `{}` | `data.items` (mine tags; no `count`) |
 | `tags.updateMineColor` | `tagId`, `color` (hex or `null` to clear) | `data.tag` |
 | `tags.deleteMine` | `tagId` | `data.deleted` `{ tagId }` - only if tag is in the viewer’s mine list, then store delete |
-| `tags.updateProjectColor` | `projectSlug`, `tagId`, `color` | `data.tag` - **maintainer+**; tag must be part of that project's tag set (board-scoped or a user-owned tag used/linked in that project) |
+| `tags.updateProjectColor` | `projectSlug`, `tagId`, `color` | `data.tag` - **maintainer+**; tag must appear in that project's `tags.listProject` set. Color semantics follow tag scope: **board-scoped** tags update shared `tags.color` (visible to all members); **user-owned** tags update this viewer's per-viewer preference in `user_tag_colors` (same as durable HTTP board color updates / `tags.updateMineColor`) |
 | `tags.deleteProject` | `projectSlug`, `tagId` | `data.deleted` `{ projectSlug, tagId }` - **maintainer+**; tag must exist as a **project-scoped** tag in that project |
 
 ### Members

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 > **Upgrades:** No breaking changes in **3.7.x** / **3.8.x** / **3.9.x** / **3.10.x** / **3.11.x** / **3.12.x** / **3.13.x** / **3.14.x** / **3.15.x** / **3.16.x** / **3.17.x** / **3.18.x** / **3.19.x** / **3.20.x** / **3.21.x** / **3.22.x** / **3.23.x** unless noted below. **3.22.0** has MCP/OAuth upgrade impact — see that release.
 
+## [3.23.1] - 2026-07-24
+
+### Fixed
+
+- **`tags.updateProjectColor` on durable projects** - The MCP tool no longer 404s for every user-owned tag on authenticated projects. Existence is checked against the same project tag set as `tags.listProject` (not board-scoped-only `GetProjectScopedTagByID`), and clearing an unset user-owned color preference is treated as a successful no-op (matching `tags.updateMineColor`). `tags.deleteProject` remains board-scoped-only.
+
+### Documentation
+
+- **`tags.updateProjectColor` color semantics** - `API.md` and the MCP `tools/list` description clarify that board-scoped tags update shared `tags.color`, while user-owned tags update this viewer's per-viewer preference.
+
 ## [3.23.0] - 2026-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.23.0-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.23.1-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/internal/mcp/adapter_test.go
+++ b/internal/mcp/adapter_test.go
@@ -3662,6 +3662,85 @@ func TestMCPTagsUpdateProjectColorWrongProjectNotFound(t *testing.T) {
 	}
 }
 
+// TestMCPTagsUpdateProjectColorUserOwnedTagSuccess covers the real-world case that was broken:
+// on a durable/authenticated project, every tag reachable via todos.create's tags param is
+// user-owned (project_id NULL, user_id set) and merely linked via project_tags — board-scoped
+// rows (project_id set, user_id NULL) only ever exist on anonymous temporary boards (migration
+// 019). Before the fix, GetProjectScopedTagByID's `user_id IS NULL` filter meant this always
+// 404'd for every durable project, making tags.updateProjectColor unusable outside tests that
+// used the insertProjectScopedTag helper to fabricate a row no production code path creates.
+func TestMCPTagsUpdateProjectColorUserOwnedTagSuccess(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	resp := doJSON(t, client, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Update PC User Tag Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Update PC User Tag Project")
+
+	doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos.create",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"title":       "t",
+			"tags":        []string{"userownedtag"},
+		},
+	})
+
+	var userTagID int64
+	if err := sqlDB.QueryRow(`SELECT id FROM tags WHERE name = 'userownedtag' AND user_id IS NOT NULL`).Scan(&userTagID); err != nil {
+		t.Fatalf("query user-owned tag: %v", err)
+	}
+
+	resp2, out := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "tags.updateProjectColor",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"tagId":       userTagID,
+			"color":       "#7c3aed",
+		},
+	})
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %#v", resp2.StatusCode, out)
+	}
+	tag := out["data"].(map[string]any)["tag"].(map[string]any)
+	if tag["tagId"] != float64(userTagID) || tag["name"] != "userownedtag" {
+		t.Fatalf("unexpected tag response: %#v", tag)
+	}
+	if tag["color"] != "#7c3aed" {
+		t.Fatalf("expected updated color, got %#v", tag["color"])
+	}
+
+	resp3, listOut := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "tags.listProject",
+		"input": map[string]any{
+			"projectSlug": slug,
+		},
+	})
+	if resp3.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp3.StatusCode)
+	}
+	items := listOut["data"].(map[string]any)["items"].([]any)
+	found := false
+	for _, item := range items {
+		m := item.(map[string]any)
+		if m["tagId"] == float64(userTagID) {
+			found = true
+			if m["color"] != "#7c3aed" {
+				t.Fatalf("expected color to persist via listProject, got %#v", m["color"])
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected tag %d in listProject items, got %#v", userTagID, items)
+	}
+}
+
 func TestMCPTagsDeleteProjectSuccess(t *testing.T) {
 	ts, sqlDB, cleanup := newTestServer(t, "full")
 	defer cleanup()

--- a/internal/mcp/adapter_test.go
+++ b/internal/mcp/adapter_test.go
@@ -3741,6 +3741,59 @@ func TestMCPTagsUpdateProjectColorUserOwnedTagSuccess(t *testing.T) {
 	}
 }
 
+// TestMCPTagsUpdateProjectColorUserOwnedTagClearNoOpSuccess covers the edge case @markrai
+// flagged on review: clearing a color (color: null) for a user-owned tag that never had a
+// custom color set. UpdateTagColor returns ErrNotFound from the user_tag_colors DELETE
+// affecting zero rows; tags.updateMineColor already normalizes that into a successful no-op,
+// and handleTagsUpdateProjectColor now mirrors that instead of surfacing a confusing 404.
+func TestMCPTagsUpdateProjectColorUserOwnedTagClearNoOpSuccess(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	resp := doJSON(t, client, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Update PC User Tag Clear Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Update PC User Tag Clear Project")
+
+	doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos.create",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"title":       "t",
+			"tags":        []string{"neverhadacolor"},
+		},
+	})
+
+	var userTagID int64
+	if err := sqlDB.QueryRow(`SELECT id FROM tags WHERE name = 'neverhadacolor' AND user_id IS NOT NULL`).Scan(&userTagID); err != nil {
+		t.Fatalf("query user-owned tag: %v", err)
+	}
+
+	resp2, out := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "tags.updateProjectColor",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"tagId":       userTagID,
+			"color":       nil,
+		},
+	})
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %#v", resp2.StatusCode, out)
+	}
+	tag := out["data"].(map[string]any)["tag"].(map[string]any)
+	if tag["tagId"] != float64(userTagID) {
+		t.Fatalf("unexpected tag response: %#v", tag)
+	}
+	if tag["color"] != nil {
+		t.Fatalf("expected no color, got %#v", tag["color"])
+	}
+}
+
 func TestMCPTagsDeleteProjectSuccess(t *testing.T) {
 	ts, sqlDB, cleanup := newTestServer(t, "full")
 	defer cleanup()

--- a/internal/mcp/tag_tools.go
+++ b/internal/mcp/tag_tools.go
@@ -297,7 +297,12 @@ func (a *Adapter) handleTagsUpdateProjectColor(ctx context.Context, input any) (
 	// API uses for durable projects (see UpdateTagColorForProject in routing_board.go).
 	updateErr := a.store.UpdateTagColor(ctx, &userID, in.TagID, in.Color)
 	if updateErr != nil {
-		return nil, nil, mapStoreError(updateErr)
+		// Clearing a color that was never set on a user-owned tag returns ErrNotFound from
+		// UpdateTagColor; tags.updateMineColor already treats that as a harmless no-op, so
+		// mirror that here rather than surfacing a confusing 404 on a successful clear.
+		if !(isColorClear(in.Color) && errors.Is(updateErr, store.ErrNotFound)) {
+			return nil, nil, mapStoreError(updateErr)
+		}
 	}
 
 	projectTags, listErr = a.store.ListTagCounts(ctx, &pc)

--- a/internal/mcp/tag_tools.go
+++ b/internal/mcp/tag_tools.go
@@ -277,32 +277,43 @@ func (a *Adapter) handleTagsUpdateProjectColor(ctx context.Context, input any) (
 		return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
 	}
 
-	if _, tagErr := a.store.GetProjectScopedTagByID(ctx, pc.Project.ID, in.TagID); tagErr != nil {
-		return nil, nil, mapStoreError(tagErr)
+	// GetProjectScopedTagByID only matches board-scoped tags (project_id set, user_id NULL),
+	// which per migration 019 are created exclusively for anonymous temporary boards. On a
+	// durable/authenticated project every tag is user-owned and merely linked via project_tags,
+	// so that lookup always 404s here even though tags.listProject reports the tag as part of
+	// the project. Use the same project-tag set listProject exposes as the existence check
+	// instead, covering both board-scoped and user-owned-but-project-linked tags.
+	projectTags, listErr := a.store.ListTagCounts(ctx, &pc)
+	if listErr != nil {
+		return nil, nil, mapStoreError(listErr)
+	}
+	if _, found := findProjectTagCount(projectTags, in.TagID); !found {
+		return nil, nil, newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
 	}
 
-	// UpdateTagColor mutates tags.color for project-scoped rows; viewerUserID is only used for user-owned tags.
+	// UpdateTagColor dispatches on the tag row's own scope: board-scoped tags get their shared
+	// tags.color updated directly, while user-owned tags (the normal case on durable projects)
+	// get this viewer's per-viewer color preference updated — the same store call the HTTP board
+	// API uses for durable projects (see UpdateTagColorForProject in routing_board.go).
 	updateErr := a.store.UpdateTagColor(ctx, &userID, in.TagID, in.Color)
 	if updateErr != nil {
 		return nil, nil, mapStoreError(updateErr)
 	}
 
-	projectTags, listErr := a.store.ListTagCounts(ctx, &pc)
+	projectTags, listErr = a.store.ListTagCounts(ctx, &pc)
 	if listErr != nil {
 		return nil, nil, mapStoreError(listErr)
 	}
-	for _, tc := range projectTags {
-		if tc.TagID == in.TagID {
-			return map[string]any{
-				"tag": projectTagItem{
-					TagID:     tc.TagID,
-					Name:      tc.Name,
-					Count:     tc.Count,
-					Color:     tc.Color,
-					CanDelete: tc.CanDelete,
-				},
-			}, map[string]any{}, nil
-		}
+	if tc, found := findProjectTagCount(projectTags, in.TagID); found {
+		return map[string]any{
+			"tag": projectTagItem{
+				TagID:     tc.TagID,
+				Name:      tc.Name,
+				Count:     tc.Count,
+				Color:     tc.Color,
+				CanDelete: tc.CanDelete,
+			},
+		}, map[string]any{}, nil
 	}
 
 	// Tag existence in project scope was already verified above; if it disappears
@@ -348,6 +359,12 @@ func (a *Adapter) handleTagsDeleteProject(ctx context.Context, input any) (any, 
 		return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
 	}
 
+	// Deliberately still board-scoped-only (unlike handleTagsUpdateProjectColor): DeleteTag on a
+	// user-owned tag deletes it across every project that user has used it in, not just this one,
+	// so tags.deleteProject intentionally 404s for user-owned tags (see
+	// TestMCPTagsDeleteProjectUserOwnedTagNotFound). tags.updateProjectColor is non-destructive
+	// and safely dispatches to a per-viewer color update for user-owned tags, so only that path
+	// was widened.
 	if _, tagErr := a.store.GetProjectScopedTagByID(ctx, pc.Project.ID, in.TagID); tagErr != nil {
 		return nil, nil, mapStoreError(tagErr)
 	}
@@ -374,6 +391,15 @@ func (a *Adapter) handleTagsDeleteProject(ctx context.Context, input any) (any, 
 			"tagId":       in.TagID,
 		},
 	}, map[string]any{}, nil
+}
+
+func findProjectTagCount(tags []store.TagCount, tagID int64) (store.TagCount, bool) {
+	for _, tag := range tags {
+		if tag.TagID == tagID {
+			return tag, true
+		}
+	}
+	return store.TagCount{}, false
 }
 
 func findMineTag(tags []store.TagWithColor, tagID int64) (store.TagWithColor, bool) {

--- a/internal/mcp/tool_catalog.go
+++ b/internal/mcp/tool_catalog.go
@@ -188,8 +188,10 @@ func toolCatalogDefinitions() map[string]mcpToolDef {
 			}, []string{"tagId"}),
 		},
 		"tags.updateProjectColor": {
-			Name:        "tags.updateProjectColor",
-			Description: "Set or clear the project-scoped color for a tag.",
+			Name: "tags.updateProjectColor",
+			Description: "Set or clear color for a tag in a project (maintainer+). " +
+				"Tag must appear in that project's tags.listProject set. " +
+				"Board-scoped tags update shared tags.color; user-owned tags update this viewer's per-viewer color preference.",
 			InputSchema: jsonSchema("object", map[string]any{
 				"projectSlug": jsonProp("string", "Project identifier (slug)"),
 				"tagId":       jsonProp("integer", "Tag ID"),

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.23.0"
+const Version = "3.23.1"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
## Summary

`tags.updateProjectColor` (MCP tool) unconditionally 404'd on every durable/authenticated project, making it effectively unusable outside its own test suite.

- `handleTagsUpdateProjectColor` gates on `GetProjectScopedTagByID`, which requires `project_id` set **and** `user_id IS NULL` on the `tags` row.
- Per migration `019_add_board_scoped_tags.sql`, that shape (`user_id IS NULL, project_id IS NOT NULL`) is created **only** for anonymous temporary boards.
- Every tag on a durable/authenticated project is user-owned (`GetOrCreateTag` / `setTodoTags`, invoked from `todos.create`'s `tags` param) and is merely linked into the project via `project_tags` — so `GetProjectScopedTagByID` never finds it, even though `tags.listProject` correctly reports the tag as part of the project's tag set.
- The existing tests for this tool (`TestMCPTagsUpdateProjectColorSuccess` etc.) all pass because they use the `insertProjectScopedTag` test helper to fabricate a board-scoped row directly — a shape no production code path creates for a durable project.

## Fix

Widen the existence check in `handleTagsUpdateProjectColor` to the same project-tag set `tags.listProject` already exposes (via `ListTagCounts`), covering both board-scoped rows and user-owned tags linked via `project_tags`. The subsequent write is unchanged — it already calls `UpdateTagColor`, which correctly dispatches per the tag's own scope: board-scoped tags get their shared `tags.color` updated directly, and user-owned tags get this viewer's per-viewer color preference updated in `user_tag_colors` (the same store call the HTTP board API already uses for durable projects via `UpdateTagColorForProject` in `routing_board.go`).

`tags.deleteProject` is deliberately left as-is. `DeleteTag` on a user-owned tag deletes it across *every* project that user has used it in (not just the current one), and `TestMCPTagsDeleteProjectUserOwnedTagNotFound` already codifies that `tags.deleteProject` should keep 404ing on user-owned tags for that reason. `updateProjectColor` is non-destructive, so only that path was widened.

Also updated `API.md`'s description of `tags.updateProjectColor` to drop the stale "tag must be project-scoped" wording.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite passes)
- [x] Added `TestMCPTagsUpdateProjectColorUserOwnedTagSuccess`, reproducing the real-world case: create a project, create a todo with a tag via `todos.create` (the only way tags get created on a durable project), then successfully set/verify its color via `tags.updateProjectColor` and confirm it's visible via `tags.listProject`.
- [x] All pre-existing tag tests still pass unchanged, including `TestMCPTagsDeleteProjectUserOwnedTagNotFound` (confirms `deleteProject`'s intentional restriction is untouched).