### PR TITLE
Admin-configurable default email notification preferences for new users (Phase 1 of #169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 > **Upgrades:** No breaking changes in **3.7.x** / **3.8.x** / **3.9.x** / **3.10.x** / **3.11.x** / **3.12.x** / **3.13.x** / **3.14.x** / **3.15.x** / **3.16.x** / **3.17.x** / **3.18.x** / **3.19.x** / **3.20.x** / **3.21.x** / **3.22.x** / **3.23.x** unless noted below. **3.22.0** has MCP/OAuth upgrade impact — see that release.
 
+## [3.23.2] - 2026-07-24
+
+### Added
+
+- **Admin-configurable default email notification preferences for new users** - Admins/owners can set an org-wide default that newly created users inherit, via `GET`/`PUT`/`DELETE /api/admin/settings/email-notify-default`. Seeding happens at creation time only and never rewrites existing users. When no override is configured, no preference row is created for new users, so an untouched instance behaves exactly as before. `DELETE` resets to the unconfigured state (`204`, idempotent). See [docs/notifications.md](docs/notifications.md).
+
+### Changed
+
+- **`user_preferences` provenance** - New `provenance` column (migration 059; `legacy` / `user` / `org_default`) records how each preference row was written. Existing rows become `legacy`; explicit user saves are tagged `user`; org-seeded rows are `org_default`. This is groundwork so a future bulk-apply can safely target only org-seeded rows and never overwrite user-customized ones. **Upgrade note:** remove any hand-rolled `AFTER INSERT ON users` preference trigger before upgrading — explicit-column triggers keep working, but positional `INSERT INTO user_preferences VALUES (...)` triggers become structurally invalid once the column is added. Running an older binary against a 059-migrated database is unsupported (forward-only upgrades).
+
 ## [3.23.1] - 2026-07-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.23.1-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.23.2-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -11,6 +11,7 @@ self-service password reset and notification email.
 - [Categories](#categories)
 - [Recipients](#recipients)
 - [User settings](#user-settings)
+- [Org-wide default for new users](#org-wide-default-for-new-users)
 - [Delivery isolation](#delivery-isolation)
 - [HTTP endpoints](#http-endpoints)
 - [Quick verification](#quick-verification)
@@ -106,6 +107,28 @@ localized failure copy. A failed initial load leaves the authenticated controls 
 than showing defaults or state from another account. Signing out or changing accounts clears the
 in-memory authenticated preference state. Signed-out/anonymous use may retain a local-only value.
 
+## Org-wide default for new users
+
+By default, every newly created user starts with the hardcoded defaults shown in
+[Categories](#categories) (**Assigned to me** and **Added to a project** on, everything else off,
+master toggle off). An admin or owner can override this per-instance default via
+`GET`/`PUT /api/admin/settings/email-notify-default` (see [HTTP endpoints](#http-endpoints)) so
+that new users start with the organization's preferred configuration instead.
+
+This is a **seed at creation time only** (#169 Phase 1), not a live-applied policy:
+
+- Changing the org default has **no effect on existing users** — each user's own
+  `emailNotifications` row, once written, is never rewritten by a later org-default change.
+- A user created **before** an org-default change keeps whatever default was in effect at their
+  own creation time (the hardcoded default, if no override existed yet).
+- A user created **after** an org-default change is seeded with the new value at creation.
+- The very first (bootstrap) user is never seeded from an org default — there is no admin yet to
+  have configured one — and instead falls back to the hardcoded default via the normal unset-value
+  path described in [HTTP endpoints](#http-endpoints).
+- There is currently no bulk-apply action to retroactively push an org-default change onto
+  existing users who haven't customized their own preferences; that and an admin-facing settings
+  UI panel are tracked as follow-up work.
+
 ## Delivery isolation
 
 Transactional account mail and bulk notification mail use separate bounded queues and separate
@@ -145,6 +168,16 @@ canonical defaults. An explicit `v` must be numeric `1`. Known boolean fields ma
 inherit their canonical defaults, while explicit `false` is preserved. Unknown fields, `null`,
 arrays, malformed JSON, unsupported or invalid versions, and non-boolean category values are
 rejected. Every write emits the complete canonical v1 object shown above in stable field order.
+
+**Org-wide default** (admin/owner only — see
+[Org-wide default for new users](#org-wide-default-for-new-users)):
+
+- `GET /api/admin/settings/email-notify-default` → `{"value": "<JSON>", "customized": bool}`.
+  `value` is always the complete canonical object currently in effect (the hardcoded default when
+  no override exists); `customized` reports whether an admin has actually set one.
+- `PUT /api/admin/settings/email-notify-default` with `{"value": "<JSON>"}` — same JSON shape and
+  validation rules as the per-user preference above. Requires `system_role` of `admin` or `owner`;
+  returns `403` otherwise.
 
 ---
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -115,19 +115,39 @@ master toggle off). An admin or owner can override this per-instance default via
 `GET`/`PUT /api/admin/settings/email-notify-default` (see [HTTP endpoints](#http-endpoints)) so
 that new users start with the organization's preferred configuration instead.
 
-This is a **seed at creation time only** (#169 Phase 1), not a live-applied policy:
+This is a **seed at creation time only**, not a live-applied policy:
 
 - Changing the org default has **no effect on existing users** — each user's own
   `emailNotifications` row, once written, is never rewritten by a later org-default change.
-- A user created **before** an org-default change keeps whatever default was in effect at their
-  own creation time (the hardcoded default, if no override existed yet).
-- A user created **after** an org-default change is seeded with the new value at creation.
+- **When no override is configured, new users are seeded no row at all** — they behave exactly
+  like an instance that never used this feature, resolving to the hardcoded default lazily. A row
+  is only written when an admin/owner has actually configured an override.
+- A user created **before** an override existed keeps that rowless state and is unaffected by any
+  later change.
+- A user created **after** an override is set is seeded with the current value at creation, tagged
+  internally as an org-seeded row (provenance `org_default`). When that user later saves their own
+  preferences, the row is re-tagged as user-owned (`user`).
 - The very first (bootstrap) user is never seeded from an org default — there is no admin yet to
   have configured one — and instead falls back to the hardcoded default via the normal unset-value
   path described in [HTTP endpoints](#http-endpoints).
+- A **corrupt** stored override (only reachable by editing the database directly) is non-fatal:
+  new users are simply not seeded (no fallback row is invented) so account creation still succeeds,
+  while admin `GET` continues to surface the corruption as an error.
+- To return to the unconfigured state, use `DELETE /api/admin/settings/email-notify-default`
+  (see [HTTP endpoints](#http-endpoints)). Re-`PUT`ting the hardcoded values is not the same as
+  clearing, because `customized` stays `true` until the override is deleted.
 - There is currently no bulk-apply action to retroactively push an org-default change onto
   existing users who haven't customized their own preferences; that and an admin-facing settings
-  UI panel are tracked as follow-up work.
+  UI panel are tracked as follow-up work. The provenance tagging above exists so a future
+  bulk-apply can safely target only org-seeded rows and never overwrite user-customized ones.
+
+> **Upgrading from a hand-rolled trigger:** some self-hosted operators worked around the lack of
+> this feature with a custom `AFTER INSERT ON users` SQLite trigger that inserts an
+> `emailNotifications` row. Remove that trigger before upgrading. A trigger that lists columns
+> explicitly (`INSERT INTO user_preferences (user_id, key, value, updated_at) VALUES (...)`) will
+> keep working (the app's seed upsert overwrites its row when an override is configured), but a
+> **positional** trigger (`INSERT INTO user_preferences VALUES (...)`) becomes structurally invalid
+> once the `provenance` column is added and must be removed.
 
 ## Delivery isolation
 
@@ -178,6 +198,10 @@ rejected. Every write emits the complete canonical v1 object shown above in stab
 - `PUT /api/admin/settings/email-notify-default` with `{"value": "<JSON>"}` — same JSON shape and
   validation rules as the per-user preference above. Requires `system_role` of `admin` or `owner`;
   returns `403` otherwise.
+- `DELETE /api/admin/settings/email-notify-default` — clears the override, returning `GET` to
+  `customized: false` and the hardcoded default. Existing users' preferences are untouched;
+  subsequently created users are seeded no row. Requires `system_role` of `admin` or `owner`
+  (`403` otherwise); returns `204 No Content` and is idempotent (deleting when unset still `204`).
 
 ---
 

--- a/internal/httpapi/admin_email_notify_default_test.go
+++ b/internal/httpapi/admin_email_notify_default_test.go
@@ -1,12 +1,13 @@
 package httpapi
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 )
 
-// TestAdminEmailNotifyDefault_GetDefaultsToHardcodedFallback covers #169 Phase 1:
-// before any admin override, GET reports the hardcoded DefaultEmailNotifyPref
+// TestAdminEmailNotifyDefault_GetDefaultsToHardcodedFallback covers the unset
+// path: before any admin override, GET reports the hardcoded DefaultEmailNotifyPref
 // with customized=false.
 func TestAdminEmailNotifyDefault_GetDefaultsToHardcodedFallback(t *testing.T) {
 	ts, _, cleanup := newTestHTTPServer(t, "full")
@@ -29,7 +30,7 @@ func TestAdminEmailNotifyDefault_GetDefaultsToHardcodedFallback(t *testing.T) {
 }
 
 // TestAdminEmailNotifyDefault_PutRequiresAdminOrOwnerAndSeedsNewUsers is the core
-// end-to-end behavior for #169 Phase 1: only admin/owner can set the org default,
+// end-to-end behavior: only admin/owner can set the org default,
 // and it seeds only users created after the change -- never retroactively.
 func TestAdminEmailNotifyDefault_PutRequiresAdminOrOwnerAndSeedsNewUsers(t *testing.T) {
 	ts, _, cleanup := newTestHTTPServer(t, "full")
@@ -95,16 +96,17 @@ func TestAdminEmailNotifyDefault_PutRequiresAdminOrOwnerAndSeedsNewUsers(t *test
 		t.Fatalf("new user should have inherited org default, got %v", pref["value"])
 	}
 
-	// The plain user, created BEFORE the org default change, was seeded from
-	// whatever the org default was AT THAT TIME (the hardcoded fallback, since no
-	// override existed yet) and is unaffected by the later admin change.
+	// The plain user, created BEFORE any org default existed, was never seeded a
+	// row (compatibility guarantee: untouched installs invent no rows), so their
+	// stored value is empty and resolves to the hardcoded default lazily. The
+	// later admin change does not retroactively affect them.
 	var plainPref map[string]any
 	resp, _ = doJSON(t, plain, http.MethodGet, ts.URL+"/api/user/preferences?key=emailNotifications", nil, &plainPref)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("get plain user preferences: expected 200, got %d", resp.StatusCode)
 	}
-	if plainPref["value"] != `{"v":1,"enabled":false,"assigned":true,"cardActivity":false,"sprintActivity":false,"projectActivity":false,"addedToProject":true}` {
-		t.Fatalf("plain user's preference should be the pre-change hardcoded default, got %v", plainPref["value"])
+	if plainPref["value"] != "" {
+		t.Fatalf("plain user created before any override should have no stored preference, got %v", plainPref["value"])
 	}
 }
 
@@ -131,5 +133,145 @@ func TestAdminEmailNotifyDefault_UnauthenticatedRejected(t *testing.T) {
 	resp, _ := doJSON(t, client, http.MethodGet, ts.URL+"/api/admin/settings/email-notify-default", nil, nil)
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+}
+
+const emailNotifyDefaultPath = "/api/admin/settings/email-notify-default"
+
+// TestAdminEmailNotifyDefault_DeleteAuthorization covers the reset endpoint's
+// authorization matrix and idempotency.
+func TestAdminEmailNotifyDefault_DeleteAuthorization(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServer(t, "full")
+	defer cleanup()
+
+	owner := newCookieClient(t)
+	bootstrapUserClient(t, owner, ts.URL, "Owner", "owner@example.com", "password123")
+
+	// Create a plain user and an admin (promoted from a plain user).
+	var plainUser map[string]any
+	resp, _ := doJSON(t, owner, http.MethodPost, ts.URL+"/api/admin/users", map[string]any{
+		"name": "Plain", "email": "plain@example.com", "password": "password123",
+	}, &plainUser)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create plain user: expected 201, got %d", resp.StatusCode)
+	}
+
+	var adminUser map[string]any
+	resp, _ = doJSON(t, owner, http.MethodPost, ts.URL+"/api/admin/users", map[string]any{
+		"name": "Admin", "email": "admin@example.com", "password": "password123",
+	}, &adminUser)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create admin user: expected 201, got %d", resp.StatusCode)
+	}
+	resp, _ = doJSON(t, owner, http.MethodPatch, ts.URL+fmt.Sprintf("/api/admin/users/%d/role", int64(adminUser["id"].(float64))), map[string]any{"role": "admin"}, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("promote admin: expected 200, got %d", resp.StatusCode)
+	}
+
+	// Unauthenticated DELETE -> 401.
+	anon := &http.Client{}
+	resp, _ = doJSON(t, anon, http.MethodDelete, ts.URL+emailNotifyDefaultPath, nil, nil)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("anon DELETE: expected 401, got %d", resp.StatusCode)
+	}
+
+	// Ordinary user DELETE -> 403.
+	plain := newCookieClient(t)
+	loginUserClient(t, plain, ts.URL, "plain@example.com", "password123")
+	resp, _ = doJSON(t, plain, http.MethodDelete, ts.URL+emailNotifyDefaultPath, nil, nil)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("plain DELETE: expected 403, got %d", resp.StatusCode)
+	}
+
+	// Admin DELETE -> 204 (bodyless).
+	admin := newCookieClient(t)
+	loginUserClient(t, admin, ts.URL, "admin@example.com", "password123")
+	resp, body := doJSON(t, admin, http.MethodDelete, ts.URL+emailNotifyDefaultPath, nil, nil)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("admin DELETE: expected 204, got %d", resp.StatusCode)
+	}
+	if len(body) != 0 {
+		t.Fatalf("expected empty body on 204, got %q", string(body))
+	}
+
+	// Owner DELETE -> 204, and repeated DELETE still 204 (idempotent).
+	resp, _ = doJSON(t, owner, http.MethodDelete, ts.URL+emailNotifyDefaultPath, nil, nil)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("owner DELETE: expected 204, got %d", resp.StatusCode)
+	}
+	resp, _ = doJSON(t, owner, http.MethodDelete, ts.URL+emailNotifyDefaultPath, nil, nil)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("repeated owner DELETE: expected 204, got %d", resp.StatusCode)
+	}
+}
+
+// TestAdminEmailNotifyDefault_DeleteResetsToUnset verifies that after setting and
+// then deleting the override, GET reports customized=false and a user created
+// afterward is not seeded, while a user created before the reset is unchanged.
+func TestAdminEmailNotifyDefault_DeleteResetsToUnset(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServer(t, "full")
+	defer cleanup()
+
+	owner := newCookieClient(t)
+	bootstrapUserClient(t, owner, ts.URL, "Owner", "owner@example.com", "password123")
+
+	// Set an override, then create a user who inherits it.
+	resp, _ := doJSON(t, owner, http.MethodPut, ts.URL+emailNotifyDefaultPath, map[string]any{
+		"value": `{"enabled":true,"projectActivity":true}`,
+	}, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PUT override: expected 200, got %d", resp.StatusCode)
+	}
+	resp, _ = doJSON(t, owner, http.MethodPost, ts.URL+"/api/admin/users", map[string]any{
+		"name": "Before", "email": "before@example.com", "password": "password123",
+	}, nil)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create before user: expected 201, got %d", resp.StatusCode)
+	}
+
+	// Reset.
+	resp, _ = doJSON(t, owner, http.MethodDelete, ts.URL+emailNotifyDefaultPath, nil, nil)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE: expected 204, got %d", resp.StatusCode)
+	}
+
+	// GET now reports customized=false.
+	var out map[string]any
+	resp, _ = doJSON(t, owner, http.MethodGet, ts.URL+emailNotifyDefaultPath, nil, &out)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET after reset: expected 200, got %d", resp.StatusCode)
+	}
+	if out["customized"] != false {
+		t.Fatalf("expected customized=false after reset, got %v", out["customized"])
+	}
+
+	// The user created before reset keeps their inherited preference.
+	before := newCookieClient(t)
+	loginUserClient(t, before, ts.URL, "before@example.com", "password123")
+	var beforePref map[string]any
+	resp, _ = doJSON(t, before, http.MethodGet, ts.URL+"/api/user/preferences?key=emailNotifications", nil, &beforePref)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("before user prefs: expected 200, got %d", resp.StatusCode)
+	}
+	if beforePref["value"] != `{"v":1,"enabled":true,"assigned":true,"cardActivity":false,"sprintActivity":false,"projectActivity":true,"addedToProject":true}` {
+		t.Fatalf("before user's inherited preference should be unchanged, got %v", beforePref["value"])
+	}
+
+	// A user created after reset has no stored value (rowless lazy default).
+	resp, _ = doJSON(t, owner, http.MethodPost, ts.URL+"/api/admin/users", map[string]any{
+		"name": "After", "email": "after@example.com", "password": "password123",
+	}, nil)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create after user: expected 201, got %d", resp.StatusCode)
+	}
+	after := newCookieClient(t)
+	loginUserClient(t, after, ts.URL, "after@example.com", "password123")
+	var afterPref map[string]any
+	resp, _ = doJSON(t, after, http.MethodGet, ts.URL+"/api/user/preferences?key=emailNotifications", nil, &afterPref)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("after user prefs: expected 200, got %d", resp.StatusCode)
+	}
+	if afterPref["value"] != "" {
+		t.Fatalf("expected empty stored value for user created after reset, got %v", afterPref["value"])
 	}
 }

--- a/internal/httpapi/admin_email_notify_default_test.go
+++ b/internal/httpapi/admin_email_notify_default_test.go
@@ -1,0 +1,135 @@
+package httpapi
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestAdminEmailNotifyDefault_GetDefaultsToHardcodedFallback covers #169 Phase 1:
+// before any admin override, GET reports the hardcoded DefaultEmailNotifyPref
+// with customized=false.
+func TestAdminEmailNotifyDefault_GetDefaultsToHardcodedFallback(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServer(t, "full")
+	defer cleanup()
+
+	client := newCookieClient(t)
+	bootstrapUserClient(t, client, ts.URL, "Owner", "owner@example.com", "password123")
+
+	var out map[string]any
+	resp, _ := doJSON(t, client, http.MethodGet, ts.URL+"/api/admin/settings/email-notify-default", nil, &out)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if out["customized"] != false {
+		t.Fatalf("expected customized=false, got %v", out["customized"])
+	}
+	if out["value"] != `{"v":1,"enabled":false,"assigned":true,"cardActivity":false,"sprintActivity":false,"projectActivity":false,"addedToProject":true}` {
+		t.Fatalf("unexpected default value: %v", out["value"])
+	}
+}
+
+// TestAdminEmailNotifyDefault_PutRequiresAdminOrOwnerAndSeedsNewUsers is the core
+// end-to-end behavior for #169 Phase 1: only admin/owner can set the org default,
+// and it seeds only users created after the change -- never retroactively.
+func TestAdminEmailNotifyDefault_PutRequiresAdminOrOwnerAndSeedsNewUsers(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServer(t, "full")
+	defer cleanup()
+
+	owner := newCookieClient(t)
+	bootstrapUserClient(t, owner, ts.URL, "Owner", "owner@example.com", "password123")
+
+	// Plain user, created before any org default override exists.
+	var plainUser map[string]any
+	resp, _ := doJSON(t, owner, http.MethodPost, ts.URL+"/api/admin/users", map[string]any{
+		"name":     "Plain",
+		"email":    "plain@example.com",
+		"password": "password123",
+	}, &plainUser)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create plain user: expected 201, got %d", resp.StatusCode)
+	}
+
+	plain := newCookieClient(t)
+	loginUserClient(t, plain, ts.URL, "plain@example.com", "password123")
+
+	// Plain (non-admin) user cannot set the org default.
+	resp, _ = doJSON(t, plain, http.MethodPut, ts.URL+"/api/admin/settings/email-notify-default", map[string]any{
+		"value": `{"enabled":true}`,
+	}, nil)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("plain user PUT: expected 403, got %d", resp.StatusCode)
+	}
+
+	// Owner sets the org default.
+	var out map[string]any
+	resp, _ = doJSON(t, owner, http.MethodPut, ts.URL+"/api/admin/settings/email-notify-default", map[string]any{
+		"value": `{"enabled":true,"projectActivity":true}`,
+	}, &out)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("owner PUT: expected 200, got %d", resp.StatusCode)
+	}
+	if out["customized"] != true {
+		t.Fatalf("expected customized=true, got %v", out["customized"])
+	}
+
+	// A user created AFTER the org default was set inherits it as their initial preference.
+	var newUser map[string]any
+	resp, _ = doJSON(t, owner, http.MethodPost, ts.URL+"/api/admin/users", map[string]any{
+		"name":     "New",
+		"email":    "new@example.com",
+		"password": "password123",
+	}, &newUser)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create new user: expected 201, got %d", resp.StatusCode)
+	}
+
+	newClient := newCookieClient(t)
+	loginUserClient(t, newClient, ts.URL, "new@example.com", "password123")
+
+	var pref map[string]any
+	resp, _ = doJSON(t, newClient, http.MethodGet, ts.URL+"/api/user/preferences?key=emailNotifications", nil, &pref)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get new user preferences: expected 200, got %d", resp.StatusCode)
+	}
+	if pref["value"] != `{"v":1,"enabled":true,"assigned":true,"cardActivity":false,"sprintActivity":false,"projectActivity":true,"addedToProject":true}` {
+		t.Fatalf("new user should have inherited org default, got %v", pref["value"])
+	}
+
+	// The plain user, created BEFORE the org default change, was seeded from
+	// whatever the org default was AT THAT TIME (the hardcoded fallback, since no
+	// override existed yet) and is unaffected by the later admin change.
+	var plainPref map[string]any
+	resp, _ = doJSON(t, plain, http.MethodGet, ts.URL+"/api/user/preferences?key=emailNotifications", nil, &plainPref)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get plain user preferences: expected 200, got %d", resp.StatusCode)
+	}
+	if plainPref["value"] != `{"v":1,"enabled":false,"assigned":true,"cardActivity":false,"sprintActivity":false,"projectActivity":false,"addedToProject":true}` {
+		t.Fatalf("plain user's preference should be the pre-change hardcoded default, got %v", plainPref["value"])
+	}
+}
+
+func TestAdminEmailNotifyDefault_RejectsInvalidJSON(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServer(t, "full")
+	defer cleanup()
+
+	client := newCookieClient(t)
+	bootstrapUserClient(t, client, ts.URL, "Owner", "owner@example.com", "password123")
+
+	resp, _ := doJSON(t, client, http.MethodPut, ts.URL+"/api/admin/settings/email-notify-default", map[string]any{
+		"value": `{"unknown":true}`,
+	}, nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestAdminEmailNotifyDefault_UnauthenticatedRejected(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServer(t, "full")
+	defer cleanup()
+
+	client := &http.Client{}
+	resp, _ := doJSON(t, client, http.MethodGet, ts.URL+"/api/admin/settings/email-notify-default", nil, nil)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+}

--- a/internal/httpapi/routing_admin.go
+++ b/internal/httpapi/routing_admin.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -61,6 +62,12 @@ func (s *Server) handleAdmin(w http.ResponseWriter, r *http.Request, rest []stri
 		} else {
 			writeError(w, http.StatusNotFound, "NOT_FOUND", "not found", nil)
 		}
+		return
+	}
+
+	if rest[0] == "settings" && len(rest) == 2 && rest[1] == "email-notify-default" {
+		// GET/PUT /api/admin/settings/email-notify-default
+		s.handleAdminEmailNotifyDefault(w, r, userID)
 		return
 	}
 
@@ -251,4 +258,62 @@ func (s *Server) handleAdminUsersPasswordReset(w http.ResponseWriter, r *http.Re
 		"reset_url":  resetURL,
 		"expires_at": expiresAt.UTC().Format(time.RFC3339),
 	})
+}
+
+// handleAdminEmailNotifyDefault gets/sets the org-wide default emailNotifications
+// preference newly created users are seeded with (#169 Phase 1). It never touches
+// existing users' own preferences -- see seedEmailNotifyPrefTx in internal/store.
+func (s *Server) handleAdminEmailNotifyDefault(w http.ResponseWriter, r *http.Request, requesterID int64) {
+	ctx := s.requestContext(r)
+
+	switch r.Method {
+	case http.MethodGet:
+		// GET /api/admin/settings/email-notify-default
+		pref, customized, err := s.store.GetEmailNotifyOrgDefault(ctx)
+		if err != nil {
+			writeStoreErr(w, err, false)
+			return
+		}
+		canonical, err := json.Marshal(pref)
+		if err != nil {
+			writeInternal(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"value":      string(canonical),
+			"customized": customized,
+		})
+		return
+
+	case http.MethodPut:
+		// PUT /api/admin/settings/email-notify-default - Body: { value: string }
+		var in struct {
+			Value string `json:"value"`
+		}
+		if err := readJSON(w, r, s.maxBody, &in); err != nil {
+			return
+		}
+		if err := s.store.SetEmailNotifyOrgDefault(ctx, requesterID, in.Value); err != nil {
+			writeStoreErr(w, err, false)
+			return
+		}
+		pref, _, err := s.store.GetEmailNotifyOrgDefault(ctx)
+		if err != nil {
+			writeStoreErr(w, err, false)
+			return
+		}
+		canonical, err := json.Marshal(pref)
+		if err != nil {
+			writeInternal(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"value":      string(canonical),
+			"customized": true,
+		})
+		return
+
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed", nil)
+	}
 }

--- a/internal/httpapi/routing_admin.go
+++ b/internal/httpapi/routing_admin.go
@@ -261,7 +261,7 @@ func (s *Server) handleAdminUsersPasswordReset(w http.ResponseWriter, r *http.Re
 }
 
 // handleAdminEmailNotifyDefault gets/sets the org-wide default emailNotifications
-// preference newly created users are seeded with (#169 Phase 1). It never touches
+// preference newly created users are seeded with. It never touches
 // existing users' own preferences -- see seedEmailNotifyPrefTx in internal/store.
 func (s *Server) handleAdminEmailNotifyDefault(w http.ResponseWriter, r *http.Request, requesterID int64) {
 	ctx := s.requestContext(r)
@@ -311,6 +311,16 @@ func (s *Server) handleAdminEmailNotifyDefault(w http.ResponseWriter, r *http.Re
 			"value":      string(canonical),
 			"customized": true,
 		})
+		return
+
+	case http.MethodDelete:
+		// DELETE /api/admin/settings/email-notify-default - reset to unconfigured.
+		// Existing users' preferences are untouched; subsequent users get no seeded row.
+		if err := s.store.ClearEmailNotifyOrgDefault(ctx, requesterID); err != nil {
+			writeStoreErr(w, err, false)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
 		return
 
 	default:

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -286,6 +286,8 @@ type storeAPI interface {
 	GetUserPreference(ctx context.Context, userID int64, key string) (string, error)
 	SetUserPreference(ctx context.Context, userID int64, key, value string) error
 	GetEmailNotifyPref(ctx context.Context, userID int64) (store.EmailNotifyPref, error)
+	GetEmailNotifyOrgDefault(ctx context.Context) (store.EmailNotifyPref, bool, error)
+	SetEmailNotifyOrgDefault(ctx context.Context, requesterID int64, raw string) error
 
 	// 2FA
 	CreateLogin2FAPending(ctx context.Context, userID int64, ttl time.Duration) (token string, expiresAt time.Time, err error)

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -288,6 +288,7 @@ type storeAPI interface {
 	GetEmailNotifyPref(ctx context.Context, userID int64) (store.EmailNotifyPref, error)
 	GetEmailNotifyOrgDefault(ctx context.Context) (store.EmailNotifyPref, bool, error)
 	SetEmailNotifyOrgDefault(ctx context.Context, requesterID int64, raw string) error
+	ClearEmailNotifyOrgDefault(ctx context.Context, requesterID int64) error
 
 	// 2FA
 	CreateLogin2FAPending(ctx context.Context, userID int64, ttl time.Duration) (token string, expiresAt time.Time, err error)

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -337,3 +337,54 @@ func TestApplyWithCanceledContextReturnsError(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+// TestMigration059ClassifiesExistingPreferencesAsLegacy proves that a
+// user_preferences row written before migration 059 is classified as 'legacy'
+// (unknown writer, never auto-updated by a future bulk-apply), and that the
+// migration leaves the row's value and updated_at untouched.
+func TestMigration059ClassifiesExistingPreferencesAsLegacy(t *testing.T) {
+	ctx := context.Background()
+	sqlDB := openRawTestDB(t)
+	if _, err := sqlDB.ExecContext(ctx, `CREATE TABLE schema_migrations (version TEXT PRIMARY KEY, applied_at INTEGER NOT NULL)`); err != nil {
+		t.Fatalf("create schema_migrations: %v", err)
+	}
+	const target = "059_add_user_preferences_provenance.sql"
+	for _, version := range embeddedMigrationVersions(t) {
+		if version == target {
+			break
+		}
+		if err := applyOne(ctx, sqlDB, version); err != nil {
+			t.Fatalf("apply %s: %v", version, err)
+		}
+	}
+
+	now := time.Now().UTC().UnixMilli()
+	if _, err := sqlDB.ExecContext(ctx, `INSERT INTO users(id, email, created_at, name, system_role) VALUES (1, 'owner@example.com', ?, 'Owner', 'owner')`, now); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	const value = `{"v":1,"enabled":true,"assigned":true,"cardActivity":false,"sprintActivity":false,"projectActivity":false,"addedToProject":true}`
+	if _, err := sqlDB.ExecContext(ctx, `INSERT INTO user_preferences(user_id, key, value, updated_at) VALUES (1, 'emailNotifications', ?, ?)`, value, now); err != nil {
+		t.Fatalf("insert pre-059 preference: %v", err)
+	}
+
+	if err := applyOne(ctx, sqlDB, target); err != nil {
+		t.Fatalf("apply migration 059: %v", err)
+	}
+
+	var gotValue, gotProvenance string
+	var gotUpdatedAt int64
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT value, provenance, updated_at FROM user_preferences WHERE user_id = 1 AND key = 'emailNotifications'`,
+	).Scan(&gotValue, &gotProvenance, &gotUpdatedAt); err != nil {
+		t.Fatalf("read migrated preference: %v", err)
+	}
+	if gotProvenance != "legacy" {
+		t.Fatalf("expected provenance 'legacy', got %q", gotProvenance)
+	}
+	if gotValue != value {
+		t.Fatalf("value changed by migration: got %q, want %q", gotValue, value)
+	}
+	if gotUpdatedAt != now {
+		t.Fatalf("updated_at changed by migration: got %d, want %d", gotUpdatedAt, now)
+	}
+}

--- a/internal/migrate/migrations/058_add_org_settings.sql
+++ b/internal/migrate/migrations/058_add_org_settings.sql
@@ -1,0 +1,9 @@
+-- Migration 058: Add org_settings table for org-wide admin-configurable settings.
+-- Phase 1 of #169: a DB-backed org default for the emailNotifications preference,
+-- seeded onto newly created users only -- never applied retroactively.
+
+CREATE TABLE IF NOT EXISTS org_settings (
+  key        TEXT PRIMARY KEY,
+  value      TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);

--- a/internal/migrate/migrations/059_add_user_preferences_provenance.sql
+++ b/internal/migrate/migrations/059_add_user_preferences_provenance.sql
@@ -1,0 +1,10 @@
+-- Migration 059: Add provenance to user_preferences.
+-- Records how each preference row was written so a future bulk-apply can safely
+-- distinguish org-seeded rows from user-customized rows.
+-- Existing rows default to 'legacy' (unknown writer) and must never be
+-- auto-updated by bulk-apply. Values are application-defined; unknown values
+-- are treated conservatively (ineligible for automatic bulk updates). No SQLite
+-- CHECK constraint, so adding a future provenance value stays cheap.
+
+ALTER TABLE user_preferences
+  ADD COLUMN provenance TEXT NOT NULL DEFAULT 'legacy';

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -499,6 +499,9 @@ func (s *Store) CreateUser(ctx context.Context, email, password, name string) (U
 	if err != nil {
 		return User{}, fmt.Errorf("last insert id user: %w", err)
 	}
+	if err := seedEmailNotifyPrefTx(ctx, tx, id); err != nil {
+		return User{}, err
+	}
 	if err := tx.Commit(); err != nil {
 		return User{}, fmt.Errorf("commit create user tx: %w", err)
 	}
@@ -742,6 +745,15 @@ func (s *Store) CreateUserOIDC(ctx context.Context, configuredIssuer, issuer, su
 			return User{}, ErrConflict
 		}
 		return User{}, fmt.Errorf("insert oidc identity: %w", err)
+	}
+
+	// Bootstrap (the first user, becoming owner) predates any org default an
+	// admin could have configured, so it keeps the hardcoded fallback via the
+	// normal lazy GetEmailNotifyPref path rather than seeding a row here.
+	if !isBootstrap {
+		if err := seedEmailNotifyPrefTx(ctx, tx, userID); err != nil {
+			return User{}, err
+		}
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/store/org_settings.go
+++ b/internal/store/org_settings.go
@@ -9,7 +9,7 @@ import (
 )
 
 // orgSettingEmailNotifyDefault is the org_settings key holding the admin-configured
-// default emailNotifications preference new users are seeded with (#169 Phase 1).
+// default emailNotifications preference new users are seeded with.
 const orgSettingEmailNotifyDefault = "emailNotifyDefault"
 
 // GetOrgSetting retrieves an org-wide setting value by key.
@@ -84,26 +84,62 @@ func (s *Store) SetEmailNotifyOrgDefault(ctx context.Context, requesterID int64,
 	return tx.Commit()
 }
 
-// seedEmailNotifyPrefTx writes the current org-wide default email-notification
-// preference as a brand-new user's initial user_preferences row, within the same
-// transaction as the user's creation. This is what makes an admin-configured
-// default apply only to users created from this point forward: existing users'
-// rows (or lack thereof, which falls back to the hardcoded DefaultEmailNotifyPref
-// via ParseEmailNotifyPref) are never touched.
+// ClearEmailNotifyOrgDefault removes the org-wide default email-notification
+// override, returning GetEmailNotifyOrgDefault to its unconfigured state
+// (customized=false, hardcoded fallback). Requires admin or owner role. Existing
+// users' own preferences are never modified; subsequently created users get no
+// seeded row (the rowless lazy-default path). Deleting a missing override is a
+// no-op success.
+func (s *Store) ClearEmailNotifyOrgDefault(ctx context.Context, requesterID int64) error {
+	if err := s.requireAdmin(ctx, requesterID); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM org_settings WHERE key = ?`, orgSettingEmailNotifyDefault); err != nil {
+		return fmt.Errorf("clear email notification org default: %w", err)
+	}
+	return nil
+}
+
+// seedEmailNotifyPrefTx seeds a brand-new user's initial emailNotifications
+// preference row from the current org-wide default, within the same transaction
+// as the user's creation.
+//
+// Compatibility contract:
+//   - No admin override configured -> insert nothing, so the user keeps the exact
+//     rowless behavior of a stock instance (lazy hardcoded DefaultEmailNotifyPref
+//     via GetEmailNotifyPref). This is what makes an untouched install behave
+//     identically to before the org-default feature existed.
+//   - Override configured -> upsert the canonical value tagged as org_default.
+//     The upsert is conflict-safe so a legacy hand-rolled AFTER INSERT ON users
+//     trigger that pre-inserts the row does not collide, and the official value
+//     wins over the trigger's.
+//   - Corrupt (non-empty, unparseable) override -> skip seeding rather than
+//     failing account creation; the user falls back to the lazy hardcoded default.
+//     This is deliberately not equivalent to "unset": admin GET still surfaces the
+//     corruption as an error.
 func seedEmailNotifyPrefTx(ctx context.Context, tx *sql.Tx, userID int64) error {
 	var raw string
 	err := tx.QueryRowContext(ctx, `SELECT value FROM org_settings WHERE key = ?`, orgSettingEmailNotifyDefault).Scan(&raw)
-	if err != nil && err != sql.ErrNoRows {
+	if err == sql.ErrNoRows {
+		// No override configured: preserve the rowless fallback behavior.
+		return nil
+	}
+	if err != nil {
+		// Must check before treating raw == "" as unset: a failed Scan leaves raw
+		// as the empty string, so combining those conditions would swallow real
+		// query errors (e.g. missing table) as a successful no-op.
 		return fmt.Errorf("get org email notify default: %w", err)
 	}
-	// ParseEmailNotifyPref("") already returns DefaultEmailNotifyPref(), covering
-	// both sql.ErrNoRows (raw == "") and the never-configured case uniformly.
+	if raw == "" {
+		// Row exists but value is empty: treat like unset (no seed).
+		return nil
+	}
 	pref, err := ParseEmailNotifyPref(raw)
 	if err != nil {
-		// Unreachable in practice: SetEmailNotifyOrgDefault only ever stores
-		// canonicalized, already-validated JSON. Fall back rather than fail
-		// user creation over a corrupted org setting.
-		pref = DefaultEmailNotifyPref()
+		// Corrupt org setting (only reachable via direct DB tampering, since
+		// SetEmailNotifyOrgDefault stores canonicalized, validated JSON). Skip
+		// seeding so account creation still succeeds; do not invent a fallback row.
+		return nil
 	}
 	canonical, err := json.Marshal(pref)
 	if err != nil {
@@ -111,9 +147,10 @@ func seedEmailNotifyPrefTx(ctx context.Context, tx *sql.Tx, userID int64) error 
 	}
 	nowMs := time.Now().UTC().UnixMilli()
 	if _, err := tx.ExecContext(ctx, `
-INSERT INTO user_preferences (user_id, key, value, updated_at)
-VALUES (?, 'emailNotifications', ?, ?)
-`, userID, string(canonical), nowMs); err != nil {
+INSERT INTO user_preferences (user_id, key, value, updated_at, provenance)
+VALUES (?, 'emailNotifications', ?, ?, ?)
+ON CONFLICT (user_id, key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at, provenance = excluded.provenance
+`, userID, string(canonical), nowMs, preferenceProvenanceOrgDefault); err != nil {
 		return fmt.Errorf("seed email notification preference: %w", err)
 	}
 	return nil

--- a/internal/store/org_settings.go
+++ b/internal/store/org_settings.go
@@ -1,0 +1,120 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// orgSettingEmailNotifyDefault is the org_settings key holding the admin-configured
+// default emailNotifications preference new users are seeded with (#169 Phase 1).
+const orgSettingEmailNotifyDefault = "emailNotifyDefault"
+
+// GetOrgSetting retrieves an org-wide setting value by key.
+// Returns empty string if not found (not an error).
+func (s *Store) GetOrgSetting(ctx context.Context, key string) (string, error) {
+	var value string
+	err := s.db.QueryRowContext(ctx, `SELECT value FROM org_settings WHERE key = ?`, key).Scan(&value)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		return "", fmt.Errorf("get org setting: %w", err)
+	}
+	return value, nil
+}
+
+func setOrgSettingTx(ctx context.Context, tx *sql.Tx, key, value string) error {
+	nowMs := time.Now().UTC().UnixMilli()
+	_, err := tx.ExecContext(ctx, `
+INSERT INTO org_settings (key, value, updated_at)
+VALUES (?, ?, ?)
+ON CONFLICT (key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+`, key, value, nowMs)
+	if err != nil {
+		return fmt.Errorf("set org setting: %w", err)
+	}
+	return nil
+}
+
+// GetEmailNotifyOrgDefault returns the org-wide default email-notification
+// preference newly created users are seeded with, falling back to
+// DefaultEmailNotifyPref() when no admin override has been configured.
+// customized reports whether an admin has actually set an override (as opposed
+// to the caller just seeing the hardcoded fallback).
+func (s *Store) GetEmailNotifyOrgDefault(ctx context.Context) (pref EmailNotifyPref, customized bool, err error) {
+	raw, err := s.GetOrgSetting(ctx, orgSettingEmailNotifyDefault)
+	if err != nil {
+		return EmailNotifyPref{}, false, err
+	}
+	pref, err = ParseEmailNotifyPref(raw)
+	if err != nil {
+		return EmailNotifyPref{}, false, err
+	}
+	return pref, raw != "", nil
+}
+
+// SetEmailNotifyOrgDefault sets the org-wide default email-notification preference
+// newly created users are seeded with. Requires admin or owner role. Existing
+// users' own preferences are never modified by this call -- the new default only
+// takes effect for users created after it's set (see seedEmailNotifyPrefTx).
+func (s *Store) SetEmailNotifyOrgDefault(ctx context.Context, requesterID int64, raw string) error {
+	if err := s.requireAdmin(ctx, requesterID); err != nil {
+		return err
+	}
+	pref, err := ParseEmailNotifyPref(raw)
+	if err != nil {
+		return err
+	}
+	canonical, err := json.Marshal(pref)
+	if err != nil {
+		return fmt.Errorf("marshal email notification org default: %w", err)
+	}
+
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin set org default tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := setOrgSettingTx(ctx, tx, orgSettingEmailNotifyDefault, string(canonical)); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// seedEmailNotifyPrefTx writes the current org-wide default email-notification
+// preference as a brand-new user's initial user_preferences row, within the same
+// transaction as the user's creation. This is what makes an admin-configured
+// default apply only to users created from this point forward: existing users'
+// rows (or lack thereof, which falls back to the hardcoded DefaultEmailNotifyPref
+// via ParseEmailNotifyPref) are never touched.
+func seedEmailNotifyPrefTx(ctx context.Context, tx *sql.Tx, userID int64) error {
+	var raw string
+	err := tx.QueryRowContext(ctx, `SELECT value FROM org_settings WHERE key = ?`, orgSettingEmailNotifyDefault).Scan(&raw)
+	if err != nil && err != sql.ErrNoRows {
+		return fmt.Errorf("get org email notify default: %w", err)
+	}
+	// ParseEmailNotifyPref("") already returns DefaultEmailNotifyPref(), covering
+	// both sql.ErrNoRows (raw == "") and the never-configured case uniformly.
+	pref, err := ParseEmailNotifyPref(raw)
+	if err != nil {
+		// Unreachable in practice: SetEmailNotifyOrgDefault only ever stores
+		// canonicalized, already-validated JSON. Fall back rather than fail
+		// user creation over a corrupted org setting.
+		pref = DefaultEmailNotifyPref()
+	}
+	canonical, err := json.Marshal(pref)
+	if err != nil {
+		return fmt.Errorf("marshal seeded email notification preference: %w", err)
+	}
+	nowMs := time.Now().UTC().UnixMilli()
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO user_preferences (user_id, key, value, updated_at)
+VALUES (?, 'emailNotifications', ?, ?)
+`, userID, string(canonical), nowMs); err != nil {
+		return fmt.Errorf("seed email notification preference: %w", err)
+	}
+	return nil
+}

--- a/internal/store/org_settings_provenance_test.go
+++ b/internal/store/org_settings_provenance_test.go
@@ -1,0 +1,429 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+)
+
+// preferenceRow reads the raw user_preferences row for (userID, key). Unlike
+// GetUserPreference, which collapses "no row" and "row with empty value" both
+// into "", this reports exists=false only when the row is genuinely absent, so
+// tests can prove the compatibility guarantee that no row was created.
+func preferenceRow(t *testing.T, st *Store, userID int64, key string) (value, provenance string, updatedAt int64, exists bool) {
+	t.Helper()
+	err := st.db.QueryRowContext(context.Background(),
+		`SELECT value, provenance, updated_at FROM user_preferences WHERE user_id = ? AND key = ?`,
+		userID, key).Scan(&value, &provenance, &updatedAt)
+	if err == sql.ErrNoRows {
+		return "", "", 0, false
+	}
+	if err != nil {
+		t.Fatalf("preferenceRow(%d, %q): %v", userID, key, err)
+	}
+	return value, provenance, updatedAt, true
+}
+
+// TestCreateUser_UnsetOrgDefault_CreatesNoRow is the core compatibility guarantee:
+// on an instance that never configures the org default, a newly created user gets
+// no emailNotifications row at all (identical to pre-feature behavior), and the
+// getter still reports "" via its intentional missing->"" collapse.
+func TestCreateUser_UnsetOrgDefault_CreatesNoRow(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if _, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner"); err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	user, err := st.CreateUser(ctx, "plain@test.com", "password123", "Plain")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, _, _, exists := preferenceRow(t, st, user.ID, "emailNotifications"); exists {
+		t.Fatalf("expected no emailNotifications row when org default is unset")
+	}
+	raw, err := st.GetUserPreference(ctx, user.ID, "emailNotifications")
+	if err != nil {
+		t.Fatalf("GetUserPreference: %v", err)
+	}
+	if raw != "" {
+		t.Fatalf("expected GetUserPreference to report %q, got %q", "", raw)
+	}
+}
+
+// TestCreateUser_OrgDefaultSet_SeedsOrgDefaultProvenance verifies a configured
+// override produces a real row tagged org_default.
+func TestCreateUser_OrgDefaultSet_SeedsOrgDefaultProvenance(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	owner, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	if err := st.SetEmailNotifyOrgDefault(ctx, owner.ID, `{"enabled":true,"projectActivity":true}`); err != nil {
+		t.Fatalf("SetEmailNotifyOrgDefault: %v", err)
+	}
+
+	user, err := st.CreateUser(ctx, "new@test.com", "password123", "New")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	_, provenance, _, exists := preferenceRow(t, st, user.ID, "emailNotifications")
+	if !exists {
+		t.Fatalf("expected a seeded row when org default is set")
+	}
+	if provenance != preferenceProvenanceOrgDefault {
+		t.Fatalf("expected provenance %q, got %q", preferenceProvenanceOrgDefault, provenance)
+	}
+}
+
+// TestSetUserPreference_FlipsInheritedRowToUser verifies an explicit user save
+// re-tags an inherited org_default row as user-owned, even when the saved value
+// is identical to what they inherited.
+func TestSetUserPreference_FlipsInheritedRowToUser(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	owner, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	orgDefault := `{"enabled":true,"projectActivity":true}`
+	if err := st.SetEmailNotifyOrgDefault(ctx, owner.ID, orgDefault); err != nil {
+		t.Fatalf("SetEmailNotifyOrgDefault: %v", err)
+	}
+	user, err := st.CreateUser(ctx, "new@test.com", "password123", "New")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	seeded, _, _, exists := preferenceRow(t, st, user.ID, "emailNotifications")
+	if !exists {
+		t.Fatalf("expected seeded row")
+	}
+	// Save the exact same canonical value the user inherited.
+	if err := st.SetUserPreference(ctx, user.ID, "emailNotifications", seeded); err != nil {
+		t.Fatalf("SetUserPreference: %v", err)
+	}
+	_, provenance, _, exists := preferenceRow(t, st, user.ID, "emailNotifications")
+	if !exists {
+		t.Fatalf("row unexpectedly gone after user save")
+	}
+	if provenance != preferenceProvenanceUser {
+		t.Fatalf("expected provenance %q after user save, got %q", preferenceProvenanceUser, provenance)
+	}
+}
+
+// TestClearEmailNotifyOrgDefault_ResetsAndLeavesUsersUntouched verifies the reset
+// lifecycle: after clearing, GetEmailNotifyOrgDefault reports unconfigured,
+// subsequently created users get no row, and previously seeded rows are unchanged.
+func TestClearEmailNotifyOrgDefault_ResetsAndLeavesUsersUntouched(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	owner, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	if err := st.SetEmailNotifyOrgDefault(ctx, owner.ID, `{"enabled":true,"projectActivity":true}`); err != nil {
+		t.Fatalf("SetEmailNotifyOrgDefault: %v", err)
+	}
+	seededUser, err := st.CreateUser(ctx, "seeded@test.com", "password123", "Seeded")
+	if err != nil {
+		t.Fatalf("CreateUser(seeded): %v", err)
+	}
+	seededValue, seededProv, seededUpdated, exists := preferenceRow(t, st, seededUser.ID, "emailNotifications")
+	if !exists {
+		t.Fatalf("expected seeded row before reset")
+	}
+
+	// Non-admin cannot clear.
+	if err := st.ClearEmailNotifyOrgDefault(ctx, seededUser.ID); err == nil {
+		t.Fatalf("expected error clearing org default as non-admin")
+	}
+	if err := st.ClearEmailNotifyOrgDefault(ctx, owner.ID); err != nil {
+		t.Fatalf("ClearEmailNotifyOrgDefault: %v", err)
+	}
+	// Idempotent.
+	if err := st.ClearEmailNotifyOrgDefault(ctx, owner.ID); err != nil {
+		t.Fatalf("ClearEmailNotifyOrgDefault (second call): %v", err)
+	}
+
+	_, customized, err := st.GetEmailNotifyOrgDefault(ctx)
+	if err != nil {
+		t.Fatalf("GetEmailNotifyOrgDefault: %v", err)
+	}
+	if customized {
+		t.Fatalf("expected customized=false after reset")
+	}
+
+	// A user created after reset gets no row.
+	afterUser, err := st.CreateUser(ctx, "after@test.com", "password123", "After")
+	if err != nil {
+		t.Fatalf("CreateUser(after): %v", err)
+	}
+	if _, _, _, exists := preferenceRow(t, st, afterUser.ID, "emailNotifications"); exists {
+		t.Fatalf("expected no row for user created after reset")
+	}
+
+	// The previously seeded user's row is completely unchanged.
+	value, prov, updated, exists := preferenceRow(t, st, seededUser.ID, "emailNotifications")
+	if !exists {
+		t.Fatalf("seeded user's row disappeared after reset")
+	}
+	if value != seededValue || prov != seededProv || updated != seededUpdated {
+		t.Fatalf("seeded row changed by reset: before {%q,%q,%d} after {%q,%q,%d}",
+			seededValue, seededProv, seededUpdated, value, prov, updated)
+	}
+}
+
+// TestBootstrapUser_CreatesNoRow proves the bootstrap owner is never seeded, even
+// when checked at the raw-row level.
+func TestBootstrapUser_CreatesNoRow(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	owner, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	if _, _, _, exists := preferenceRow(t, st, owner.ID, "emailNotifications"); exists {
+		t.Fatalf("expected no emailNotifications row for bootstrap owner")
+	}
+}
+
+// TestCreateUserOIDC_UnsetOrgDefault_CreatesNoRow mirrors the unset compatibility
+// guarantee for the non-bootstrap OIDC creation path.
+func TestCreateUserOIDC_UnsetOrgDefault_CreatesNoRow(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	st.configuredOIDCIssuer = "https://idp.example"
+
+	if _, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner"); err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	oidcUser, err := st.CreateUserOIDC(ctx, st.configuredOIDCIssuer, st.configuredOIDCIssuer, "sub-1", "sso@test.com", "SSO User")
+	if err != nil {
+		t.Fatalf("CreateUserOIDC: %v", err)
+	}
+	if oidcUser.IsBootstrap {
+		t.Fatalf("expected non-bootstrap OIDC user")
+	}
+	if _, _, _, exists := preferenceRow(t, st, oidcUser.ID, "emailNotifications"); exists {
+		t.Fatalf("expected no row for OIDC user when org default is unset")
+	}
+}
+
+// TestCreateUser_CorruptOrgDefault_SkipsSeedingWithoutFailing proves a corrupt
+// org_settings value (only reachable via direct DB tampering) does not block
+// account creation and does not invent a fallback row.
+func TestCreateUser_CorruptOrgDefault_SkipsSeedingWithoutFailing(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if _, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner"); err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	// Tamper: write invalid JSON directly, bypassing SetEmailNotifyOrgDefault validation.
+	if _, err := st.db.ExecContext(ctx,
+		`INSERT INTO org_settings (key, value, updated_at) VALUES (?, ?, ?)`,
+		orgSettingEmailNotifyDefault, `{not json`, time.Now().UTC().UnixMilli()); err != nil {
+		t.Fatalf("insert corrupt org setting: %v", err)
+	}
+
+	user, err := st.CreateUser(ctx, "victim@test.com", "password123", "Victim")
+	if err != nil {
+		t.Fatalf("CreateUser should succeed despite corrupt org default: %v", err)
+	}
+	if _, _, _, exists := preferenceRow(t, st, user.ID, "emailNotifications"); exists {
+		t.Fatalf("expected no seeded row when org default is corrupt")
+	}
+}
+
+// installExplicitColumnPrefTrigger installs a representative legacy workaround:
+// an AFTER INSERT ON users trigger that pre-inserts an emailNotifications row
+// using an explicit column list. Explicit-column triggers survive the addition of
+// the provenance column (it takes its default); positional
+// `INSERT INTO user_preferences VALUES (...)` triggers do NOT and must be removed
+// before upgrading -- that case is intentionally out of scope here.
+func installExplicitColumnPrefTrigger(t *testing.T, st *Store, value string) {
+	t.Helper()
+	if _, err := st.db.ExecContext(context.Background(), `
+CREATE TRIGGER test_seed_email_notify AFTER INSERT ON users
+BEGIN
+  INSERT INTO user_preferences (user_id, key, value, updated_at)
+  VALUES (NEW.id, 'emailNotifications', '`+value+`', 0);
+END;`); err != nil {
+		t.Fatalf("install trigger: %v", err)
+	}
+}
+
+// TestCreateUser_ExplicitColumnTrigger_NoOverrideSucceeds proves that with a
+// legacy explicit-column trigger present and no org override, user creation still
+// succeeds (the seed inserts nothing, so there is no uniqueness collision).
+func TestCreateUser_ExplicitColumnTrigger_NoOverrideSucceeds(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if _, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner"); err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	triggerValue := `{"v":1,"enabled":false,"assigned":false,"cardActivity":false,"sprintActivity":false,"projectActivity":false,"addedToProject":false}`
+	installExplicitColumnPrefTrigger(t, st, triggerValue)
+
+	user, err := st.CreateUser(ctx, "trig@test.com", "password123", "Trig")
+	if err != nil {
+		t.Fatalf("CreateUser with legacy trigger should succeed: %v", err)
+	}
+	value, provenance, _, exists := preferenceRow(t, st, user.ID, "emailNotifications")
+	if !exists {
+		t.Fatalf("expected the trigger's row to be present")
+	}
+	if value != triggerValue {
+		t.Fatalf("expected trigger value untouched (no override), got %q", value)
+	}
+	if provenance != preferenceProvenanceLegacy {
+		t.Fatalf("expected trigger row provenance %q, got %q", preferenceProvenanceLegacy, provenance)
+	}
+}
+
+// TestCreateUser_ExplicitColumnTrigger_OverrideWins proves that when an org
+// override is configured, the seed upsert overwrites the trigger-created row with
+// the official value and tags it org_default.
+func TestCreateUser_ExplicitColumnTrigger_OverrideWins(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	owner, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	if err := st.SetEmailNotifyOrgDefault(ctx, owner.ID, `{"enabled":true,"projectActivity":true}`); err != nil {
+		t.Fatalf("SetEmailNotifyOrgDefault: %v", err)
+	}
+	triggerValue := `{"v":1,"enabled":false,"assigned":false,"cardActivity":false,"sprintActivity":false,"projectActivity":false,"addedToProject":false}`
+	installExplicitColumnPrefTrigger(t, st, triggerValue)
+
+	user, err := st.CreateUser(ctx, "trig@test.com", "password123", "Trig")
+	if err != nil {
+		t.Fatalf("CreateUser with legacy trigger + override should succeed: %v", err)
+	}
+	value, provenance, _, exists := preferenceRow(t, st, user.ID, "emailNotifications")
+	if !exists {
+		t.Fatalf("expected a row after creation")
+	}
+	want := `{"v":1,"enabled":true,"assigned":true,"cardActivity":false,"sprintActivity":false,"projectActivity":true,"addedToProject":true}`
+	if value != want {
+		t.Fatalf("expected org override to win over trigger value: got %q, want %q", value, want)
+	}
+	if provenance != preferenceProvenanceOrgDefault {
+		t.Fatalf("expected provenance %q, got %q", preferenceProvenanceOrgDefault, provenance)
+	}
+}
+
+// TestCreateUser_OrgDefaultQueryErrorIsReturned proves that a real org_settings
+// query failure (anything other than ErrNoRows) fails CreateUser instead of being
+// swallowed as a successful "unset" no-op. The previous err==ErrNoRows||raw==""
+// check was unsafe because a failed Scan leaves raw as "".
+func TestCreateUser_OrgDefaultQueryErrorIsReturned(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if _, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner"); err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	if _, err := st.db.ExecContext(ctx, `DROP TABLE org_settings`); err != nil {
+		t.Fatalf("DROP TABLE org_settings: %v", err)
+	}
+
+	_, err := st.CreateUser(ctx, "victim@test.com", "password123", "Victim")
+	if err == nil {
+		t.Fatal("expected CreateUser to fail when org_settings query errors, got nil")
+	}
+}
+
+// TestOrgDefaultChange_LeavesUserAndLegacyRowsUntouched proves a later org-default
+// change never rewrites existing preference rows tagged user or legacy.
+func TestOrgDefaultChange_LeavesUserAndLegacyRowsUntouched(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	owner, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	if err := st.SetEmailNotifyOrgDefault(ctx, owner.ID, `{"enabled":true,"projectActivity":true}`); err != nil {
+		t.Fatalf("SetEmailNotifyOrgDefault: %v", err)
+	}
+
+	// Inherited org_default row, then explicitly saved by the user (same JSON).
+	userOwned, err := st.CreateUser(ctx, "userowned@test.com", "password123", "UserOwned")
+	if err != nil {
+		t.Fatalf("CreateUser(userOwned): %v", err)
+	}
+	seeded, _, _, exists := preferenceRow(t, st, userOwned.ID, "emailNotifications")
+	if !exists {
+		t.Fatalf("expected seeded row for userOwned")
+	}
+	if err := st.SetUserPreference(ctx, userOwned.ID, "emailNotifications", seeded); err != nil {
+		t.Fatalf("SetUserPreference: %v", err)
+	}
+	userValue, userProv, userUpdated, exists := preferenceRow(t, st, userOwned.ID, "emailNotifications")
+	if !exists || userProv != preferenceProvenanceUser {
+		t.Fatalf("expected user provenance before org change, exists=%v provenance=%q", exists, userProv)
+	}
+
+	// Pre-existing unknown/hand-written row classified as legacy.
+	legacyUser, err := st.CreateUser(ctx, "legacy@test.com", "password123", "Legacy")
+	if err != nil {
+		t.Fatalf("CreateUser(legacy): %v", err)
+	}
+	// Clear any seed from the current override, then insert a legacy-tagged row.
+	if _, err := st.db.ExecContext(ctx, `DELETE FROM user_preferences WHERE user_id = ? AND key = 'emailNotifications'`, legacyUser.ID); err != nil {
+		t.Fatalf("clear seeded row: %v", err)
+	}
+	legacyValue := `{"v":1,"enabled":false,"assigned":true,"cardActivity":false,"sprintActivity":false,"projectActivity":false,"addedToProject":true}`
+	legacyUpdated := time.Now().UTC().UnixMilli()
+	if _, err := st.db.ExecContext(ctx, `
+INSERT INTO user_preferences (user_id, key, value, updated_at, provenance)
+VALUES (?, 'emailNotifications', ?, ?, ?)
+`, legacyUser.ID, legacyValue, legacyUpdated, preferenceProvenanceLegacy); err != nil {
+		t.Fatalf("insert legacy preference: %v", err)
+	}
+
+	if err := st.SetEmailNotifyOrgDefault(ctx, owner.ID, `{"enabled":true,"sprintActivity":true}`); err != nil {
+		t.Fatalf("SetEmailNotifyOrgDefault(change): %v", err)
+	}
+
+	gotValue, gotProv, gotUpdated, exists := preferenceRow(t, st, userOwned.ID, "emailNotifications")
+	if !exists {
+		t.Fatalf("user-owned row disappeared after org default change")
+	}
+	if gotValue != userValue || gotProv != userProv || gotUpdated != userUpdated {
+		t.Fatalf("user-owned row changed: before {%q,%q,%d} after {%q,%q,%d}",
+			userValue, userProv, userUpdated, gotValue, gotProv, gotUpdated)
+	}
+
+	gotValue, gotProv, gotUpdated, exists = preferenceRow(t, st, legacyUser.ID, "emailNotifications")
+	if !exists {
+		t.Fatalf("legacy row disappeared after org default change")
+	}
+	if gotValue != legacyValue || gotProv != preferenceProvenanceLegacy || gotUpdated != legacyUpdated {
+		t.Fatalf("legacy row changed: before {%q,%q,%d} after {%q,%q,%d}",
+			legacyValue, preferenceProvenanceLegacy, legacyUpdated, gotValue, gotProv, gotUpdated)
+	}
+}

--- a/internal/store/org_settings_test.go
+++ b/internal/store/org_settings_test.go
@@ -1,0 +1,210 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestGetEmailNotifyOrgDefault_UnsetFallsBackToHardcodedDefault(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	pref, customized, err := st.GetEmailNotifyOrgDefault(ctx)
+	if err != nil {
+		t.Fatalf("GetEmailNotifyOrgDefault: %v", err)
+	}
+	if customized {
+		t.Fatalf("expected customized=false when no admin override set")
+	}
+	if pref != DefaultEmailNotifyPref() {
+		t.Fatalf("got %+v, want hardcoded default %+v", pref, DefaultEmailNotifyPref())
+	}
+}
+
+func TestSetEmailNotifyOrgDefault_RequiresAdminOrOwner(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	owner, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	user, err := st.CreateUser(ctx, "user@test.com", "password123", "User")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if err := st.SetEmailNotifyOrgDefault(ctx, user.ID, `{"enabled":true}`); !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("expected ErrUnauthorized for plain user, got %v", err)
+	}
+
+	if err := st.SetEmailNotifyOrgDefault(ctx, owner.ID, `{"enabled":true}`); err != nil {
+		t.Fatalf("SetEmailNotifyOrgDefault(owner): %v", err)
+	}
+
+	pref, customized, err := st.GetEmailNotifyOrgDefault(ctx)
+	if err != nil {
+		t.Fatalf("GetEmailNotifyOrgDefault: %v", err)
+	}
+	if !customized {
+		t.Fatalf("expected customized=true after admin override")
+	}
+	if !pref.Enabled {
+		t.Fatalf("expected Enabled=true, got %+v", pref)
+	}
+}
+
+func TestSetEmailNotifyOrgDefault_RejectsInvalidJSON(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	owner, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+
+	if err := st.SetEmailNotifyOrgDefault(ctx, owner.ID, `{"unknown":true}`); !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+// TestCreateUser_SeedsCurrentOrgDefault is the core Phase 1 behavior: a user created
+// after an admin sets an org override gets that override as their initial
+// emailNotifications preference, not the hardcoded DefaultEmailNotifyPref().
+func TestCreateUser_SeedsCurrentOrgDefault(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	owner, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	if err := st.SetEmailNotifyOrgDefault(ctx, owner.ID, `{"enabled":true,"projectActivity":true}`); err != nil {
+		t.Fatalf("SetEmailNotifyOrgDefault: %v", err)
+	}
+
+	newUser, err := st.CreateUser(ctx, "new@test.com", "password123", "New User")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	got, err := st.GetEmailNotifyPref(ctx, newUser.ID)
+	if err != nil {
+		t.Fatalf("GetEmailNotifyPref: %v", err)
+	}
+	if !got.Enabled || !got.ProjectActivity {
+		t.Fatalf("new user should have inherited org default, got %+v", got)
+	}
+}
+
+// TestCreateUser_ExistingUsersUnaffectedByLaterOrgDefaultChange proves the org
+// default is only ever a seed at creation time, never applied retroactively.
+func TestCreateUser_ExistingUsersUnaffectedByLaterOrgDefaultChange(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	owner, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+
+	earlyUser, err := st.CreateUser(ctx, "early@test.com", "password123", "Early User")
+	if err != nil {
+		t.Fatalf("CreateUser(early): %v", err)
+	}
+	// Early user seeded from the (unset) hardcoded default.
+	early, err := st.GetEmailNotifyPref(ctx, earlyUser.ID)
+	if err != nil {
+		t.Fatalf("GetEmailNotifyPref(early): %v", err)
+	}
+	if early != DefaultEmailNotifyPref() {
+		t.Fatalf("early user should start from hardcoded default, got %+v", early)
+	}
+
+	if err := st.SetEmailNotifyOrgDefault(ctx, owner.ID, `{"enabled":true,"sprintActivity":true}`); err != nil {
+		t.Fatalf("SetEmailNotifyOrgDefault: %v", err)
+	}
+
+	// Existing early user's preference is untouched by the later admin change.
+	early, err = st.GetEmailNotifyPref(ctx, earlyUser.ID)
+	if err != nil {
+		t.Fatalf("GetEmailNotifyPref(early, after org default change): %v", err)
+	}
+	if early != DefaultEmailNotifyPref() {
+		t.Fatalf("existing user's preference should be unchanged by org default update, got %+v", early)
+	}
+
+	lateUser, err := st.CreateUser(ctx, "late@test.com", "password123", "Late User")
+	if err != nil {
+		t.Fatalf("CreateUser(late): %v", err)
+	}
+	late, err := st.GetEmailNotifyPref(ctx, lateUser.ID)
+	if err != nil {
+		t.Fatalf("GetEmailNotifyPref(late): %v", err)
+	}
+	if !late.Enabled || !late.SprintActivity {
+		t.Fatalf("late user should have inherited the updated org default, got %+v", late)
+	}
+}
+
+// TestCreateUserOIDC_SeedsCurrentOrgDefault mirrors TestCreateUser_SeedsCurrentOrgDefault
+// for the OIDC user-creation path, but only for a non-bootstrap OIDC user (an owner
+// already exists here via BootstrapUser first).
+func TestCreateUserOIDC_SeedsCurrentOrgDefault(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	st.configuredOIDCIssuer = "https://idp.example"
+
+	owner, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	if err := st.SetEmailNotifyOrgDefault(ctx, owner.ID, `{"enabled":true,"cardActivity":true}`); err != nil {
+		t.Fatalf("SetEmailNotifyOrgDefault: %v", err)
+	}
+
+	oidcUser, err := st.CreateUserOIDC(ctx, st.configuredOIDCIssuer, st.configuredOIDCIssuer, "sub-1", "sso@test.com", "SSO User")
+	if err != nil {
+		t.Fatalf("CreateUserOIDC: %v", err)
+	}
+	if oidcUser.IsBootstrap {
+		t.Fatalf("expected non-bootstrap OIDC user since an owner already exists")
+	}
+
+	got, err := st.GetEmailNotifyPref(ctx, oidcUser.ID)
+	if err != nil {
+		t.Fatalf("GetEmailNotifyPref: %v", err)
+	}
+	if !got.Enabled || !got.CardActivity {
+		t.Fatalf("OIDC user should have inherited org default, got %+v", got)
+	}
+}
+
+// TestBootstrapUser_NotSeededFromOrgDefault documents that the first (bootstrap)
+// owner predates any org default and keeps the lazy hardcoded-fallback path
+// instead of a seeded user_preferences row.
+func TestBootstrapUser_NotSeededFromOrgDefault(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	owner, err := st.BootstrapUser(ctx, "owner@test.com", "password123", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+
+	raw, err := st.GetUserPreference(ctx, owner.ID, "emailNotifications")
+	if err != nil {
+		t.Fatalf("GetUserPreference: %v", err)
+	}
+	if raw != "" {
+		t.Fatalf("expected no seeded emailNotifications row for bootstrap owner, got %q", raw)
+	}
+}

--- a/internal/store/org_settings_test.go
+++ b/internal/store/org_settings_test.go
@@ -185,6 +185,13 @@ func TestCreateUserOIDC_SeedsCurrentOrgDefault(t *testing.T) {
 	if !got.Enabled || !got.CardActivity {
 		t.Fatalf("OIDC user should have inherited org default, got %+v", got)
 	}
+	_, provenance, _, exists := preferenceRow(t, st, oidcUser.ID, "emailNotifications")
+	if !exists {
+		t.Fatalf("expected a seeded emailNotifications row for OIDC user when org default is set")
+	}
+	if provenance != preferenceProvenanceOrgDefault {
+		t.Fatalf("expected provenance %q, got %q", preferenceProvenanceOrgDefault, provenance)
+	}
 }
 
 // TestBootstrapUser_NotSeededFromOrgDefault documents that the first (bootstrap)

--- a/internal/store/preferences.go
+++ b/internal/store/preferences.go
@@ -9,6 +9,16 @@ import (
 	"time"
 )
 
+// Preference provenance records how a user_preferences row was written, so a
+// future bulk-apply can safely tell org-seeded rows apart from user-customized
+// ones. Values are application-defined; unknown values are treated conservatively
+// (never auto-updated). Kept unexported: bulk-apply is expected to live in this package.
+const (
+	preferenceProvenanceLegacy     = "legacy"
+	preferenceProvenanceUser       = "user"
+	preferenceProvenanceOrgDefault = "org_default"
+)
+
 // validateTagColorsJSON returns ErrValidation if any color in the tagColors JSON is invalid.
 func validateTagColorsJSON(value string) error {
 	var m map[string]string
@@ -63,11 +73,13 @@ func (s *Store) SetUserPreference(ctx context.Context, userID int64, key, value 
 		value = string(canonical)
 	}
 	nowMs := time.Now().UTC().UnixMilli()
+	// An explicit user write always marks the row as user-owned, including when
+	// it overwrites an inherited org_default row with the same value.
 	_, err := s.db.ExecContext(ctx, `
-INSERT INTO user_preferences (user_id, key, value, updated_at)
-VALUES (?, ?, ?, ?)
-ON CONFLICT (user_id, key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
-`, userID, key, value, nowMs)
+INSERT INTO user_preferences (user_id, key, value, updated_at, provenance)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT (user_id, key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at, provenance = excluded.provenance
+`, userID, key, value, nowMs, preferenceProvenanceUser)
 	if err != nil {
 		return fmt.Errorf("set user preference: %w", err)
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.23.1"
+const Version = "3.23.2"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
Closes #169 (Phase 1)

## Summary

Per the discussion on #169, this scopes down to the narrower shape @markrai proposed rather than the original issue's larger 3-part design (env var + admin UI + bulk-apply):

> I think best option would be to simply have DB backed admin setting, which would be cleaner/nicer... I think if we do this effort in digestible chunks, we'll come out happier.

This PR is that first digestible chunk: a **DB-backed org-wide default**, seeded onto **new users only, at creation time**. No env var (avoids the `SCRUMBOY_SMTP_FROM`-style quoting/escaping issues @markrai flagged), no bulk-apply action, no admin UI panel yet — see [Follow-ups](#follow-ups).

## What's added

- **Migration 058** — new `org_settings(key, value, updated_at)` table for org-wide admin-configurable settings (generic shape, but this PR only wires up one key: `emailNotifyDefault`).
- **`internal/store/org_settings.go`** — `GetEmailNotifyOrgDefault`/`SetEmailNotifyOrgDefault`, reusing the existing `ParseEmailNotifyPref`/`ValidateEmailNotifyPrefJSON` validation from #131. `SetEmailNotifyOrgDefault` requires `admin` or `owner` system role (`requireAdmin`).
- **`GET`/`PUT /api/admin/settings/email-notify-default`** — new admin endpoint, added alongside the existing `/api/admin/users/*` routes in `routing_admin.go`, behind the same admin-or-owner gate `handleAdmin` already enforces.
- **`CreateUser` / `CreateUserOIDC`** (non-bootstrap path only) now seed each new user's initial `user_preferences` row (key `emailNotifications`) from whatever the org default is **at that moment**, in the same transaction as the `INSERT INTO users`.

## Why creation-time seeding, not a live-applied default

This is the key design point from the issue: an org-default change must never retroactively change an existing user's preferences.

- A user created **before** an org-default change keeps whatever was in effect when *they* were created (the hardcoded fallback, if no override existed yet).
- A user created **after** an org-default change inherits the new value.
- The bootstrap owner (the very first user) is deliberately **not** seeded from an org default — there's no admin yet to have configured one — and keeps the existing lazy `GetEmailNotifyPref`/`ParseEmailNotifyPref` fallback path unchanged.

This is proven by `TestCreateUser_ExistingUsersUnaffectedByLaterOrgDefaultChange` and the end-to-end HTTP test `TestAdminEmailNotifyDefault_PutRequiresAdminOrOwnerAndSeedsNewUsers`.

## Follow-ups (intentionally out of scope here)

- **Admin settings UI panel** (the "menu where they pick what to disable/enable" from the issue) — the API this PR adds is what such a panel would call; a natural next PR.
- **Bulk-apply action** — an explicit "apply current org default to users who haven't customized their own preferences" action, distinct from this creation-time seeding.
- The "distant future" onboarding click-through @markrai mentioned.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite passes)
- [x] New store tests: unset fallback, admin/owner-only write, invalid JSON rejection, `CreateUser` and `CreateUserOIDC` seeding from the current org default, existing users unaffected by a later change, bootstrap owner not seeded.
- [x] New HTTP tests: `GET` reports the hardcoded default with `customized: false` before any override; non-admin `PUT` is rejected; owner `PUT` updates the org default and is reflected in a subsequently created user's own `GET /api/user/preferences?key=emailNotifications`; a user created *before* the change is unaffected; invalid JSON is rejected; unauthenticated requests are rejected.
- [x] Documented in `docs/notifications.md` (new "Org-wide default for new users" section, plus the new endpoint under "HTTP endpoints").