### PR TITLE
align MCP tags_updateProjectColor tagId path with REST temporary-boar…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.24.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags) - see those releases.
 
+## [3.26.1] - 2026-07-26
+
+### Fixed
+
+- **MCP `tags_updateProjectColor` on temporary boards** - The `tagId` path no longer requires Maintainer (which could never pass because temporary-board `ProjectContext` leaves `Role` empty) and now calls `UpdateTagColorForTemporaryBoard`, matching REST link-holder semantics for authenticated Full-mode callers. Anonymous MCP mode remains unavailable.
+
 ## [3.26.0] - 2026-07-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.26.0-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.26.1-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -298,6 +298,9 @@ edge. See [API.md](../API.md#todos) for the full semantics.
 > **Temporary boards are not grouped.** Any project with an expiry keeps the previous
 > row-level projection: one entry per tag row, each with a real `tagId`. Their colors
 > and deletions are still addressed by `tagId`, so grouping would strand those writes.
+> For authenticated Full-mode callers, `tags_updateProjectColor` with `tagId` matches
+> REST link-holder semantics (`UpdateTagColorForTemporaryBoard`, no Maintainer gate).
+> Anonymous MCP mode remains unavailable; unauthenticated pastebin visitors use REST.
 >
 > A grouped entry is labelled by its canonical name. A legacy row whose stored name
 > cannot be canonicalized at all keeps its raw stored name as the label, and that label
@@ -308,9 +311,10 @@ edge. See [API.md](../API.md#todos) for the full semantics.
 > empty `tagName` alongside the other field is rejected instead of silently falling
 > through to one path. An explicitly empty `tagName` counts as supplied. `tagName`
 > sets only the caller's own per-viewer color for a personal label on a durable project
-> and is allowed for any authenticated project member (non-members are rejected);
-> `tagId` updates a board-scoped tag's shared color and still requires maintainer or
-> above.
+> and is allowed for any authenticated project member (non-members are rejected;
+> temporary boards reject `tagName`). On durable projects, `tagId` updates a
+> board-scoped tag's shared color and requires maintainer or above; on temporary
+> boards, `tagId` uses link-holder color semantics (no Maintainer gate).
 >
 > **Known limitation:** a per-viewer color set by `tagName` lands on backing tag rows
 > the caller also uses in their other projects. Only the targeted project emits a

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -45,6 +45,7 @@ type storeAPI interface {
 	ListUserTags(ctx context.Context, userID int64) ([]store.TagWithColor, error)
 	UpdateTagColor(ctx context.Context, viewerUserID *int64, tagID int64, color *string) error
 	UpdateTagColorForDurableProjectByID(ctx context.Context, projectID int64, viewerUserID int64, tagID int64, color *string) error
+	UpdateTagColorForTemporaryBoard(ctx context.Context, projectID int64, viewerUserID *int64, tagID int64, color *string) error
 	SetViewerTagColorByName(ctx context.Context, projectID int64, viewerUserID int64, name string, color *string) error
 	DeleteTag(ctx context.Context, userID int64, tagID int64, isAnonymousBoard bool) error
 	GetProjectScopedTagByID(ctx context.Context, projectID, tagID int64) (store.TagWithColor, error)

--- a/internal/mcp/adapter_test.go
+++ b/internal/mcp/adapter_test.go
@@ -3519,6 +3519,80 @@ func TestMCPTagsUpdateProjectColorSuccess(t *testing.T) {
 	}
 }
 
+// TestMCPTagsUpdateProjectColorTemporaryBoardSucceeds pins that authenticated Full-mode
+// MCP callers can update tag colors on temporary boards. buildProjectContext leaves
+// pc.Role empty for ExpiresAt != nil, so a Maintainer gate would always 403; the path
+// must skip that gate and use UpdateTagColorForTemporaryBoard (matching REST).
+func TestMCPTagsUpdateProjectColorTemporaryBoardSucceeds(t *testing.T) {
+	ts, sqlDB, cleanup := newTestServer(t, "full")
+	defer cleanup()
+
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	resp := doJSON(t, client, http.MethodPost, ts.URL+"/api/projects", map[string]any{
+		"name": "Temp Board Tag Color",
+	}, &map[string]any{})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project status=%d", resp.StatusCode)
+	}
+	slug := projectSlugByName(t, sqlDB, "Temp Board Tag Color")
+	projectID := projectIDBySlug(t, sqlDB, slug)
+	expires := time.Now().UTC().Add(24 * time.Hour).UnixMilli()
+	if _, err := sqlDB.Exec(`UPDATE projects SET expires_at = ? WHERE id = ?`, expires, projectID); err != nil {
+		t.Fatalf("make project temporary: %v", err)
+	}
+	tagID := insertProjectScopedTag(t, sqlDB, projectID, "shared", nil)
+
+	listResp, listOut := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "tags_listProject",
+		"input": map[string]any{
+			"projectSlug": slug,
+		},
+	})
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("tags_listProject status=%d", listResp.StatusCode)
+	}
+	var listed bool
+	for _, it := range listOut["data"].(map[string]any)["items"].([]any) {
+		m := it.(map[string]any)
+		if int64(m["tagId"].(float64)) != tagID {
+			continue
+		}
+		listed = true
+		if m["canUpdateColor"] != true {
+			t.Fatalf("temporary-board listing must report canUpdateColor true, got %#v", m)
+		}
+	}
+	if !listed {
+		t.Fatalf("expected tag %d in temporary board listProject", tagID)
+	}
+
+	wantColor := "#123456"
+	resp2, out := doMCP(t, client, ts.URL+"/mcp", map[string]any{
+		"tool": "tags_updateProjectColor",
+		"input": map[string]any{
+			"projectSlug": slug,
+			"tagId":       tagID,
+			"color":       wantColor,
+		},
+	})
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 on temporary board tagId color, got %d body=%#v", resp2.StatusCode, out)
+	}
+	tag := out["data"].(map[string]any)["tag"].(map[string]any)
+	if tag["color"] != wantColor {
+		t.Fatalf("expected color %q in response, got %#v", wantColor, tag["color"])
+	}
+
+	var stored sql.NullString
+	if err := sqlDB.QueryRow(`SELECT color FROM tags WHERE id = ?`, tagID).Scan(&stored); err != nil {
+		t.Fatalf("read tags.color: %v", err)
+	}
+	if !stored.Valid || stored.String != wantColor {
+		t.Fatalf("expected shared tags.color %q, got %#v", wantColor, stored)
+	}
+}
+
 // TestMCPTagsUpdateProjectColorVisibleToOtherMemberViaListProject checks that a project-scoped
 // color change is stored on the shared tag row (tags.color), not as a per-viewer preference:
 // a different project member sees the same color via tags_listProject / ListTagCounts.

--- a/internal/mcp/tag_tools.go
+++ b/internal/mcp/tag_tools.go
@@ -333,17 +333,18 @@ func (a *Adapter) handleTagsUpdateProjectColor(ctx context.Context, input any) (
 		return nil, nil, newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
 	}
 
-	// tagId addresses a shared board-scoped color on durable projects (personal groups
-	// omit tagId from listProject) and remains maintainer+ on temporary boards too.
-	if !pc.Role.HasMinimumRole(store.RoleMaintainer) {
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
-	}
-
 	var updateErr error
 	if pc.Project.ExpiresAt != nil {
-		updateErr = a.store.UpdateTagColor(ctx, &userID, tagID, in.Color)
+		// Temporary boards are link-shareable: buildProjectContext leaves pc.Role empty
+		// on purpose, and REST uses UpdateTagColorForTemporaryBoard with no Maintainer
+		// gate. Match that for authenticated Full-mode MCP callers (anonymous MCP mode
+		// remains unavailable; pastebin visitors use REST).
+		updateErr = a.store.UpdateTagColorForTemporaryBoard(ctx, pc.Project.ID, &userID, tagID, in.Color)
 	} else {
-		// Durable: also verify project membership and that the tag belongs here.
+		// Durable board-scoped tagId: shared tags.color requires Maintainer+.
+		if !pc.Role.HasMinimumRole(store.RoleMaintainer) {
+			return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
+		}
 		updateErr = a.store.UpdateTagColorForDurableProjectByID(ctx, pc.Project.ID, userID, tagID, in.Color)
 	}
 	if updateErr != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.26.0"
+const Version = "3.26.1"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
- Detects temporary boards with pc.Project.ExpiresAt != nil.
- Skips the impossible RoleMaintainer check for those boards.
- Calls UpdateTagColorForTemporaryBoard, matching the REST route.
- Keeps the Maintainer+ requirement and project-aware durable method for durable projects.
- Leaves anonymous MCP mode unavailable, as intended.

The store method also revalidates scope: board-scoped tags must belong to that project, while user-owned tags must actually be used by a todo on that temporary board. Expired boards are rejected while building the project context.