### PR TITLE
Add MCP tools for Linked Stories (todos_linksList, todos_linkAdd, todos_linkRemove)

### DIFF
--- a/API.md
+++ b/API.md
@@ -396,6 +396,19 @@ web UI (`GET/POST/DELETE /api/board/{slug}/todos/{localId}/links[/targetLocalId]
 self-links (`targetLocalId == localId`) and links to a nonexistent todo both fail validation/not-found
 the same way the REST endpoint does.
 
+Links are **directed** from `localId` to `targetLocalId`, and the `linkType` describes `localId` as the
+subject of the relation:
+
+- `relates_to` (default) - `localId` is related to `targetLocalId` (directed related-to edge).
+- `blocks` - `localId` blocks `targetLocalId`.
+- `duplicates` - `localId` duplicates `targetLocalId`.
+- `parent` - `localId` is the parent of `targetLocalId`.
+
+`todos_linksList` reports `outbound` (edges where the todo is the source) separately from `inbound`
+(edges where the todo is the target). `todos_linkRemove` deletes only the directed `localId ->
+targetLocalId` edge with the same orientation used to add it; a reverse edge, if one exists, is left
+intact.
+
 ### Sprints
 
 Shared inputs: many tools use `projectSlug` only or `projectSlug` + `sprintId` (stored id).

--- a/API.md
+++ b/API.md
@@ -326,7 +326,7 @@ Grouped by domain. All are listed in `implementedTools` from capabilities.
 
 **todos**
 
-- `todos_create`, `todos_get`, `todos_search`, `todos_update`, `todos_delete`, `todos_move`
+- `todos_create`, `todos_get`, `todos_search`, `todos_update`, `todos_delete`, `todos_move`, `todos_linksList`, `todos_linkAdd`, `todos_linkRemove`
 
 **sprints**
 
@@ -385,8 +385,16 @@ Conventions:
 | `todos_update` | `projectSlug`, `localId`, `patch` (JSON patch object) | `data.todo` |
 | `todos_delete` | `projectSlug`, `localId` | `data` with `status: "deleted"`, `projectSlug`, `localId` |
 | `todos_move` | `projectSlug`, `localId`, `toColumnKey`, optional `afterLocalId`, `beforeLocalId` | `data.todo` |
+| `todos_linksList` | `projectSlug`, `localId` | `data.outbound`, `data.inbound` (arrays of `{localId, title, linkType}`) |
+| `todos_linkAdd` | `projectSlug`, `localId`, `targetLocalId`, optional `linkType` (default `relates_to`; also `blocks`, `duplicates`, `parent`) | `data.outbound`, `data.inbound` (refreshed) |
+| `todos_linkRemove` | `projectSlug`, `localId`, `targetLocalId` | `data.outbound`, `data.inbound` (refreshed) |
 
 Column keys accept common aliases (normalized internally). Todo payloads use **`localId`** and **`projectSlug`**; they do not expose the internal global todo id.
+
+**Linked stories:** this is the same "Linked Stories" relation shown on the todo detail page in the
+web UI (`GET/POST/DELETE /api/board/{slug}/todos/{localId}/links[/targetLocalId]`). `todos_linkAdd`
+self-links (`targetLocalId == localId`) and links to a nonexistent todo both fail validation/not-found
+the same way the REST endpoint does.
 
 ### Sprints
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [3.24.0] - 2026-07-24
 
+### Added
+
+- **MCP tools for Linked Stories** - `todos_linksList`, `todos_linkAdd`, and `todos_linkRemove` expose the todo detail page's "Linked Stories" relation (`relates_to`, `blocks`, `duplicates`, `parent`) over MCP, matching the existing `GET/POST/DELETE /api/board/{slug}/todos/{localId}/links[/targetLocalId]` REST endpoints. Previously this relation had no MCP surface at all — the only related tool, `todos_search`, just searches link *targets* for the picker UI and never applied a link. See [API.md](API.md#todos).
+
 ### Changed
 
 - **MCP tool names renamed from dot- to underscore-separated (compatibility-relevant)** — Claude's MCP client validates every tool name returned by `tools/list` against `^[a-zA-Z0-9_-]{1,64}$` (letters, digits, underscore, hyphen only). Scrumboy's MCP tools were named with dots (`todos.create`, `sprints.getActive`, `board.get`, etc.), which fail that regex; because Claude validates the whole `tools/list` array as one schema, a single invalid name broke tool-calling for *every* MCP server connected to the session, not just Scrumboy, until Scrumboy was disconnected. All 28 tool names now use underscores instead (e.g. `todos.create` → `todos_create`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.24.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names) - see those releases.
 
-## [3.24.0] - 2026-07-24
+## [3.24.1] - 2026-07-24
 
 ### Added
 
-- **MCP tools for Linked Stories** - `todos_linksList`, `todos_linkAdd`, and `todos_linkRemove` expose the todo detail page's "Linked Stories" relation (`relates_to`, `blocks`, `duplicates`, `parent`) over MCP, matching the existing `GET/POST/DELETE /api/board/{slug}/todos/{localId}/links[/targetLocalId]` REST endpoints. Previously this relation had no MCP surface at all — the only related tool, `todos_search`, just searches link *targets* for the picker UI and never applied a link. See [API.md](API.md#todos).
+- **MCP tools for Linked Stories** - `todos_linksList`, `todos_linkAdd`, and `todos_linkRemove` expose the todo detail page's "Linked Stories" relation (`relates_to`, `blocks`, `duplicates`, `parent`) over MCP, matching the existing `GET/POST/DELETE /api/board/{slug}/todos/{localId}/links[/targetLocalId]` REST endpoints. Links are directed from `localId` to `targetLocalId` with `localId` as the subject of the type. Previously this relation had no MCP surface at all — the only related tool, `todos_search`, just searches link *targets* for the picker UI and never applied a link. See [API.md](API.md#todos).
+
+### Limitations
+
+- **MCP mutations do not refresh open web clients (or fan out card-activity email)** - Unlike REST, MCP tools call the store directly and do not emit `board.refresh_needed` (e.g. `todo_links_updated`). An agent can change links (or other board data) while a browser stays stale until another refresh.
+
+
+## [3.24.0] - 2026-07-24
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.24.0-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.24.1-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -188,6 +188,9 @@ Malformed, invalid, expired, revoked, unbound, or wrong-resource Bearer tokens r
     "todos_update",
     "todos_delete",
     "todos_move",
+    "todos_linksList",
+    "todos_linkAdd",
+    "todos_linkRemove",
     "sprints_list",
     "sprints_get",
     "sprints_getActive",
@@ -218,7 +221,7 @@ When there are no planned tools, **`plannedTools`** is omitted from JSON (`omite
 
 ## Available Tools
 
-Exact names match `internal/mcp/registry.go` / `implementedTools()` (28 tools).
+Exact names match `internal/mcp/registry.go` / `implementedTools()` (31 tools).
 
 > **Deprecated dotted names (compatibility shim, kept indefinitely).** Tool names were
 > renamed from dot-separated (`todos.create`, `board.get`, ...) to
@@ -250,6 +253,9 @@ Exact names match `internal/mcp/registry.go` / `implementedTools()` (28 tools).
 - `todos_update`
 - `todos_delete`
 - `todos_move`
+- `todos_linksList`
+- `todos_linkAdd`
+- `todos_linkRemove`
 
 **Sprints**
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -257,6 +257,11 @@ Exact names match `internal/mcp/registry.go` / `implementedTools()` (31 tools).
 - `todos_linkAdd`
 - `todos_linkRemove`
 
+Linked stories are **directed** from `localId` to `targetLocalId`, and `linkType` describes `localId` as
+the subject (`blocks` = localId blocks target; `parent` = localId is parent of target; `duplicates` =
+localId duplicates target; `relates_to` is the default). `todos_linkRemove` deletes only that directed
+edge. See [API.md](../API.md#todos) for the full semantics.
+
 **Sprints**
 
 - `sprints_list`

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -23,6 +23,10 @@ type storeAPI interface {
 	CreateTodo(ctx context.Context, projectID int64, in store.CreateTodoInput, mode store.Mode) (store.Todo, error)
 	GetTodoByLocalID(ctx context.Context, projectID, localID int64, mode store.Mode) (store.Todo, error)
 	SearchTodosForLinkPicker(ctx context.Context, projectID int64, q string, limit int, excludeLocalIDs []int64, mode store.Mode) ([]store.TodoLinkTarget, error)
+	AddLink(ctx context.Context, projectID, fromLocalID, toLocalID int64, linkType string, mode store.Mode) error
+	RemoveLink(ctx context.Context, projectID, fromLocalID, toLocalID int64, mode store.Mode) error
+	ListLinksForTodo(ctx context.Context, projectID, localID int64, mode store.Mode) ([]store.TodoLinkTarget, error)
+	ListBacklinksForTodo(ctx context.Context, projectID, localID int64, mode store.Mode) ([]store.TodoLinkTarget, error)
 	UpdateTodoByLocalID(ctx context.Context, projectID, localID int64, in store.UpdateTodoInput, mode store.Mode) (store.Todo, error)
 	DeleteTodoByLocalID(ctx context.Context, projectID, localID int64, mode store.Mode) error
 	MoveTodoByLocalID(ctx context.Context, projectID, localID int64, toColumnKey string, afterLocalID, beforeLocalID *int64, mode store.Mode) (store.Todo, error)
@@ -224,6 +228,9 @@ func (a *Adapter) implementedTools() []string {
 		"todos_update",
 		"todos_delete",
 		"todos_move",
+		"todos_linksList",
+		"todos_linkAdd",
+		"todos_linkRemove",
 		"sprints_list",
 		"sprints_get",
 		"sprints_getActive",

--- a/internal/mcp/adapter_test.go
+++ b/internal/mcp/adapter_test.go
@@ -473,7 +473,7 @@ func TestMCPSystemGetCapabilities_FullPreBootstrap(t *testing.T) {
 		t.Fatalf("expected authenticatedToolsUsable false, got %#v", auth["authenticatedToolsUsable"])
 	}
 	tools := data["implementedTools"].([]any)
-	if len(tools) != 28 || tools[0] != "system_getCapabilities" || tools[1] != "projects_list" || tools[2] != "todos_create" || tools[3] != "todos_get" || tools[4] != "todos_search" || tools[5] != "todos_update" || tools[6] != "todos_delete" || tools[7] != "todos_move" || tools[8] != "sprints_list" || tools[9] != "sprints_get" || tools[10] != "sprints_getActive" || tools[11] != "sprints_create" || tools[12] != "sprints_activate" || tools[13] != "sprints_close" || tools[14] != "sprints_update" || tools[15] != "sprints_delete" || tools[16] != "tags_listProject" || tools[17] != "tags_listMine" || tools[18] != "tags_updateMineColor" || tools[19] != "tags_deleteMine" || tools[20] != "tags_updateProjectColor" || tools[21] != "tags_deleteProject" || tools[22] != "members_list" || tools[23] != "members_listAvailable" || tools[24] != "members_add" || tools[25] != "members_updateRole" || tools[26] != "members_remove" || tools[27] != "board_get" {
+	if len(tools) != 31 || tools[0] != "system_getCapabilities" || tools[1] != "projects_list" || tools[2] != "todos_create" || tools[3] != "todos_get" || tools[4] != "todos_search" || tools[5] != "todos_update" || tools[6] != "todos_delete" || tools[7] != "todos_move" || tools[8] != "todos_linksList" || tools[9] != "todos_linkAdd" || tools[10] != "todos_linkRemove" || tools[11] != "sprints_list" || tools[12] != "sprints_get" || tools[13] != "sprints_getActive" || tools[14] != "sprints_create" || tools[15] != "sprints_activate" || tools[16] != "sprints_close" || tools[17] != "sprints_update" || tools[18] != "sprints_delete" || tools[19] != "tags_listProject" || tools[20] != "tags_listMine" || tools[21] != "tags_updateMineColor" || tools[22] != "tags_deleteMine" || tools[23] != "tags_updateProjectColor" || tools[24] != "tags_deleteProject" || tools[25] != "members_list" || tools[26] != "members_listAvailable" || tools[27] != "members_add" || tools[28] != "members_updateRole" || tools[29] != "members_remove" || tools[30] != "board_get" {
 		t.Fatalf("unexpected implementedTools: %#v", tools)
 	}
 	if _, ok := data["plannedTools"]; ok {
@@ -3110,8 +3110,8 @@ func TestMCPTagsDeleteMineValidationUnknownField(t *testing.T) {
 	resp2, out := doMCP(t, client, ts.URL+"/mcp", map[string]any{
 		"tool": "tags_deleteMine",
 		"input": map[string]any{
-			"tagId":         float64(1),
-			"projectSlug":   "nope",
+			"tagId":       float64(1),
+			"projectSlug": "nope",
 		},
 	})
 	if resp2.StatusCode != http.StatusBadRequest {
@@ -5105,21 +5105,21 @@ func TestMCPMembersUpdateRoleLastMaintainerDemotionConflict(t *testing.T) {
 	}
 	// Align with store TestUpdateProjectMemberRole_LastMaintainerCannotDemoteToViewer setup.
 	r1, _ := doMCP(t, ownerClient, ts.URL+"/mcp", map[string]any{
-		"tool": "members_updateRole",
+		"tool":  "members_updateRole",
 		"input": map[string]any{"projectSlug": slug, "userId": m2.ID, "role": "maintainer"},
 	})
 	if r1.StatusCode != http.StatusOK {
 		t.Fatalf("mcp promote m2: %d", r1.StatusCode)
 	}
 	r2, _ := doMCP(t, ownerClient, ts.URL+"/mcp", map[string]any{
-		"tool": "members_updateRole",
+		"tool":  "members_updateRole",
 		"input": map[string]any{"projectSlug": slug, "userId": m2.ID, "role": "contributor"},
 	})
 	if r2.StatusCode != http.StatusOK {
 		t.Fatalf("mcp demote m2: %d", r2.StatusCode)
 	}
 	r3, _ := doMCP(t, ownerClient, ts.URL+"/mcp", map[string]any{
-		"tool": "members_updateRole",
+		"tool":  "members_updateRole",
 		"input": map[string]any{"projectSlug": slug, "userId": m2.ID, "role": "maintainer"},
 	})
 	if r3.StatusCode != http.StatusOK {
@@ -5127,7 +5127,7 @@ func TestMCPMembersUpdateRoleLastMaintainerDemotionConflict(t *testing.T) {
 	}
 	m2Client := newSessionClientForUser(t, ts, st, m2.ID)
 	r4, _ := doMCP(t, m2Client, ts.URL+"/mcp", map[string]any{
-		"tool": "members_updateRole",
+		"tool":  "members_updateRole",
 		"input": map[string]any{"projectSlug": slug, "userId": ownerID, "role": "contributor"},
 	})
 	if r4.StatusCode != http.StatusOK {
@@ -5458,7 +5458,7 @@ func TestMCPMembersRemoveSelfSuccessWhenNotLastMaintainer(t *testing.T) {
 		t.Fatalf("add m2: %v", err)
 	}
 	r1, _ := doMCP(t, ownerClient, ts.URL+"/mcp", map[string]any{
-		"tool": "members_updateRole",
+		"tool":  "members_updateRole",
 		"input": map[string]any{"projectSlug": slug, "userId": m2.ID, "role": "maintainer"},
 	})
 	if r1.StatusCode != http.StatusOK {

--- a/internal/mcp/jsonrpc_test.go
+++ b/internal/mcp/jsonrpc_test.go
@@ -736,6 +736,58 @@ func TestJSONRPC_ToolsList_TodosUpdateSchema(t *testing.T) {
 	}
 }
 
+func TestJSONRPC_ToolsList_TodosLinkAddSchema(t *testing.T) {
+	ts, _, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newStatelessClient(ts)
+	_, out := doJSONRPC(t, client, ts.URL, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/list",
+	})
+
+	result := out["result"].(map[string]any)
+	tools := result["tools"].([]any)
+
+	var todosLinkAdd map[string]any
+	for _, t2 := range tools {
+		tool := t2.(map[string]any)
+		if tool["name"] == "todos_linkAdd" {
+			todosLinkAdd = tool
+			break
+		}
+	}
+	if todosLinkAdd == nil {
+		t.Fatal("todos_linkAdd not found in tools/list")
+	}
+
+	schema := todosLinkAdd["inputSchema"].(map[string]any)
+	props := schema["properties"].(map[string]any)
+
+	linkType, ok := props["linkType"].(map[string]any)
+	if !ok {
+		t.Fatalf("todos_linkAdd schema missing linkType property, got %#v", props["linkType"])
+	}
+	if linkType["type"] != "string" {
+		t.Fatalf("todos_linkAdd linkType type expected string, got %v", linkType["type"])
+	}
+
+	enum, ok := linkType["enum"].([]any)
+	if !ok {
+		t.Fatalf("todos_linkAdd linkType.enum expected array, got %T %#v", linkType["enum"], linkType["enum"])
+	}
+	want := []string{"relates_to", "blocks", "duplicates", "parent"}
+	if len(enum) != len(want) {
+		t.Fatalf("todos_linkAdd linkType.enum expected %v, got %#v", want, enum)
+	}
+	for i, v := range want {
+		if enum[i] != v {
+			t.Fatalf("todos_linkAdd linkType.enum[%d] expected %q, got %q", i, v, enum[i])
+		}
+	}
+}
+
 func TestJSONRPC_ToolsList_ProjectsListSchema(t *testing.T) {
 	ts, _, cleanup := newTestServer(t, "full")
 	defer cleanup()

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -15,6 +15,9 @@ func (a *Adapter) registerTools() {
 	a.tools["todos_update"] = a.handleTodosUpdate
 	a.tools["todos_delete"] = a.handleTodosDelete
 	a.tools["todos_move"] = a.handleTodosMove
+	a.tools["todos_linksList"] = a.handleTodosLinksList
+	a.tools["todos_linkAdd"] = a.handleTodosLinkAdd
+	a.tools["todos_linkRemove"] = a.handleTodosLinkRemove
 	a.tools["sprints_list"] = a.handleSprintsList
 	a.tools["sprints_get"] = a.handleSprintsGet
 	a.tools["sprints_getActive"] = a.handleSprintsGetActive

--- a/internal/mcp/todos_links_tools.go
+++ b/internal/mcp/todos_links_tools.go
@@ -46,9 +46,9 @@ func (a *Adapter) handleTodosLinksList(ctx context.Context, input any) (any, map
 
 	switch {
 	case a.mode == "anonymous":
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos.linksList is unavailable in anonymous mode", nil)
+		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos_linksList is unavailable in anonymous mode", nil)
 	case bootstrapAvailable:
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos.linksList is unavailable before bootstrap", nil)
+		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos_linksList is unavailable before bootstrap", nil)
 	case !auth.Authenticated:
 		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
 	}
@@ -99,9 +99,9 @@ func (a *Adapter) handleTodosLinkAdd(ctx context.Context, input any) (any, map[s
 
 	switch {
 	case a.mode == "anonymous":
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos.linkAdd is unavailable in anonymous mode", nil)
+		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos_linkAdd is unavailable in anonymous mode", nil)
 	case bootstrapAvailable:
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos.linkAdd is unavailable before bootstrap", nil)
+		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos_linkAdd is unavailable before bootstrap", nil)
 	case !auth.Authenticated:
 		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
 	}
@@ -167,9 +167,9 @@ func (a *Adapter) handleTodosLinkRemove(ctx context.Context, input any) (any, ma
 
 	switch {
 	case a.mode == "anonymous":
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos.linkRemove is unavailable in anonymous mode", nil)
+		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos_linkRemove is unavailable in anonymous mode", nil)
 	case bootstrapAvailable:
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos.linkRemove is unavailable before bootstrap", nil)
+		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos_linkRemove is unavailable before bootstrap", nil)
 	case !auth.Authenticated:
 		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
 	}

--- a/internal/mcp/todos_links_tools.go
+++ b/internal/mcp/todos_links_tools.go
@@ -1,0 +1,223 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"scrumboy/internal/store"
+)
+
+type todosLinksListInput struct {
+	ProjectSlug string `json:"projectSlug"`
+	LocalID     int64  `json:"localId"`
+}
+
+type todosLinkAddInput struct {
+	ProjectSlug   string `json:"projectSlug"`
+	LocalID       int64  `json:"localId"`
+	TargetLocalId int64  `json:"targetLocalId"`
+	LinkType      string `json:"linkType"`
+}
+
+type todosLinkRemoveInput struct {
+	ProjectSlug   string `json:"projectSlug"`
+	LocalID       int64  `json:"localId"`
+	TargetLocalId int64  `json:"targetLocalId"`
+}
+
+func todoLinkTargetsToItems(targets []store.TodoLinkTarget) []todoLinkItem {
+	out := make([]todoLinkItem, 0, len(targets))
+	for _, t := range targets {
+		out = append(out, todoLinkItem{
+			LocalID:  t.LocalID,
+			Title:    t.Title,
+			LinkType: t.LinkType,
+		})
+	}
+	return out
+}
+
+func (a *Adapter) handleTodosLinksList(ctx context.Context, input any) (any, map[string]any, *adapterError) {
+	auth, bootstrapAvailable, err := a.authState(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch {
+	case a.mode == "anonymous":
+		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos.linksList is unavailable in anonymous mode", nil)
+	case bootstrapAvailable:
+		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos.linksList is unavailable before bootstrap", nil)
+	case !auth.Authenticated:
+		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
+	}
+
+	var in todosLinksListInput
+	if err := decodeInput(input, &in); err != nil {
+		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid input", map[string]any{"detail": err.Error()})
+	}
+	if in.ProjectSlug == "" {
+		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "missing projectSlug", map[string]any{"field": "projectSlug"})
+	}
+	if in.LocalID <= 0 {
+		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid localId", map[string]any{"field": "localId"})
+	}
+
+	pc, pcErr := a.store.GetProjectContextBySlug(ctx, in.ProjectSlug, a.storeMode())
+	if pcErr != nil {
+		return nil, nil, mapStoreError(pcErr)
+	}
+
+	if _, getErr := a.store.GetTodoByLocalID(ctx, pc.Project.ID, in.LocalID, a.storeMode()); getErr != nil {
+		if errors.Is(getErr, store.ErrUnauthorized) {
+			return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "forbidden", nil)
+		}
+		return nil, nil, mapStoreError(getErr)
+	}
+
+	outbound, listErr := a.store.ListLinksForTodo(ctx, pc.Project.ID, in.LocalID, a.storeMode())
+	if listErr != nil {
+		return nil, nil, mapStoreError(listErr)
+	}
+	inbound, listErr := a.store.ListBacklinksForTodo(ctx, pc.Project.ID, in.LocalID, a.storeMode())
+	if listErr != nil {
+		return nil, nil, mapStoreError(listErr)
+	}
+
+	return map[string]any{
+		"outbound": todoLinkTargetsToItems(outbound),
+		"inbound":  todoLinkTargetsToItems(inbound),
+	}, map[string]any{}, nil
+}
+
+func (a *Adapter) handleTodosLinkAdd(ctx context.Context, input any) (any, map[string]any, *adapterError) {
+	auth, bootstrapAvailable, err := a.authState(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch {
+	case a.mode == "anonymous":
+		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos.linkAdd is unavailable in anonymous mode", nil)
+	case bootstrapAvailable:
+		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos.linkAdd is unavailable before bootstrap", nil)
+	case !auth.Authenticated:
+		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
+	}
+
+	var in todosLinkAddInput
+	if err := decodeInput(input, &in); err != nil {
+		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid input", map[string]any{"detail": err.Error()})
+	}
+	if in.ProjectSlug == "" {
+		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "missing projectSlug", map[string]any{"field": "projectSlug"})
+	}
+	if in.LocalID <= 0 {
+		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid localId", map[string]any{"field": "localId"})
+	}
+	if in.TargetLocalId <= 0 {
+		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid targetLocalId", map[string]any{"field": "targetLocalId"})
+	}
+
+	pc, pcErr := a.store.GetProjectContextBySlug(ctx, in.ProjectSlug, a.storeMode())
+	if pcErr != nil {
+		return nil, nil, mapStoreError(pcErr)
+	}
+
+	if _, getErr := a.store.GetTodoByLocalID(ctx, pc.Project.ID, in.LocalID, a.storeMode()); getErr != nil {
+		if errors.Is(getErr, store.ErrUnauthorized) {
+			return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "forbidden", nil)
+		}
+		return nil, nil, mapStoreError(getErr)
+	}
+
+	linkType := in.LinkType
+	if linkType == "" {
+		linkType = "relates_to"
+	}
+
+	if addErr := a.store.AddLink(ctx, pc.Project.ID, in.LocalID, in.TargetLocalId, linkType, a.storeMode()); addErr != nil {
+		if errors.Is(addErr, store.ErrUnauthorized) {
+			return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "forbidden", nil)
+		}
+		return nil, nil, mapStoreError(addErr)
+	}
+
+	outbound, listErr := a.store.ListLinksForTodo(ctx, pc.Project.ID, in.LocalID, a.storeMode())
+	if listErr != nil {
+		return nil, nil, mapStoreError(listErr)
+	}
+	inbound, listErr := a.store.ListBacklinksForTodo(ctx, pc.Project.ID, in.LocalID, a.storeMode())
+	if listErr != nil {
+		return nil, nil, mapStoreError(listErr)
+	}
+
+	return map[string]any{
+		"outbound": todoLinkTargetsToItems(outbound),
+		"inbound":  todoLinkTargetsToItems(inbound),
+	}, map[string]any{}, nil
+}
+
+func (a *Adapter) handleTodosLinkRemove(ctx context.Context, input any) (any, map[string]any, *adapterError) {
+	auth, bootstrapAvailable, err := a.authState(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch {
+	case a.mode == "anonymous":
+		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos.linkRemove is unavailable in anonymous mode", nil)
+	case bootstrapAvailable:
+		return nil, nil, newAdapterError(http.StatusForbidden, CodeCapabilityUnavailable, "todos.linkRemove is unavailable before bootstrap", nil)
+	case !auth.Authenticated:
+		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
+	}
+
+	var in todosLinkRemoveInput
+	if err := decodeInput(input, &in); err != nil {
+		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid input", map[string]any{"detail": err.Error()})
+	}
+	if in.ProjectSlug == "" {
+		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "missing projectSlug", map[string]any{"field": "projectSlug"})
+	}
+	if in.LocalID <= 0 {
+		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid localId", map[string]any{"field": "localId"})
+	}
+	if in.TargetLocalId <= 0 {
+		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid targetLocalId", map[string]any{"field": "targetLocalId"})
+	}
+
+	pc, pcErr := a.store.GetProjectContextBySlug(ctx, in.ProjectSlug, a.storeMode())
+	if pcErr != nil {
+		return nil, nil, mapStoreError(pcErr)
+	}
+
+	if _, getErr := a.store.GetTodoByLocalID(ctx, pc.Project.ID, in.LocalID, a.storeMode()); getErr != nil {
+		if errors.Is(getErr, store.ErrUnauthorized) {
+			return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "forbidden", nil)
+		}
+		return nil, nil, mapStoreError(getErr)
+	}
+
+	if removeErr := a.store.RemoveLink(ctx, pc.Project.ID, in.LocalID, in.TargetLocalId, a.storeMode()); removeErr != nil {
+		if errors.Is(removeErr, store.ErrUnauthorized) {
+			return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "forbidden", nil)
+		}
+		return nil, nil, mapStoreError(removeErr)
+	}
+
+	outbound, listErr := a.store.ListLinksForTodo(ctx, pc.Project.ID, in.LocalID, a.storeMode())
+	if listErr != nil {
+		return nil, nil, mapStoreError(listErr)
+	}
+	inbound, listErr := a.store.ListBacklinksForTodo(ctx, pc.Project.ID, in.LocalID, a.storeMode())
+	if listErr != nil {
+		return nil, nil, mapStoreError(listErr)
+	}
+
+	return map[string]any{
+		"outbound": todoLinkTargetsToItems(outbound),
+		"inbound":  todoLinkTargetsToItems(inbound),
+	}, map[string]any{}, nil
+}

--- a/internal/mcp/todos_links_tools_test.go
+++ b/internal/mcp/todos_links_tools_test.go
@@ -1,8 +1,11 @@
 package mcp_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
+
+	"scrumboy/internal/store"
 )
 
 func createTwoTodosForLinking(t *testing.T, client *http.Client, tsURL, slug string) (fromLocalID, toLocalID float64) {
@@ -342,5 +345,416 @@ func TestMCPTodosLinkAddCapabilityUnavailableInAnonymousMode(t *testing.T) {
 	errObj := out["error"].(map[string]any)
 	if errObj["code"] != "CAPABILITY_UNAVAILABLE" {
 		t.Fatalf("expected CAPABILITY_UNAVAILABLE, got %#v", errObj["code"])
+	}
+}
+
+func TestMCPTodosLinkAddRejectsInvalidLinkType(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	resp := doJSON(t, client, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Link Invalid Type Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Link Invalid Type Project")
+
+	fromID, toID := createTwoTodosForLinking(t, client, ts.URL, slug)
+
+	resp2, out := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkAdd",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       fromID,
+			"targetLocalId": toID,
+			"linkType":      "nope",
+		},
+	})
+	if resp2.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%#v", resp2.StatusCode, out)
+	}
+	errObj := out["error"].(map[string]any)
+	if errObj["code"] != "VALIDATION_ERROR" {
+		t.Fatalf("expected VALIDATION_ERROR, got %#v", errObj["code"])
+	}
+}
+
+// A read-only project member (viewer) can list a todo's links...
+func TestMCPTodosLinksListViewerCanRead(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	ownerClient := newCookieClient(t, ts)
+	bootstrapUser(t, ownerClient, ts.URL)
+	ownerID := firstUserID(t, sqlDB)
+	resp := doJSON(t, ownerClient, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Link Viewer Read Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Link Viewer Read Project")
+	projectID := projectIDBySlug(t, sqlDB, slug)
+
+	fromID, toID := createTwoTodosForLinking(t, ownerClient, ts.URL, slug)
+	if r, o := doMCP(t, ownerClient, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkAdd",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       fromID,
+			"targetLocalId": toID,
+		},
+	}); r.StatusCode != http.StatusOK {
+		t.Fatalf("owner todos_linkAdd status=%d body=%#v", r.StatusCode, o)
+	}
+
+	st := store.New(sqlDB, nil)
+	viewer, err := st.CreateUser(context.Background(), "linkviewer@example.com", "password123", "Viewer")
+	if err != nil {
+		t.Fatalf("create viewer: %v", err)
+	}
+	if err := st.AddProjectMember(context.Background(), ownerID, projectID, viewer.ID, store.RoleViewer); err != nil {
+		t.Fatalf("add viewer membership: %v", err)
+	}
+	viewerClient := newSessionClientForUser(t, ts, st, viewer.ID)
+
+	resp2, out := doMCP(t, viewerClient, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linksList",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"localId":     fromID,
+		},
+	})
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("viewer todos_linksList status=%d body=%#v", resp2.StatusCode, out)
+	}
+	data := out["data"].(map[string]any)
+	outbound := data["outbound"].([]any)
+	if len(outbound) != 1 {
+		t.Fatalf("expected 1 outbound link for viewer, got %#v", outbound)
+	}
+}
+
+// ...but cannot add a link: the store write path requires contributor+, and a
+// viewer that lacks it gets ErrNotFound (existence is not leaked), surfaced as
+// NOT_FOUND at the MCP boundary. The rejected add must not create a link.
+func TestMCPTodosLinkAddViewerCannotAdd(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	ownerClient := newCookieClient(t, ts)
+	bootstrapUser(t, ownerClient, ts.URL)
+	ownerID := firstUserID(t, sqlDB)
+	resp := doJSON(t, ownerClient, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Link Viewer Add Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Link Viewer Add Project")
+	projectID := projectIDBySlug(t, sqlDB, slug)
+
+	fromID, toID := createTwoTodosForLinking(t, ownerClient, ts.URL, slug)
+
+	st := store.New(sqlDB, nil)
+	viewer, err := st.CreateUser(context.Background(), "linkvieweradd@example.com", "password123", "Viewer")
+	if err != nil {
+		t.Fatalf("create viewer: %v", err)
+	}
+	if err := st.AddProjectMember(context.Background(), ownerID, projectID, viewer.ID, store.RoleViewer); err != nil {
+		t.Fatalf("add viewer membership: %v", err)
+	}
+	viewerClient := newSessionClientForUser(t, ts, st, viewer.ID)
+
+	respAdd, outAdd := doMCP(t, viewerClient, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkAdd",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       fromID,
+			"targetLocalId": toID,
+		},
+	})
+	if respAdd.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected viewer todos_linkAdd 404, got %d body=%#v", respAdd.StatusCode, outAdd)
+	}
+	if code := outAdd["error"].(map[string]any)["code"]; code != "NOT_FOUND" {
+		t.Fatalf("expected NOT_FOUND for viewer todos_linkAdd, got %#v", code)
+	}
+
+	// The rejected add must not have created a link.
+	_, outList := doMCP(t, ownerClient, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linksList",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"localId":     fromID,
+		},
+	})
+	if outbound := outList["data"].(map[string]any)["outbound"].([]any); len(outbound) != 0 {
+		t.Fatalf("expected no link created by rejected viewer add, got %#v", outbound)
+	}
+}
+
+// A viewer cannot remove an existing link. The owner creates the link first, so
+// the viewer's NOT_FOUND proves the contributor+ write gate rather than a merely
+// missing link (RemoveLink authorizes before checking existence), and the link
+// must survive the rejected removal.
+func TestMCPTodosLinkRemoveViewerCannotRemoveExistingLink(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	ownerClient := newCookieClient(t, ts)
+	bootstrapUser(t, ownerClient, ts.URL)
+	ownerID := firstUserID(t, sqlDB)
+	resp := doJSON(t, ownerClient, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Link Viewer Remove Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Link Viewer Remove Project")
+	projectID := projectIDBySlug(t, sqlDB, slug)
+
+	fromID, toID := createTwoTodosForLinking(t, ownerClient, ts.URL, slug)
+	if r, o := doMCP(t, ownerClient, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkAdd",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       fromID,
+			"targetLocalId": toID,
+		},
+	}); r.StatusCode != http.StatusOK {
+		t.Fatalf("owner todos_linkAdd status=%d body=%#v", r.StatusCode, o)
+	}
+
+	st := store.New(sqlDB, nil)
+	viewer, err := st.CreateUser(context.Background(), "linkviewerrem@example.com", "password123", "Viewer")
+	if err != nil {
+		t.Fatalf("create viewer: %v", err)
+	}
+	if err := st.AddProjectMember(context.Background(), ownerID, projectID, viewer.ID, store.RoleViewer); err != nil {
+		t.Fatalf("add viewer membership: %v", err)
+	}
+	viewerClient := newSessionClientForUser(t, ts, st, viewer.ID)
+
+	respRemove, outRemove := doMCP(t, viewerClient, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkRemove",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       fromID,
+			"targetLocalId": toID,
+		},
+	})
+	if respRemove.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected viewer todos_linkRemove 404, got %d body=%#v", respRemove.StatusCode, outRemove)
+	}
+	if code := outRemove["error"].(map[string]any)["code"]; code != "NOT_FOUND" {
+		t.Fatalf("expected NOT_FOUND for viewer todos_linkRemove, got %#v", code)
+	}
+
+	// The existing link must survive the rejected removal.
+	_, outList := doMCP(t, ownerClient, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linksList",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"localId":     fromID,
+		},
+	})
+	if outbound := outList["data"].(map[string]any)["outbound"].([]any); len(outbound) != 1 {
+		t.Fatalf("expected existing link to survive rejected viewer remove, got %#v", outbound)
+	}
+}
+
+// An authenticated user who is not a member of the project cannot even resolve
+// it: GetProjectContextBySlug returns ErrNotFound (existence not leaked), so
+// list and mutate both surface NOT_FOUND.
+func TestMCPTodosLinksNonMemberNotFound(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	ownerClient := newCookieClient(t, ts)
+	bootstrapUser(t, ownerClient, ts.URL)
+	resp := doJSON(t, ownerClient, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Link Non Member Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Link Non Member Project")
+
+	fromID, toID := createTwoTodosForLinking(t, ownerClient, ts.URL, slug)
+
+	st := store.New(sqlDB, nil)
+	other, err := st.CreateUser(context.Background(), "linknonmember@example.com", "password123", "Other")
+	if err != nil {
+		t.Fatalf("create non-member: %v", err)
+	}
+	otherClient := newSessionClientForUser(t, ts, st, other.ID)
+
+	respList, outList := doMCP(t, otherClient, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linksList",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"localId":     fromID,
+		},
+	})
+	if respList.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected non-member todos_linksList 404, got %d body=%#v", respList.StatusCode, outList)
+	}
+	if code := outList["error"].(map[string]any)["code"]; code != "NOT_FOUND" {
+		t.Fatalf("expected NOT_FOUND for non-member todos_linksList, got %#v", code)
+	}
+
+	respAdd, outAdd := doMCP(t, otherClient, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkAdd",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       fromID,
+			"targetLocalId": toID,
+		},
+	})
+	if respAdd.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected non-member todos_linkAdd 404, got %d body=%#v", respAdd.StatusCode, outAdd)
+	}
+	if code := outAdd["error"].(map[string]any)["code"]; code != "NOT_FOUND" {
+		t.Fatalf("expected NOT_FOUND for non-member todos_linkAdd, got %#v", code)
+	}
+
+	respRemove, outRemove := doMCP(t, otherClient, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkRemove",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       fromID,
+			"targetLocalId": toID,
+		},
+	})
+	if respRemove.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected non-member todos_linkRemove 404, got %d body=%#v", respRemove.StatusCode, outRemove)
+	}
+	if code := outRemove["error"].(map[string]any)["code"]; code != "NOT_FOUND" {
+		t.Fatalf("expected NOT_FOUND for non-member todos_linkRemove, got %#v", code)
+	}
+}
+
+// A contributor (the minimum intended write role) can both add and remove links.
+// This pins the lower bound of the write gate so a future regression that tightened
+// it to maintainer/owner-only would be caught by the suite.
+func TestMCPTodosLinkContributorCanMutate(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	ownerClient := newCookieClient(t, ts)
+	bootstrapUser(t, ownerClient, ts.URL)
+	ownerID := firstUserID(t, sqlDB)
+	resp := doJSON(t, ownerClient, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Link Contributor Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Link Contributor Project")
+	projectID := projectIDBySlug(t, sqlDB, slug)
+
+	fromID, toID := createTwoTodosForLinking(t, ownerClient, ts.URL, slug)
+
+	st := store.New(sqlDB, nil)
+	contributor, err := st.CreateUser(context.Background(), "linkcontrib@example.com", "password123", "Contributor")
+	if err != nil {
+		t.Fatalf("create contributor: %v", err)
+	}
+	if err := st.AddProjectMember(context.Background(), ownerID, projectID, contributor.ID, store.RoleContributor); err != nil {
+		t.Fatalf("add contributor membership: %v", err)
+	}
+	contribClient := newSessionClientForUser(t, ts, st, contributor.ID)
+
+	respAdd, outAdd := doMCP(t, contribClient, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkAdd",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       fromID,
+			"targetLocalId": toID,
+		},
+	})
+	if respAdd.StatusCode != http.StatusOK {
+		t.Fatalf("expected contributor todos_linkAdd 200, got %d body=%#v", respAdd.StatusCode, outAdd)
+	}
+	if outbound := outAdd["data"].(map[string]any)["outbound"].([]any); len(outbound) != 1 {
+		t.Fatalf("expected 1 outbound link after contributor add, got %#v", outbound)
+	}
+
+	respRemove, outRemove := doMCP(t, contribClient, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkRemove",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       fromID,
+			"targetLocalId": toID,
+		},
+	})
+	if respRemove.StatusCode != http.StatusOK {
+		t.Fatalf("expected contributor todos_linkRemove 200, got %d body=%#v", respRemove.StatusCode, outRemove)
+	}
+	if outbound := outRemove["data"].(map[string]any)["outbound"].([]any); len(outbound) != 0 {
+		t.Fatalf("expected 0 outbound links after contributor remove, got %#v", outbound)
+	}
+}
+
+// The target todo lookup is scoped by project_id: a target localId that exists
+// only in another project must not resolve. Project A has a single source todo
+// (localId 1) and no localId 2; project B has a localId 2. Linking A's source to
+// targetLocalId 2 must fail with NOT_FOUND rather than resolving B's todo.
+func TestMCPTodosLinkAddCrossProjectTargetIsolation(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+
+	respA := doJSON(t, client, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Cross Project A",
+	}, &map[string]any{})
+	if respA.StatusCode != http.StatusCreated {
+		t.Fatalf("create project A status=%d", respA.StatusCode)
+	}
+	slugA := projectSlugByName(t, sqlDB, "Cross Project A")
+
+	respB := doJSON(t, client, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Cross Project B",
+	}, &map[string]any{})
+	if respB.StatusCode != http.StatusCreated {
+		t.Fatalf("create project B status=%d", respB.StatusCode)
+	}
+	slugB := projectSlugByName(t, sqlDB, "Cross Project B")
+
+	// Project A: a single source todo (localId 1); no localId 2 exists here.
+	rA, oA := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_create",
+		"input": map[string]any{
+			"projectSlug": slugA,
+			"title":       "A source",
+		},
+	})
+	if rA.StatusCode != http.StatusOK {
+		t.Fatalf("create A source todo status=%d body=%#v", rA.StatusCode, oA)
+	}
+	sourceLocalID := oA["data"].(map[string]any)["todo"].(map[string]any)["localId"].(float64)
+
+	// Project B: two todos so a localId 2 exists in B (but not in A).
+	_, targetLocalID := createTwoTodosForLinking(t, client, ts.URL, slugB)
+
+	resp2, out := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkAdd",
+		"input": map[string]any{
+			"projectSlug":   slugA,
+			"localId":       sourceLocalID,
+			"targetLocalId": targetLocalID,
+		},
+	})
+	if resp2.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected cross-project todos_linkAdd 404, got %d body=%#v", resp2.StatusCode, out)
+	}
+	if code := out["error"].(map[string]any)["code"]; code != "NOT_FOUND" {
+		t.Fatalf("expected NOT_FOUND for cross-project target, got %#v", code)
 	}
 }

--- a/internal/mcp/todos_links_tools_test.go
+++ b/internal/mcp/todos_links_tools_test.go
@@ -1,0 +1,346 @@
+package mcp_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+func createTwoTodosForLinking(t *testing.T, client *http.Client, tsURL, slug string) (fromLocalID, toLocalID float64) {
+	t.Helper()
+
+	resp1, out1 := doMCP(t, client, tsURL+"/mcp", map[string]any{
+		"tool": "todos_create",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"title":       "From todo",
+		},
+	})
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("todos_create (from) status=%d body=%#v", resp1.StatusCode, out1)
+	}
+	fromTodo := out1["data"].(map[string]any)["todo"].(map[string]any)
+
+	resp2, out2 := doMCP(t, client, tsURL+"/mcp", map[string]any{
+		"tool": "todos_create",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"title":       "To todo",
+		},
+	})
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("todos_create (to) status=%d body=%#v", resp2.StatusCode, out2)
+	}
+	toTodo := out2["data"].(map[string]any)["todo"].(map[string]any)
+
+	return fromTodo["localId"].(float64), toTodo["localId"].(float64)
+}
+
+func TestMCPTodosLinkAddAndListSuccess(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	resp := doJSON(t, client, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Link Add Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Link Add Project")
+
+	fromID, toID := createTwoTodosForLinking(t, client, ts.URL, slug)
+
+	resp2, out := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkAdd",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       fromID,
+			"targetLocalId": toID,
+		},
+	})
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("todos_linkAdd status=%d body=%#v", resp2.StatusCode, out)
+	}
+	data := out["data"].(map[string]any)
+	outbound := data["outbound"].([]any)
+	if len(outbound) != 1 {
+		t.Fatalf("expected 1 outbound link, got %#v", outbound)
+	}
+	link := outbound[0].(map[string]any)
+	if link["localId"] != toID {
+		t.Fatalf("expected outbound localId %v, got %#v", toID, link["localId"])
+	}
+	if link["linkType"] != "relates_to" {
+		t.Fatalf("expected default linkType relates_to, got %#v", link["linkType"])
+	}
+	inbound := data["inbound"].([]any)
+	if len(inbound) != 0 {
+		t.Fatalf("expected 0 inbound links on the from-todo, got %#v", inbound)
+	}
+
+	resp3, out3 := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linksList",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"localId":     toID,
+		},
+	})
+	if resp3.StatusCode != http.StatusOK {
+		t.Fatalf("todos_linksList status=%d body=%#v", resp3.StatusCode, out3)
+	}
+	data3 := out3["data"].(map[string]any)
+	inbound3 := data3["inbound"].([]any)
+	if len(inbound3) != 1 {
+		t.Fatalf("expected 1 inbound link on the to-todo, got %#v", inbound3)
+	}
+}
+
+func TestMCPTodosLinkAddWithExplicitLinkType(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	resp := doJSON(t, client, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Link Type Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Link Type Project")
+
+	fromID, toID := createTwoTodosForLinking(t, client, ts.URL, slug)
+
+	resp2, out := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkAdd",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       fromID,
+			"targetLocalId": toID,
+			"linkType":      "blocks",
+		},
+	})
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("todos_linkAdd status=%d body=%#v", resp2.StatusCode, out)
+	}
+	data := out["data"].(map[string]any)
+	outbound := data["outbound"].([]any)
+	link := outbound[0].(map[string]any)
+	if link["linkType"] != "blocks" {
+		t.Fatalf("expected linkType blocks, got %#v", link["linkType"])
+	}
+}
+
+func TestMCPTodosLinkAddRejectsSelfLink(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	resp := doJSON(t, client, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Link Self Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Link Self Project")
+
+	doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_create",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"title":       "Solo todo",
+		},
+	})
+
+	resp2, out := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkAdd",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       1,
+			"targetLocalId": 1,
+		},
+	})
+	if resp2.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%#v", resp2.StatusCode, out)
+	}
+	errObj := out["error"].(map[string]any)
+	if errObj["code"] != "VALIDATION_ERROR" {
+		t.Fatalf("expected VALIDATION_ERROR, got %#v", errObj["code"])
+	}
+}
+
+func TestMCPTodosLinkAddNotFoundForMissingTarget(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	resp := doJSON(t, client, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Link Missing Target Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Link Missing Target Project")
+
+	doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_create",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"title":       "Solo todo",
+		},
+	})
+
+	resp2, out := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkAdd",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       1,
+			"targetLocalId": 999,
+		},
+	})
+	if resp2.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%#v", resp2.StatusCode, out)
+	}
+	errObj := out["error"].(map[string]any)
+	if errObj["code"] != "NOT_FOUND" {
+		t.Fatalf("expected NOT_FOUND, got %#v", errObj["code"])
+	}
+}
+
+func TestMCPTodosLinkRemoveSuccess(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	resp := doJSON(t, client, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Link Remove Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Link Remove Project")
+
+	fromID, toID := createTwoTodosForLinking(t, client, ts.URL, slug)
+
+	doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkAdd",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       fromID,
+			"targetLocalId": toID,
+		},
+	})
+
+	resp2, out := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkRemove",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       fromID,
+			"targetLocalId": toID,
+		},
+	})
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("todos_linkRemove status=%d body=%#v", resp2.StatusCode, out)
+	}
+	data := out["data"].(map[string]any)
+	outbound := data["outbound"].([]any)
+	if len(outbound) != 0 {
+		t.Fatalf("expected 0 outbound links after removal, got %#v", outbound)
+	}
+}
+
+func TestMCPTodosLinkRemoveNotFoundForMissingLink(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	resp := doJSON(t, client, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Link Remove Missing Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Link Remove Missing Project")
+
+	fromID, toID := createTwoTodosForLinking(t, client, ts.URL, slug)
+
+	resp2, out := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkRemove",
+		"input": map[string]any{
+			"projectSlug":   slug,
+			"localId":       fromID,
+			"targetLocalId": toID,
+		},
+	})
+	if resp2.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%#v", resp2.StatusCode, out)
+	}
+	errObj := out["error"].(map[string]any)
+	if errObj["code"] != "NOT_FOUND" {
+		t.Fatalf("expected NOT_FOUND, got %#v", errObj["code"])
+	}
+}
+
+func TestMCPTodosLinksListRequiresAuth(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	resp := doJSON(t, client, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Link List Auth Project",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Link List Auth Project")
+
+	doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "todos_create",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"title":       "Solo todo",
+		},
+	})
+
+	resp2, out := doMCP(t, newStatelessClient(ts), ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linksList",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"localId":     1,
+		},
+	})
+	if resp2.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp2.StatusCode)
+	}
+	errObj := out["error"].(map[string]any)
+	if errObj["code"] != "AUTH_REQUIRED" {
+		t.Fatalf("expected AUTH_REQUIRED, got %#v", errObj["code"])
+	}
+}
+
+func TestMCPTodosLinkAddCapabilityUnavailableInAnonymousMode(t *testing.T) {
+	ts, _, cleanup := newTestServer(t, "anonymous")
+	defer cleanup()
+
+	resp, out := doMCP(t, ts.Client(), ts.URL+"/mcp", map[string]any{
+		"tool": "todos_linkAdd",
+		"input": map[string]any{
+			"projectSlug":   "demo",
+			"localId":       1,
+			"targetLocalId": 2,
+		},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+	errObj := out["error"].(map[string]any)
+	if errObj["code"] != "CAPABILITY_UNAVAILABLE" {
+		t.Fatalf("expected CAPABILITY_UNAVAILABLE, got %#v", errObj["code"])
+	}
+}

--- a/internal/mcp/tool_catalog.go
+++ b/internal/mcp/tool_catalog.go
@@ -91,6 +91,33 @@ func toolCatalogDefinitions() map[string]mcpToolDef {
 				"beforeLocalId": jsonPropWithNull("integer", "Place before this todo local ID"),
 			}, []string{"projectSlug", "localId", "toColumnKey"}),
 		},
+		"todos_linksList": {
+			Name:        "todos_linksList",
+			Description: "List the outbound and inbound linked stories for a todo.",
+			InputSchema: jsonSchema("object", map[string]any{
+				"projectSlug": jsonProp("string", "Project identifier (slug)"),
+				"localId":     jsonProp("integer", "Project-scoped todo ID"),
+			}, []string{"projectSlug", "localId"}),
+		},
+		"todos_linkAdd": {
+			Name:        "todos_linkAdd",
+			Description: "Link a todo to another todo (a \"linked story\"). Defaults to link type relates_to; also supports blocks, duplicates, and parent.",
+			InputSchema: jsonSchema("object", map[string]any{
+				"projectSlug":   jsonProp("string", "Project identifier (slug)"),
+				"localId":       jsonProp("integer", "Project-scoped todo ID to link from"),
+				"targetLocalId": jsonProp("integer", "Project-scoped todo ID to link to"),
+				"linkType":      jsonProp("string", "Link type: relates_to (default), blocks, duplicates, or parent"),
+			}, []string{"projectSlug", "localId", "targetLocalId"}),
+		},
+		"todos_linkRemove": {
+			Name:        "todos_linkRemove",
+			Description: "Remove a link between two todos.",
+			InputSchema: jsonSchema("object", map[string]any{
+				"projectSlug":   jsonProp("string", "Project identifier (slug)"),
+				"localId":       jsonProp("integer", "Project-scoped todo ID to unlink from"),
+				"targetLocalId": jsonProp("integer", "Project-scoped todo ID to unlink"),
+			}, []string{"projectSlug", "localId", "targetLocalId"}),
+		},
 		"sprints_list": {
 			Name:        "sprints_list",
 			Description: "List sprints for a project.",

--- a/internal/mcp/tool_catalog.go
+++ b/internal/mcp/tool_catalog.go
@@ -93,7 +93,7 @@ func toolCatalogDefinitions() map[string]mcpToolDef {
 		},
 		"todos_linksList": {
 			Name:        "todos_linksList",
-			Description: "List the outbound and inbound linked stories for a todo.",
+			Description: "List the linked stories for a todo. Returns outbound links (edges where this todo is the source) and inbound links (edges where this todo is the target).",
 			InputSchema: jsonSchema("object", map[string]any{
 				"projectSlug": jsonProp("string", "Project identifier (slug)"),
 				"localId":     jsonProp("integer", "Project-scoped todo ID"),
@@ -101,21 +101,21 @@ func toolCatalogDefinitions() map[string]mcpToolDef {
 		},
 		"todos_linkAdd": {
 			Name:        "todos_linkAdd",
-			Description: "Link a todo to another todo (a \"linked story\"). Defaults to link type relates_to; also supports blocks, duplicates, and parent.",
+			Description: "Link a todo to another todo (a \"linked story\"). The edge is directed from localId to targetLocalId, and the type describes localId as the subject: for blocks, localId blocks targetLocalId; for parent, localId is the parent of targetLocalId; for duplicates, localId duplicates targetLocalId; relates_to (the default) is a directed related-to edge with the same orientation.",
 			InputSchema: jsonSchema("object", map[string]any{
 				"projectSlug":   jsonProp("string", "Project identifier (slug)"),
-				"localId":       jsonProp("integer", "Project-scoped todo ID to link from"),
-				"targetLocalId": jsonProp("integer", "Project-scoped todo ID to link to"),
-				"linkType":      jsonProp("string", "Link type: relates_to (default), blocks, duplicates, or parent"),
+				"localId":       jsonProp("integer", "Project-scoped todo ID to link from (the subject of the link type)"),
+				"targetLocalId": jsonProp("integer", "Project-scoped todo ID to link to (the object of the link type)"),
+				"linkType":      jsonStringEnumProp("Link type describing localId as the subject: relates_to (default), blocks (localId blocks target), duplicates (localId duplicates target), or parent (localId is parent of target)", []string{"relates_to", "blocks", "duplicates", "parent"}),
 			}, []string{"projectSlug", "localId", "targetLocalId"}),
 		},
 		"todos_linkRemove": {
 			Name:        "todos_linkRemove",
-			Description: "Remove a link between two todos.",
+			Description: "Remove a linked story. Deletes only the directed edge from localId to targetLocalId (the same orientation used by todos_linkAdd); the reverse edge, if any, is left intact.",
 			InputSchema: jsonSchema("object", map[string]any{
 				"projectSlug":   jsonProp("string", "Project identifier (slug)"),
-				"localId":       jsonProp("integer", "Project-scoped todo ID to unlink from"),
-				"targetLocalId": jsonProp("integer", "Project-scoped todo ID to unlink"),
+				"localId":       jsonProp("integer", "Project-scoped todo ID to unlink from (link source)"),
+				"targetLocalId": jsonProp("integer", "Project-scoped todo ID to unlink (link target)"),
 			}, []string{"projectSlug", "localId", "targetLocalId"}),
 		},
 		"sprints_list": {
@@ -326,6 +326,16 @@ func jsonSchema(typ string, properties map[string]any, required []string) map[st
 
 func jsonProp(typ, description string) map[string]any {
 	return map[string]any{"type": typ, "description": description}
+}
+
+// jsonStringEnumProp builds a string property constrained to a fixed set of
+// allowed values, so MCP clients can constrain generation to valid inputs.
+func jsonStringEnumProp(description string, values []string) map[string]any {
+	return map[string]any{
+		"type":        "string",
+		"description": description,
+		"enum":        values,
+	}
 }
 
 func jsonPropWithNull(typ, description string) map[string]any {

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -89,6 +89,12 @@ type todoSearchItem struct {
 	Title       string `json:"title"`
 }
 
+type todoLinkItem struct {
+	LocalID  int64  `json:"localId"`
+	Title    string `json:"title"`
+	LinkType string `json:"linkType"`
+}
+
 type sprintItem struct {
 	ProjectSlug    string `json:"projectSlug"`
 	SprintID       int64  `json:"sprintId"`

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.24.0"
+const Version = "3.24.1"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
## Summary

- Adds MCP tool support for the todo detail page's "Linked Stories" relation, which previously had no MCP surface — the only related tool, `todos_search`, just searches link *targets* for the picker UI and never applies anything.
- `todos_linksList` (get outbound + inbound links for a todo), `todos_linkAdd` (link two todos, default type `relates_to`, also `blocks`/`duplicates`/`parent`), `todos_linkRemove`. All three wire into the existing `store.AddLink`/`RemoveLink`/`ListLinksForTodo`/`ListBacklinksForTodo` functions that already back the web UI's REST endpoints (`GET/POST/DELETE /api/board/{slug}/todos/{localId}/links[/targetLocalId]`).
- Found while using the MCP tools day-to-day to manage a project backlog: a parent todo needed several children linked to it, and there was no way to do that through MCP short of writing `#id` references into the free-text body.

Rebased onto `main` now that #172 (dot-to-underscore tool rename) has merged — the three new tools were named with underscores from the start, so no further renaming was needed.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1 -timeout=5m` (full suite, all packages pass)
- [x] New test file `internal/mcp/todos_links_tools_test.go` covers: add + list success (outbound/inbound), explicit link type, self-link rejection (`VALIDATION_ERROR`), missing target (`NOT_FOUND`), remove success, remove of nonexistent link (`NOT_FOUND`), auth-required gate, anonymous-mode capability gate.
- [x] Updated the hardcoded tool-count/order assertion in `adapter_test.go` (28 → 31 tools) for the three new entries.
- [x] `gofmt -l` clean on touched files.
- [x] `cd internal/httpapi/web && npm run build` passes
- [x] `npm test` reproduces the same 36 pre-existing failing suites (localStorage undefined in this Node/vitest environment) on unmodified `main`, confirming they're unrelated to this change
- [x] Ran a security-focused review of this commit's diff (auth gating, multi-tenant/IDOR scoping, injection) — no findings.
