### PR TITLE
restrictive top-level default with scoped job permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})


### PR DESCRIPTION
StepSecurity fix so the workflow level default is read-all