### PR TITLE
Fix cross-lane drag disabled under chronological sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.28.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags) - see those releases.
 
+## [3.28.1] - 2026-07-27
+
+### Fixed
+
+- **Cross-lane drag disabled under chronological sort** - #3.28.0's "Chronological sort disables manual reorder" went further than intended: it hid the card drag handle entirely and skipped creating any Sortable instances, so cards couldn't be dragged to a *different* lane either, not just reordered within one. Manual-rank anchors derived from chronological DOM neighbors are still invalid, so same-lane reordering stays disabled (`Sortable`'s `sort: false`), but the drag handle is always rendered and cross-lane drops now go through, appending the card to the end of the target lane's rank order (`afterId`/`beforeId` both omitted) rather than trying to anchor off chronological neighbors.
+
 ## [3.28.0] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.28.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags) - see those releases.
 
-## [3.28.1] - 2026-07-27
-
-### Fixed
-
-- **Cross-lane drag disabled under chronological sort** - #3.28.0's "Chronological sort disables manual reorder" went further than intended: it hid the card drag handle entirely and skipped creating any Sortable instances, so cards couldn't be dragged to a *different* lane either, not just reordered within one. Manual-rank anchors derived from chronological DOM neighbors are still invalid, so same-lane reordering stays disabled (`Sortable`'s `sort: false`), but the drag handle is always rendered and cross-lane drops now go through, appending the card to the end of the target lane's rank order (`afterId`/`beforeId` both omitted) rather than trying to anchor off chronological neighbors.
-
 ## [3.28.0] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.28.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags) - see those releases.
 
+## [3.28.1] - 2026-07-27
+
+### Fixed
+
+- **Cross-lane drag disabled under chronological sort (PR #196)** - 3.28.0's "Chronological sort disables manual reorder" went further than intended: it hid the card drag handle entirely and skipped creating any Sortable instances, so cards couldn't be dragged to a *different* lane either, not just reordered within one. Manual-rank anchors derived from chronological DOM neighbors are still invalid, so same-lane reordering stays disabled (`Sortable`'s `sort: false`), but the drag handle is always rendered and cross-lane drops now go through, appending the card to the end of the target lane's rank order (`afterId`/`beforeId` both omitted) rather than trying to anchor off chronological neighbors. Stale Sortable callbacks after a reinit or sort-mode change are ignored so they cannot rewrite ranks from the wrong ordering.
+
 ## [3.28.0] - 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.28.0-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.28.1-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/internal/httpapi/web/modules/features/drag-drop.test.ts
+++ b/internal/httpapi/web/modules/features/drag-drop.test.ts
@@ -137,34 +137,41 @@ describe("drag-drop i18n errors", () => {
   });
 
   it.each(["newest", "oldest"] as const)(
-    "does not create Sortable instances or requests for %s ordering",
+    "still creates Sortable instances for %s ordering, but with in-lane sorting disabled",
     async (sort) => {
       selectorState.sort = sort;
       const dragDrop = await import("./drag-drop.js");
 
       dragDrop.initDnD();
 
-      expect(sortableCreateMock).not.toHaveBeenCalled();
+      expect(sortableCreateMock).toHaveBeenCalledTimes(2);
+      const doingSortableCall = sortableCreateMock.mock.calls.find(([el]) => (el as HTMLElement).id === "list_doing");
+      if (!doingSortableCall) throw new Error("missing Sortable call for doing lane");
+      expect(doingSortableCall[1].sort).toBe(false);
       expect(apiFetchMock).not.toHaveBeenCalled();
     },
   );
 
-  it("destroys manual-order Sortable instances when chronological ordering becomes active", async () => {
+  it("re-creates Sortable instances with sort re-enabled when leaving chronological ordering", async () => {
+    selectorState.sort = "newest";
     const dragDrop = await import("./drag-drop.js");
     dragDrop.initDnD();
-    expect(sortableCreateMock).toHaveBeenCalledTimes(2);
     expect(sortableInstances).toHaveLength(2);
 
-    selectorState.sort = "newest";
+    selectorState.sort = null;
     sortableCreateMock.mockClear();
     dragDrop.initDnD();
 
     expect(sortableInstances[0].destroy).toHaveBeenCalledTimes(1);
     expect(sortableInstances[1].destroy).toHaveBeenCalledTimes(1);
-    expect(sortableCreateMock).not.toHaveBeenCalled();
+    const doingSortableCall = sortableCreateMock.mock.calls.find(([el]) => (el as HTMLElement).id === "list_doing");
+    if (!doingSortableCall) throw new Error("missing Sortable call for doing lane");
+    expect(doingSortableCall[1].sort).toBe(true);
   });
 
-  it("blocks a stale manual-order onEnd callback after chronological ordering is selected", async () => {
+  it("still allows a cross-lane drop while chronological ordering is active, appending to the end of the target lane", async () => {
+    selectorState.sort = "oldest";
+    apiFetchMock.mockResolvedValue({});
     const dragDrop = await import("./drag-drop.js");
     dragDrop.initDnD();
 
@@ -180,7 +187,6 @@ describe("drag-drop i18n errors", () => {
     const doingSortableCall = sortableCreateMock.mock.calls.find(([el]) => (el as HTMLElement).id === "list_doing");
     if (!doingSortableCall) throw new Error("missing Sortable call for doing lane");
 
-    selectorState.sort = "oldest";
     await doingSortableCall[1].onEnd({
       item,
       to: list,
@@ -189,7 +195,11 @@ describe("drag-drop i18n errors", () => {
       newIndex: 1,
     });
 
-    expect(apiFetchMock).not.toHaveBeenCalled();
-    expect(invalidateBoardMock).not.toHaveBeenCalled();
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      "/api/board/alpha/todos/12/move",
+      expect.objectContaining({
+        body: JSON.stringify({ toStatus: "doing", afterId: null, beforeId: null }),
+      }),
+    );
   });
 });

--- a/internal/httpapi/web/modules/features/drag-drop.test.ts
+++ b/internal/httpapi/web/modules/features/drag-drop.test.ts
@@ -5,12 +5,14 @@ const apiFetchMock = vi.hoisted(() => vi.fn());
 const showToastMock = vi.hoisted(() => vi.fn());
 const invalidateBoardMock = vi.hoisted(() => vi.fn());
 const sortableCreateMock = vi.hoisted(() => vi.fn());
+const recordBoardInteractionMock = vi.hoisted(() => vi.fn());
+const recordLocalMutationMock = vi.hoisted(() => vi.fn());
 const sortableInstances: Array<{ destroy: ReturnType<typeof vi.fn> }> = [];
 const selectorState = vi.hoisted(() => ({
   slug: "alpha",
-  tag: "bug",
-  search: "login",
-  sprintId: "7",
+  tag: null as string | null,
+  search: null as string | null,
+  sprintId: null as string | null,
   assignee: null as string | null,
   sort: null as string | null,
   laneMeta: {
@@ -46,8 +48,8 @@ vi.mock("../orchestration/board-refresh.js", () => ({
 }));
 
 vi.mock("../realtime/guard.js", () => ({
-  recordBoardInteraction: vi.fn(),
-  recordLocalMutation: vi.fn(),
+  recordBoardInteraction: recordBoardInteractionMock,
+  recordLocalMutation: recordLocalMutationMock,
 }));
 
 const enCatalog = {
@@ -62,13 +64,51 @@ const pseudoCatalog = {
   "board.todo.movedTo": "[!! Todo moved to {lane} !!]",
 };
 
-describe("drag-drop i18n errors", () => {
+type SortableOptions = {
+  group: string;
+  sort?: boolean;
+  onStart?: () => void;
+  onEnd: (evt: any) => Promise<void>;
+};
+
+function getElement(id: string): HTMLElement {
+  const element = document.getElementById(id);
+  if (!element) throw new Error(`missing ${id}`);
+  return element;
+}
+
+function getSortableOptions(id: string, occurrence = -1): SortableOptions {
+  const matches = sortableCreateMock.mock.calls.filter(([element]) => (element as HTMLElement).id === id);
+  const index = occurrence < 0 ? matches.length - 1 : occurrence;
+  const match = matches[index];
+  if (!match) throw new Error(`missing Sortable call for ${id}`);
+  return match[1] as SortableOptions;
+}
+
+function makeCard(localId: number): HTMLButtonElement {
+  const item = document.createElement("button");
+  item.className = "card";
+  item.setAttribute("data-todo-local-id", String(localId));
+  return item;
+}
+
+function expectMove(localId: number, toStatus: string, afterId: number | null, beforeId: number | null): void {
+  expect(apiFetchMock).toHaveBeenCalledWith(
+    `/api/board/alpha/todos/${localId}/move`,
+    expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ toStatus, afterId, beforeId }),
+    }),
+  );
+}
+
+describe("drag-drop", () => {
   beforeEach(() => {
     vi.resetModules();
     selectorState.slug = "alpha";
-    selectorState.tag = "bug";
-    selectorState.search = "login";
-    selectorState.sprintId = "7";
+    selectorState.tag = null;
+    selectorState.search = null;
+    selectorState.sprintId = null;
     selectorState.assignee = null;
     selectorState.sort = null;
     Object.values(selectorState.laneMeta).forEach((meta) => {
@@ -77,13 +117,22 @@ describe("drag-drop i18n errors", () => {
       meta.loading = false;
     });
     document.body.innerHTML = `
-      <div id="list_doing" data-status="doing"></div>
-      <div id="tab_drop_doing" data-status="doing"></div>
+      <div class="mobile-board-wrapper">
+        <div id="list_backlog" data-status="backlog"></div>
+        <div id="list_doing" data-status="doing"></div>
+        <div id="mobileTabDropZones">
+          <div id="tab_drop_backlog" data-status="backlog"></div>
+          <div id="tab_drop_doing" data-status="doing"></div>
+        </div>
+      </div>
     `;
     apiFetchMock.mockReset();
+    apiFetchMock.mockResolvedValue({});
     showToastMock.mockReset();
     invalidateBoardMock.mockReset();
     invalidateBoardMock.mockResolvedValue(undefined);
+    recordBoardInteractionMock.mockReset();
+    recordLocalMutationMock.mockReset();
     sortableCreateMock.mockReset();
     sortableInstances.length = 0;
     sortableCreateMock.mockImplementation(() => {
@@ -102,7 +151,292 @@ describe("drag-drop i18n errors", () => {
     document.body.innerHTML = "";
   });
 
+  it("preserves manual same-lane rank anchors", async () => {
+    const list = getElement("list_doing");
+    const before = makeCard(11);
+    const item = makeCard(12);
+    const after = makeCard(13);
+    list.append(before, item, after);
+
+    const dragDrop = await import("./drag-drop.js");
+    dragDrop.initDnD();
+
+    expect(getSortableOptions("list_doing").sort).toBe(true);
+    await getSortableOptions("list_doing").onEnd({
+      item,
+      to: list,
+      from: list,
+      oldIndex: 0,
+      newIndex: 1,
+    });
+
+    expectMove(12, "doing", 11, 13);
+  });
+
+  it("preserves manual cross-lane rank anchors", async () => {
+    const from = getElement("list_backlog");
+    const list = getElement("list_doing");
+    const before = makeCard(21);
+    const item = makeCard(22);
+    const after = makeCard(23);
+    list.append(before, item, after);
+
+    const dragDrop = await import("./drag-drop.js");
+    dragDrop.initDnD();
+
+    await getSortableOptions("list_doing").onEnd({
+      item,
+      to: list,
+      from,
+      oldIndex: 0,
+      newIndex: 1,
+    });
+
+    expectMove(22, "doing", 21, 23);
+  });
+
+  it.each(["newest", "oldest"] as const)(
+    "keeps connected cross-lane dragging enabled with in-lane sorting disabled for %s ordering",
+    async (sort) => {
+      selectorState.sort = sort;
+      const dragDrop = await import("./drag-drop.js");
+
+      dragDrop.initDnD();
+
+      expect(sortableCreateMock).toHaveBeenCalledTimes(4);
+      expect(getSortableOptions("list_backlog")).toEqual(expect.objectContaining({ group: "board", sort: false }));
+      expect(getSortableOptions("list_doing")).toEqual(expect.objectContaining({ group: "board", sort: false }));
+      expect(getSortableOptions("tab_drop_backlog")).toEqual(expect.objectContaining({ group: "board" }));
+      expect(getSortableOptions("tab_drop_doing")).toEqual(expect.objectContaining({ group: "board" }));
+      expect(apiFetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("destroys chronological Sortables and re-enables in-lane sorting when returning to manual order", async () => {
+    selectorState.sort = "newest";
+    const dragDrop = await import("./drag-drop.js");
+    dragDrop.initDnD();
+    expect(sortableInstances).toHaveLength(4);
+
+    selectorState.sort = null;
+    sortableCreateMock.mockClear();
+    dragDrop.initDnD();
+
+    sortableInstances.slice(0, 4).forEach((instance) => {
+      expect(instance.destroy).toHaveBeenCalledTimes(1);
+    });
+    expect(getSortableOptions("list_doing").sort).toBe(true);
+  });
+
+  it("rejects a synthetic chronological same-lane callback without making a request", async () => {
+    selectorState.sort = "newest";
+    const list = getElement("list_doing");
+    const item = makeCard(32);
+    list.append(makeCard(31), item, makeCard(33));
+
+    const dragDrop = await import("./drag-drop.js");
+    dragDrop.initDnD();
+
+    await getSortableOptions("list_doing").onEnd({
+      item,
+      to: list,
+      from: list,
+      oldIndex: 0,
+      newIndex: 1,
+    });
+
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("moves chronologically rendered cards across lanes without deriving DOM rank anchors", async () => {
+    selectorState.sort = "oldest";
+    const from = getElement("list_backlog");
+    const list = getElement("list_doing");
+    const item = makeCard(42);
+    list.append(makeCard(41), item, makeCard(43));
+
+    const dragDrop = await import("./drag-drop.js");
+    dragDrop.initDnD();
+
+    await getSortableOptions("list_doing").onEnd({
+      item,
+      to: list,
+      from,
+      oldIndex: 0,
+      newIndex: 1,
+    });
+
+    expectMove(42, "doing", null, null);
+  });
+
+  it("rejects a manual callback after the board switches to chronological order", async () => {
+    const from = getElement("list_backlog");
+    const list = getElement("list_doing");
+    const item = makeCard(52);
+    list.append(makeCard(51), item, makeCard(53));
+    const dragDrop = await import("./drag-drop.js");
+    dragDrop.initDnD();
+    const staleOptions = getSortableOptions("list_doing");
+
+    selectorState.sort = "newest";
+    await staleOptions.onEnd({
+      item,
+      to: list,
+      from,
+      oldIndex: 0,
+      newIndex: 1,
+    });
+
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a chronological callback after the board switches to manual order", async () => {
+    selectorState.sort = "oldest";
+    const from = getElement("list_backlog");
+    const list = getElement("list_doing");
+    const item = makeCard(62);
+    list.append(makeCard(61), item, makeCard(63));
+    const dragDrop = await import("./drag-drop.js");
+    dragDrop.initDnD();
+    const staleOptions = getSortableOptions("list_doing");
+
+    selectorState.sort = null;
+    await staleOptions.onEnd({
+      item,
+      to: list,
+      from,
+      oldIndex: 0,
+      newIndex: 1,
+    });
+
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps a newer active drag isolated from an older generation's stale onEnd", async () => {
+    const from = getElement("list_backlog");
+    const list = getElement("list_doing");
+    const wrapper = document.querySelector(".mobile-board-wrapper");
+    const dropZones = getElement("mobileTabDropZones");
+    const item = makeCard(72);
+    list.append(makeCard(71), item, makeCard(73));
+    const dragDrop = await import("./drag-drop.js");
+    dragDrop.initDnD();
+    const staleOptions = getSortableOptions("list_doing");
+    if (!staleOptions.onStart) throw new Error("missing onStart for stale Sortable");
+
+    staleOptions.onStart();
+    expect(dragDrop.dragInProgress).toBe(true);
+    expect(wrapper?.classList.contains("dragging")).toBe(true);
+    expect(dropZones.classList.contains("mobile-tab-drops--intro-glow")).toBe(true);
+
+    dragDrop.initDnD();
+    const currentOptions = getSortableOptions("list_doing");
+    if (!currentOptions.onStart) throw new Error("missing onStart for current Sortable");
+
+    expect(dragDrop.dragInProgress).toBe(false);
+    expect(dragDrop.dragJustEnded).toBe(true);
+    expect(wrapper?.classList.contains("dragging")).toBe(false);
+    expect(dropZones.classList.contains("mobile-tab-drops--intro-glow")).toBe(false);
+
+    currentOptions.onStart();
+    expect(dragDrop.dragInProgress).toBe(true);
+    expect(dragDrop.dragJustEnded).toBe(false);
+    expect(wrapper?.classList.contains("dragging")).toBe(true);
+    expect(dropZones.classList.contains("mobile-tab-drops--intro-glow")).toBe(true);
+    recordBoardInteractionMock.mockClear();
+
+    await staleOptions.onEnd({
+      item,
+      to: list,
+      from,
+      oldIndex: 0,
+      newIndex: 1,
+    });
+    expect(apiFetchMock).not.toHaveBeenCalled();
+    expect(recordBoardInteractionMock).not.toHaveBeenCalled();
+    expect(dragDrop.dragInProgress).toBe(true);
+    expect(dragDrop.dragJustEnded).toBe(false);
+    expect(wrapper?.classList.contains("dragging")).toBe(true);
+    expect(dropZones.classList.contains("mobile-tab-drops--intro-glow")).toBe(true);
+
+    await currentOptions.onEnd({
+      item,
+      to: list,
+      from,
+      oldIndex: 0,
+      newIndex: 1,
+    });
+    expectMove(72, "doing", 71, 73);
+    expect(recordBoardInteractionMock).toHaveBeenCalledTimes(1);
+    expect(dragDrop.dragInProgress).toBe(false);
+    expect(dragDrop.dragJustEnded).toBe(true);
+    expect(wrapper?.classList.contains("dragging")).toBe(false);
+    expect(dropZones.classList.contains("mobile-tab-drops--intro-glow")).toBe(false);
+  });
+
+  it("does not let a stale onStart reactivate drag state after reinitialization", async () => {
+    const wrapper = document.querySelector(".mobile-board-wrapper");
+    const dropZones = getElement("mobileTabDropZones");
+    const dragDrop = await import("./drag-drop.js");
+    dragDrop.initDnD();
+    const staleOptions = getSortableOptions("list_doing");
+    if (!staleOptions.onStart) throw new Error("missing onStart for stale Sortable");
+
+    dragDrop.initDnD();
+    recordBoardInteractionMock.mockClear();
+    staleOptions.onStart();
+
+    expect(recordBoardInteractionMock).not.toHaveBeenCalled();
+    expect(dragDrop.dragInProgress).toBe(false);
+    expect(dragDrop.dragJustEnded).toBe(false);
+    expect(wrapper?.classList.contains("dragging")).toBe(false);
+    expect(dropZones.classList.contains("mobile-tab-drops--intro-glow")).toBe(false);
+  });
+
+  it("uses null anchors for chronological mobile lane-tab drops", async () => {
+    selectorState.sort = "newest";
+    const from = getElement("list_backlog");
+    const tabDrop = getElement("tab_drop_doing");
+    const item = makeCard(82);
+    tabDrop.append(item);
+    const dragDrop = await import("./drag-drop.js");
+    dragDrop.initDnD();
+
+    await getSortableOptions("tab_drop_doing").onEnd({
+      item,
+      to: tabDrop,
+      from,
+      oldIndex: 0,
+      newIndex: 0,
+    });
+
+    expectMove(82, "doing", null, null);
+  });
+
+  it("rejects a chronological mobile drop onto the card's current lane", async () => {
+    selectorState.sort = "newest";
+    const from = getElement("list_doing");
+    const tabDrop = getElement("tab_drop_doing");
+    const item = makeCard(92);
+    tabDrop.append(item);
+    const dragDrop = await import("./drag-drop.js");
+    dragDrop.initDnD();
+
+    await getSortableOptions("tab_drop_doing").onEnd({
+      item,
+      to: tabDrop,
+      from,
+      oldIndex: 0,
+      newIndex: 0,
+    });
+
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
   it("localizes move failure toasts and preserves current filters for recovery invalidation", async () => {
+    selectorState.tag = "bug";
+    selectorState.search = "login";
+    selectorState.sprintId = "7";
     const i18n = await import("../i18n/index.js");
     await i18n.initI18n({
       locale: "pseudo",
@@ -113,18 +447,12 @@ describe("drag-drop i18n errors", () => {
     const dragDrop = await import("./drag-drop.js");
     dragDrop.initDnD();
 
-    const list = document.getElementById("list_doing");
-    if (!list) throw new Error("missing list_doing");
-    const from = document.createElement("div");
-    from.setAttribute("data-status", "backlog");
-    const item = document.createElement("button");
-    item.className = "card";
-    item.setAttribute("data-todo-local-id", "12");
+    const list = getElement("list_doing");
+    const from = getElement("list_backlog");
+    const item = makeCard(12);
     list.appendChild(item);
 
-    const doingSortableCall = sortableCreateMock.mock.calls.find(([el]) => (el as HTMLElement).id === "list_doing");
-    if (!doingSortableCall) throw new Error("missing Sortable call for doing lane");
-    await doingSortableCall[1].onEnd({
+    await getSortableOptions("list_doing").onEnd({
       item,
       to: list,
       from,
@@ -134,72 +462,5 @@ describe("drag-drop i18n errors", () => {
 
     expect(showToastMock).toHaveBeenCalledWith("[!! Failed to move todo !!]");
     expect(invalidateBoardMock).toHaveBeenCalledWith("alpha", "bug", "login", "7", null, null);
-  });
-
-  it.each(["newest", "oldest"] as const)(
-    "still creates Sortable instances for %s ordering, but with in-lane sorting disabled",
-    async (sort) => {
-      selectorState.sort = sort;
-      const dragDrop = await import("./drag-drop.js");
-
-      dragDrop.initDnD();
-
-      expect(sortableCreateMock).toHaveBeenCalledTimes(2);
-      const doingSortableCall = sortableCreateMock.mock.calls.find(([el]) => (el as HTMLElement).id === "list_doing");
-      if (!doingSortableCall) throw new Error("missing Sortable call for doing lane");
-      expect(doingSortableCall[1].sort).toBe(false);
-      expect(apiFetchMock).not.toHaveBeenCalled();
-    },
-  );
-
-  it("re-creates Sortable instances with sort re-enabled when leaving chronological ordering", async () => {
-    selectorState.sort = "newest";
-    const dragDrop = await import("./drag-drop.js");
-    dragDrop.initDnD();
-    expect(sortableInstances).toHaveLength(2);
-
-    selectorState.sort = null;
-    sortableCreateMock.mockClear();
-    dragDrop.initDnD();
-
-    expect(sortableInstances[0].destroy).toHaveBeenCalledTimes(1);
-    expect(sortableInstances[1].destroy).toHaveBeenCalledTimes(1);
-    const doingSortableCall = sortableCreateMock.mock.calls.find(([el]) => (el as HTMLElement).id === "list_doing");
-    if (!doingSortableCall) throw new Error("missing Sortable call for doing lane");
-    expect(doingSortableCall[1].sort).toBe(true);
-  });
-
-  it("still allows a cross-lane drop while chronological ordering is active, appending to the end of the target lane", async () => {
-    selectorState.sort = "oldest";
-    apiFetchMock.mockResolvedValue({});
-    const dragDrop = await import("./drag-drop.js");
-    dragDrop.initDnD();
-
-    const list = document.getElementById("list_doing");
-    if (!list) throw new Error("missing list_doing");
-    const from = document.createElement("div");
-    from.setAttribute("data-status", "backlog");
-    const item = document.createElement("button");
-    item.className = "card";
-    item.setAttribute("data-todo-local-id", "12");
-    list.appendChild(item);
-
-    const doingSortableCall = sortableCreateMock.mock.calls.find(([el]) => (el as HTMLElement).id === "list_doing");
-    if (!doingSortableCall) throw new Error("missing Sortable call for doing lane");
-
-    await doingSortableCall[1].onEnd({
-      item,
-      to: list,
-      from,
-      oldIndex: 0,
-      newIndex: 1,
-    });
-
-    expect(apiFetchMock).toHaveBeenCalledWith(
-      "/api/board/alpha/todos/12/move",
-      expect.objectContaining({
-        body: JSON.stringify({ toStatus: "doing", afterId: null, beforeId: null }),
-      }),
-    );
   });
 });

--- a/internal/httpapi/web/modules/features/drag-drop.ts
+++ b/internal/httpapi/web/modules/features/drag-drop.ts
@@ -14,6 +14,8 @@ export let dragInProgress = false;
 export let dragJustEnded = false;
 let moveInFlight = false;
 let activeSortables: any[] = [];
+let dragDropGeneration = 0;
+let dragJustEndedTimer: ReturnType<typeof setTimeout> | null = null;
 let boardColumns: Array<{ key: string; title: string; color?: string }> = columnsSpec();
 let mobileTabIntroGlowTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -66,6 +68,23 @@ function updateCardColorOptimistic(card: Element, targetKey: string, targetColor
 function setMobileDragging(active: boolean): void {
   const wrapper = document.querySelector(".mobile-board-wrapper");
   if (wrapper) wrapper.classList.toggle("dragging", active);
+}
+
+function clearPostDragClickSuppression(): void {
+  if (dragJustEndedTimer != null) {
+    clearTimeout(dragJustEndedTimer);
+    dragJustEndedTimer = null;
+  }
+  dragJustEnded = false;
+}
+
+function suppressPostDragClick(): void {
+  clearPostDragClickSuppression();
+  dragJustEnded = true;
+  dragJustEndedTimer = setTimeout(() => {
+    dragJustEndedTimer = null;
+    dragJustEnded = false;
+  }, 250);
 }
 
 function clearMobileTabIntroGlow(): void {
@@ -153,20 +172,29 @@ async function getFilteredLaneEndMove(status: string): Promise<{ afterId: number
 }
 
 export function initDnD(): void {
-  clearMobileTabIntroGlow();
+  const cancelledActiveDrag = dragInProgress;
+  const generation = ++dragDropGeneration;
+  const chronological = isChronologicalSortActive();
   // Destroy previous instances to prevent duplicate handlers
   for (const s of activeSortables) {
     try { s.destroy(); } catch (_) { /* element may already be removed */ }
   }
   activeSortables = [];
+  clearMobileTabIntroGlow();
+  setMobileDragging(false);
+  dragInProgress = false;
+  if (cancelledActiveDrag) suppressPostDragClick();
 
   const group = "board";
-  const chronological = isChronologicalSortActive();
+  const callbackIsCurrent = () =>
+    generation === dragDropGeneration
+    && chronological === isChronologicalSortActive();
 
   const handleEnd = async (evt: any) => {
+    if (!callbackIsCurrent()) return;
+
     dragInProgress = false;
-    dragJustEnded = true;
-    setTimeout(() => { dragJustEnded = false; }, 250);
+    suppressPostDragClick();
     clearMobileTabIntroGlow();
     setMobileDragging(false);
 
@@ -185,12 +213,15 @@ export function initDnD(): void {
       if (!toStatus) return;
 
       const fromStatus = evt.from?.getAttribute("data-status");
+      const sameLane = evt.from === evt.to || (fromStatus != null && fromStatus === toStatus);
+      if (chronological && sameLane) return;
+
       const isTabDrop = !!list.closest("#mobileTabDropZones");
       const filteredSubsetActive = hasActiveBoardSubsetFilter();
 
       let afterId: number | null = null;
       let beforeId: number | null = null;
-      if (isChronologicalSortActive()) {
+      if (chronological) {
         // Chronological DOM neighbors are not valid manual-rank anchors: a
         // cross-lane drop always appends to the end of the target lane's
         // rank order instead. Same-lane reordering is disabled via the
@@ -206,6 +237,8 @@ export function initDnD(): void {
           beforeId = await getHiddenLaneBoundaryLocalId(toStatus);
         }
       }
+
+      if (!callbackIsCurrent()) return;
 
       // No-op: dropped in the same position it started
       if (!isTabDrop && evt.from === evt.to && evt.oldIndex === evt.newIndex) return;
@@ -259,8 +292,10 @@ export function initDnD(): void {
       delay: 100,
       delayOnTouchOnly: true,
       onStart: () => {
+        if (!callbackIsCurrent()) return;
+
+        clearPostDragClickSuppression();
         dragInProgress = true;
-        dragJustEnded = false;
         setMobileDragging(true);
         startMobileTabIntroGlow();
         recordBoardInteraction();

--- a/internal/httpapi/web/modules/features/drag-drop.ts
+++ b/internal/httpapi/web/modules/features/drag-drop.ts
@@ -160,11 +160,8 @@ export function initDnD(): void {
   }
   activeSortables = [];
 
-  // Chronological DOM neighbors are not valid manual-rank anchors. Keep DnD
-  // completely disabled until the board returns to its default rank order.
-  if (isChronologicalSortActive()) return;
-
   const group = "board";
+  const chronological = isChronologicalSortActive();
 
   const handleEnd = async (evt: any) => {
     dragInProgress = false;
@@ -172,10 +169,6 @@ export function initDnD(): void {
     setTimeout(() => { dragJustEnded = false; }, 250);
     clearMobileTabIntroGlow();
     setMobileDragging(false);
-
-    // A sort can change while a stale Sortable callback is winding down.
-    // Never let that callback derive manual-rank anchors from chronological DOM.
-    if (isChronologicalSortActive()) return;
 
     recordBoardInteraction();
 
@@ -197,7 +190,12 @@ export function initDnD(): void {
 
       let afterId: number | null = null;
       let beforeId: number | null = null;
-      if (isTabDrop) {
+      if (isChronologicalSortActive()) {
+        // Chronological DOM neighbors are not valid manual-rank anchors: a
+        // cross-lane drop always appends to the end of the target lane's
+        // rank order instead. Same-lane reordering is disabled via the
+        // per-Sortable `sort: false` option set below.
+      } else if (isTabDrop) {
         if (filteredSubsetActive) {
           ({ afterId, beforeId } = await getFilteredLaneEndMove(toStatus));
         }
@@ -250,6 +248,7 @@ export function initDnD(): void {
     if (!el) return;
     activeSortables.push(Sortable.create(el, {
       group,
+      sort: !chronological,
       handle: ".card__drag-handle",
       animation: 150,
       ghostClass: "card--ghost",

--- a/internal/httpapi/web/modules/i18n/index.ts
+++ b/internal/httpapi/web/modules/i18n/index.ts
@@ -207,7 +207,7 @@ const BOOTSTRAP_EN_CATALOG: MessageCatalog = {
   "board.selection.multiple": "Edit {count} selected",
   "board.selection.single": "Edit 1 selected",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "Drag to reorder",
+  "board.todo.dragCard": "Drag card",
   "board.todo.moveFailed": "Failed to move todo",
   "board.todo.movedTo": "Todo moved to {lane}",
   "board.voice.boardChanged": "The board changed before commands opened",

--- a/internal/httpapi/web/modules/i18n/locales/ar.json
+++ b/internal/httpapi/web/modules/i18n/locales/ar.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "تحرير العناصر المحددة ({count})",
   "board.selection.single": "تحرير عنصر محدد واحد",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "اسحب لإعادة الترتيب",
+  "board.todo.dragCard": "اسحب البطاقة",
   "board.todo.moveFailed": "فشل نقل المهمة",
   "board.todo.movedTo": "نُقلت المهمة إلى {lane}",
   "board.voice.boardChanged": "تغيّرت اللوحة قبل فتح الأوامر",

--- a/internal/httpapi/web/modules/i18n/locales/bn.json
+++ b/internal/httpapi/web/modules/i18n/locales/bn.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "{count}টি নির্বাচিত সম্পাদনা",
   "board.selection.single": "১টি নির্বাচিত সম্পাদনা",
   "board.status.backlog": "ব্যাকলগ",
-  "board.todo.dragToReorder": "ক্রম বদলাতে টেনে আনুন",
+  "board.todo.dragCard": "কার্ড টেনে আনুন",
   "board.todo.moveFailed": "Todo সরাতে ব্যর্থ",
   "board.todo.movedTo": "Todo {lane}-এ সরানো",
   "board.voice.boardChanged": "কমান্ড খোলার আগে বোর্ড বদলেছে",

--- a/internal/httpapi/web/modules/i18n/locales/de.json
+++ b/internal/httpapi/web/modules/i18n/locales/de.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "{count} ausgewählte Todos bearbeiten",
   "board.selection.single": "1 ausgewähltes Todo bearbeiten",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "Zum Neuordnen ziehen",
+  "board.todo.dragCard": "Karte ziehen",
   "board.todo.moveFailed": "Todo konnte nicht verschoben werden",
   "board.todo.movedTo": "Todo nach {lane} verschoben",
   "board.voice.boardChanged": "Das Board hat sich geändert, bevor die Befehle geöffnet wurden",

--- a/internal/httpapi/web/modules/i18n/locales/en.json
+++ b/internal/httpapi/web/modules/i18n/locales/en.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "Edit {count} selected",
   "board.selection.single": "Edit 1 selected",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "Drag to reorder",
+  "board.todo.dragCard": "Drag card",
   "board.todo.moveFailed": "Failed to move todo",
   "board.todo.movedTo": "Todo moved to {lane}",
   "board.voice.boardChanged": "The board changed before commands opened",

--- a/internal/httpapi/web/modules/i18n/locales/es.json
+++ b/internal/httpapi/web/modules/i18n/locales/es.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "Editar {count} seleccionados",
   "board.selection.single": "Editar 1 elemento seleccionado",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "Arrastra para reordenar",
+  "board.todo.dragCard": "Arrastra la tarjeta",
   "board.todo.moveFailed": "Error al mover todo",
   "board.todo.movedTo": "Todo movido a {lane}",
   "board.voice.boardChanged": "El tablero cambió antes de que se abrieran los comandos",

--- a/internal/httpapi/web/modules/i18n/locales/fa.json
+++ b/internal/httpapi/web/modules/i18n/locales/fa.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "ویرایش {count} مورد انتخاب‌شده",
   "board.selection.single": "ویرایش ۱ مورد انتخاب‌شده",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "برای مرتب‌سازی بکشید",
+  "board.todo.dragCard": "کارت را بکشید",
   "board.todo.moveFailed": "جابه‌جایی Todo ناموفق بود",
   "board.todo.movedTo": "Todo به {lane} منتقل شد",
   "board.voice.boardChanged": "برد قبل از باز شدن دستورات تغییر کرد",

--- a/internal/httpapi/web/modules/i18n/locales/fr.json
+++ b/internal/httpapi/web/modules/i18n/locales/fr.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "Modifier {count} todos sélectionnés",
   "board.selection.single": "Modifier 1 todo sélectionné",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "Glisser pour réordonner",
+  "board.todo.dragCard": "Faire glisser la carte",
   "board.todo.moveFailed": "Impossible de déplacer le todo",
   "board.todo.movedTo": "Todo déplacé vers {lane}",
   "board.voice.boardChanged": "Le tableau a changé avant l'ouverture des commandes",

--- a/internal/httpapi/web/modules/i18n/locales/hi.json
+++ b/internal/httpapi/web/modules/i18n/locales/hi.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "{count} चयनित संपादित करें",
   "board.selection.single": "1 चयनित संपादित करें",
   "board.status.backlog": "बैकलॉग",
-  "board.todo.dragToReorder": "क्रम बदलने के लिए drag करें",
+  "board.todo.dragCard": "कार्ड खींचें",
   "board.todo.moveFailed": "Todo स्थानांतरित करना विफल",
   "board.todo.movedTo": "Todo {lane} में स्थानांतरित",
   "board.voice.boardChanged": "कमांड खुलने से पहले बोर्ड बदल गया",

--- a/internal/httpapi/web/modules/i18n/locales/id.json
+++ b/internal/httpapi/web/modules/i18n/locales/id.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "Edit {count} yang dipilih",
   "board.selection.single": "Edit 1 yang dipilih",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "Seret untuk mengurutkan ulang",
+  "board.todo.dragCard": "Seret kartu",
   "board.todo.moveFailed": "Gagal memindahkan todo",
   "board.todo.movedTo": "Todo dipindahkan ke {lane}",
   "board.voice.boardChanged": "Papan berubah sebelum perintah dibuka",

--- a/internal/httpapi/web/modules/i18n/locales/it.json
+++ b/internal/httpapi/web/modules/i18n/locales/it.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "Modifica {count} selezionati",
   "board.selection.single": "Modifica 1 elemento selezionato",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "Trascina per riordinare",
+  "board.todo.dragCard": "Trascina la scheda",
   "board.todo.moveFailed": "Impossibile spostare il Todo",
   "board.todo.movedTo": "Todo spostato in {lane}",
   "board.voice.boardChanged": "La board è cambiata prima dell'apertura dei comandi",

--- a/internal/httpapi/web/modules/i18n/locales/ja.json
+++ b/internal/httpapi/web/modules/i18n/locales/ja.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "選択中 {count} 件を編集",
   "board.selection.single": "選択中 1 件を編集",
   "board.status.backlog": "バックログ",
-  "board.todo.dragToReorder": "ドラッグして並べ替え",
+  "board.todo.dragCard": "カードをドラッグ",
   "board.todo.moveFailed": "Todo の移動に失敗しました",
   "board.todo.movedTo": "Todo を {lane} に移動しました",
   "board.voice.boardChanged": "コマンドを開く前にボードが変更されました",

--- a/internal/httpapi/web/modules/i18n/locales/ko.json
+++ b/internal/httpapi/web/modules/i18n/locales/ko.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "선택한 {count}개 편집",
   "board.selection.single": "선택한 Todo 1개 편집",
   "board.status.backlog": "백로그",
-  "board.todo.dragToReorder": "드래그하여 순서 변경",
+  "board.todo.dragCard": "카드 드래그",
   "board.todo.moveFailed": "Todo 이동에 실패했습니다",
   "board.todo.movedTo": "Todo가 {lane}(으)로 이동되었습니다",
   "board.voice.boardChanged": "명령을 열기 전에 보드가 변경되었습니다",

--- a/internal/httpapi/web/modules/i18n/locales/ms.json
+++ b/internal/httpapi/web/modules/i18n/locales/ms.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "Edit {count} yang dipilih",
   "board.selection.single": "Edit 1 yang dipilih",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "Seret untuk mengurutkan ulang",
+  "board.todo.dragCard": "Seret kad",
   "board.todo.moveFailed": "Gagal memindahkan Todo",
   "board.todo.movedTo": "Todo dipindahkan ke {lane}",
   "board.voice.boardChanged": "Papan berubah sebelum perintah dibuka",

--- a/internal/httpapi/web/modules/i18n/locales/pl.json
+++ b/internal/httpapi/web/modules/i18n/locales/pl.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "Edytuj {count} zaznaczonych",
   "board.selection.single": "Edytuj zaznaczony element",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "Przeciągnij, aby zmienić kolejność",
+  "board.todo.dragCard": "Przeciągnij kartę",
   "board.todo.moveFailed": "Nie udało się przenieść Todo",
   "board.todo.movedTo": "Todo przeniesiono do {lane}",
   "board.voice.boardChanged": "Tablica zmieniła się, zanim otwarto polecenia",

--- a/internal/httpapi/web/modules/i18n/locales/pseudo.json
+++ b/internal/httpapi/web/modules/i18n/locales/pseudo.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "[!! Edit {count} selected !!]",
   "board.selection.single": "[!! Edit 1 selected !!]",
   "board.status.backlog": "[!! Backlog !!]",
-  "board.todo.dragToReorder": "[!! Drag to reorder !!]",
+  "board.todo.dragCard": "[!! Drag card !!]",
   "board.todo.moveFailed": "[!! Failed to move todo !!]",
   "board.todo.movedTo": "[!! Todo moved to {lane} !!]",
   "board.voice.boardChanged": "[!! The board changed before commands opened !!]",

--- a/internal/httpapi/web/modules/i18n/locales/pt.json
+++ b/internal/httpapi/web/modules/i18n/locales/pt.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "Editar {count} todos selecionados",
   "board.selection.single": "Editar 1 todo selecionado",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "Arraste para reordenar",
+  "board.todo.dragCard": "Arraste o cartão",
   "board.todo.moveFailed": "Não foi possível mover o todo",
   "board.todo.movedTo": "Todo movido para {lane}",
   "board.voice.boardChanged": "O quadro mudou antes de abrir os comandos",

--- a/internal/httpapi/web/modules/i18n/locales/ru.json
+++ b/internal/httpapi/web/modules/i18n/locales/ru.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "Редактировать выбранные ({count})",
   "board.selection.single": "Редактировать 1 выбранную задачу",
   "board.status.backlog": "Бэклог",
-  "board.todo.dragToReorder": "Перетащите для изменения порядка",
+  "board.todo.dragCard": "Перетащите карточку",
   "board.todo.moveFailed": "Не удалось переместить задачу",
   "board.todo.movedTo": "Задача перемещена в {lane}",
   "board.voice.boardChanged": "Доска изменилась до открытия команд",

--- a/internal/httpapi/web/modules/i18n/locales/sw.json
+++ b/internal/httpapi/web/modules/i18n/locales/sw.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "Hariri {count} zilizochaguliwa",
   "board.selection.single": "Hariri 1 iliyochaguliwa",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "Buruta ili kupanga upya",
+  "board.todo.dragCard": "Buruta kadi",
   "board.todo.moveFailed": "Imeshindwa kuhamisha Todo",
   "board.todo.movedTo": "Todo imehamishwa kwenda {lane}",
   "board.voice.boardChanged": "Bodi ilibadilika kabla ya commands kufunguliwa",

--- a/internal/httpapi/web/modules/i18n/locales/th.json
+++ b/internal/httpapi/web/modules/i18n/locales/th.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "แก้ไข {count} รายการที่เลือก",
   "board.selection.single": "แก้ไข Todo ที่เลือก 1 รายการ",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "ลากเพื่อจัดลำดับใหม่",
+  "board.todo.dragCard": "ลากการ์ด",
   "board.todo.moveFailed": "ย้าย Todo ไม่สำเร็จ",
   "board.todo.movedTo": "ย้าย Todo ไป {lane} แล้ว",
   "board.voice.boardChanged": "บอร์ดเปลี่ยนก่อนเปิดคำสั่ง",

--- a/internal/httpapi/web/modules/i18n/locales/tr.json
+++ b/internal/httpapi/web/modules/i18n/locales/tr.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "Seçilen {count} todo'yu düzenle",
   "board.selection.single": "Seçilen 1 todo'yu düzenle",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "Yeniden sıralamak için sürükleyin",
+  "board.todo.dragCard": "Kartı sürükleyin",
   "board.todo.moveFailed": "Todo taşınamadı",
   "board.todo.movedTo": "Todo {lane} sütununa taşındı",
   "board.voice.boardChanged": "Komutlar açılmadan önce pano değişti",

--- a/internal/httpapi/web/modules/i18n/locales/uk.json
+++ b/internal/httpapi/web/modules/i18n/locales/uk.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "Редагувати {count} вибраних",
   "board.selection.single": "Редагувати вибране",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "Перетягни, щоб змінити порядок",
+  "board.todo.dragCard": "Перетягніть картку",
   "board.todo.moveFailed": "Не вдалося перемістити Todo",
   "board.todo.movedTo": "Todo переміщено в {lane}",
   "board.voice.boardChanged": "Дошка змінилася до відкриття команд",

--- a/internal/httpapi/web/modules/i18n/locales/ur.json
+++ b/internal/httpapi/web/modules/i18n/locales/ur.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "{count} منتخب میں ترمیم",
   "board.selection.single": "منتخب Todo 1 میں ترمیم",
   "board.status.backlog": "بیک لاگ",
-  "board.todo.dragToReorder": "ترتیب بدلنے کے لیے کھینچیں",
+  "board.todo.dragCard": "کارڈ کھینچیں",
   "board.todo.moveFailed": "Todo منتقل ناکام",
   "board.todo.movedTo": "Todo {lane} میں منتقل ہوا",
   "board.voice.boardChanged": "کمانڈز کھلنے سے پہلے بورڈ بدل گیا",

--- a/internal/httpapi/web/modules/i18n/locales/vi.json
+++ b/internal/httpapi/web/modules/i18n/locales/vi.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "Sửa {count} đã chọn",
   "board.selection.single": "Sửa 1 đã chọn",
   "board.status.backlog": "Backlog",
-  "board.todo.dragToReorder": "Kéo để sắp xếp lại",
+  "board.todo.dragCard": "Kéo thẻ",
   "board.todo.moveFailed": "Không di chuyển được todo",
   "board.todo.movedTo": "Đã chuyển todo sang {lane}",
   "board.voice.boardChanged": "Bảng đã thay đổi trước khi mở lệnh",

--- a/internal/httpapi/web/modules/i18n/locales/zh.json
+++ b/internal/httpapi/web/modules/i18n/locales/zh.json
@@ -199,7 +199,7 @@
   "board.selection.multiple": "编辑已选 {count} 项",
   "board.selection.single": "编辑已选 1 项",
   "board.status.backlog": "待办池",
-  "board.todo.dragToReorder": "拖动以调整顺序",
+  "board.todo.dragCard": "拖动卡片",
   "board.todo.moveFailed": "移动 Todo 失败",
   "board.todo.movedTo": "Todo 已移至 {lane}",
   "board.voice.boardChanged": "打开命令前看板已发生变化",

--- a/internal/httpapi/web/modules/views/board-i18n.test.ts
+++ b/internal/httpapi/web/modules/views/board-i18n.test.ts
@@ -185,7 +185,7 @@ const enCatalog = {
   "board.noResults": "No todos found matching \"{search}\"",
   "board.search.placeholder.desktop": "Search todos...",
   "board.search.placeholder.mobile": "Search",
-  "board.todo.dragToReorder": "Drag to reorder",
+  "board.todo.dragCard": "Drag card",
 };
 
 const pseudoCatalog = Object.fromEntries(
@@ -221,7 +221,7 @@ async function flushPromises(count = 6): Promise<void> {
 
 async function renderPrefetchedBoard(
   mod: typeof import("./board.js"),
-  opts: { tag?: string; search?: string } = {},
+  opts: { tag?: string; search?: string; sort?: string | null } = {},
 ): Promise<void> {
   await mod.renderBoard(
     "alpha",
@@ -229,7 +229,7 @@ async function renderPrefetchedBoard(
     opts.search ?? "needle",
     null,
     null,
-    null,
+    opts.sort ?? null,
     null,
     null,
     { prefetchedBoard: board() },
@@ -273,9 +273,45 @@ describe("board i18n locale switching", () => {
     customBootstrapBackLabel.value = null;
     const i18n = await import("../i18n/index.js");
     i18n.resetI18nForTests();
+    const mutations = await import("../state/mutations.js");
+    mutations.setUser(null);
+    mutations.setAuthStatusAvailable(false);
     document.body.innerHTML = "";
     localStorage.clear();
     vi.restoreAllMocks();
+  });
+
+  it("does not initialize usable card dragging for viewers in chronological mode", async () => {
+    const i18n = await import("../i18n/index.js");
+    await i18n.initI18n({
+      locale: "en",
+      loadLocale: vi.fn(async () => enCatalog),
+    });
+    const membersCache = await import("../members-cache.js");
+    const mutations = await import("../state/mutations.js");
+    mutations.setAuthStatusAvailable(true);
+    mutations.setUser({ id: 1, name: "Alex", email: "alex@example.com" } as any);
+    vi.mocked(membersCache.fetchProjectMembers).mockResolvedValueOnce([
+      { userId: 1, name: "Alex", email: "alex@example.com", role: "viewer" },
+    ] as any);
+    const viewerBoard = board();
+    viewerBoard.columns.backlog = [{
+      id: 7,
+      localId: 12,
+      title: "Read only",
+      body: "",
+      status: "BACKLOG",
+      tags: [],
+    }] as any;
+    const mod = await import("./board.js");
+
+    await mod.renderBoard("alpha", "", "needle", null, null, "newest", null, null, {
+      prefetchedBoard: viewerBoard,
+    });
+    await flushPromises();
+
+    expect(document.querySelector(".card__drag-handle")).not.toBeNull();
+    expect(initDnDMock).not.toHaveBeenCalled();
   });
 
   it("updates the default back label after locale change without refetching", async () => {

--- a/internal/httpapi/web/modules/views/board-rendering.test.ts
+++ b/internal/httpapi/web/modules/views/board-rendering.test.ts
@@ -118,6 +118,9 @@ describe('board topbar rendering', () => {
       tags: [],
     };
 
-    expect(renderTodoCard(todo)).toContain('card__drag-handle');
+    const html = renderTodoCard(todo);
+    expect(html).toContain('card__drag-handle');
+    expect(html).toContain('aria-label="Drag card"');
+    expect(html).toContain('data-i18n-aria-label="board.todo.dragCard"');
   });
 });

--- a/internal/httpapi/web/modules/views/board-rendering.test.ts
+++ b/internal/httpapi/web/modules/views/board-rendering.test.ts
@@ -108,7 +108,7 @@ describe('board topbar rendering', () => {
     expect(html).not.toContain('todo-mermaid');
   });
 
-  it('renders drag handles only when manual reordering is enabled', () => {
+  it('always renders a drag handle, even under chronological sort where only cross-lane drag is allowed', () => {
     const todo = {
       id: 7,
       localId: 12,
@@ -119,7 +119,5 @@ describe('board topbar rendering', () => {
     };
 
     expect(renderTodoCard(todo)).toContain('card__drag-handle');
-    expect(renderTodoCard(todo, undefined, undefined, { reorderEnabled: true })).toContain('card__drag-handle');
-    expect(renderTodoCard(todo, undefined, undefined, { reorderEnabled: false })).not.toContain('card__drag-handle');
   });
 });

--- a/internal/httpapi/web/modules/views/board-rendering.ts
+++ b/internal/httpapi/web/modules/views/board-rendering.ts
@@ -197,7 +197,7 @@ export function renderTodoCard(
   const footerContent = pointsHTML + avatarHTML;
   const selectedClass = opts?.selectedIds?.has(todo.id) ? " card--selected" : "";
   const dragHandleHTML = `
-      <div class="card__drag-handle" aria-label="${escapeHTML(t("board.todo.dragToReorder"))}" data-i18n-aria-label="board.todo.dragToReorder">
+      <div class="card__drag-handle" aria-label="${escapeHTML(t("board.todo.dragCard"))}" data-i18n-aria-label="board.todo.dragCard">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
           <circle cx="4" cy="3" r="1.5"/>
           <circle cx="4" cy="8" r="1.5"/>

--- a/internal/httpapi/web/modules/views/board-rendering.ts
+++ b/internal/httpapi/web/modules/views/board-rendering.ts
@@ -34,7 +34,6 @@ export type RenderTodoCardOpts = {
   tagColors?: Record<string, string>;
   showPointsMode?: boolean;
   selectedIds?: Set<number>;
-  reorderEnabled?: boolean;
 };
 
 type BuildTopbarHtmlArgs = {
@@ -197,9 +196,7 @@ export function renderTodoCard(
     : "";
   const footerContent = pointsHTML + avatarHTML;
   const selectedClass = opts?.selectedIds?.has(todo.id) ? " card--selected" : "";
-  const dragHandleHTML = opts?.reorderEnabled === false
-    ? ""
-    : `
+  const dragHandleHTML = `
       <div class="card__drag-handle" aria-label="${escapeHTML(t("board.todo.dragToReorder"))}" data-i18n-aria-label="board.todo.dragToReorder">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
           <circle cx="4" cy="3" r="1.5"/>

--- a/internal/httpapi/web/modules/views/board.ts
+++ b/internal/httpapi/web/modules/views/board.ts
@@ -543,7 +543,6 @@ async function handleLoadMore(status: TodoStatus): Promise<void> {
         tagColors,
         showPointsMode,
         selectedIds: getSelectedTodoIds(),
-        reorderEnabled: sort !== "newest" && sort !== "oldest",
       };
       items.forEach((t) => {
         const card = document.createElement("div");
@@ -860,7 +859,6 @@ function updateBoardContent(board: Board, tag: string, search: string, sprintId:
       tagColors,
       showPointsMode,
       selectedIds: getSelectedTodoIds(),
-      reorderEnabled: sort !== "newest" && sort !== "oldest",
     };
     boardEl.innerHTML = buildBoardColumnsHtml({
       boardCols,
@@ -989,7 +987,6 @@ function renderBoardFromData(board: Board, projectId: number, tag: string, searc
     tagColors,
     showPointsMode,
     selectedIds: getSelectedTodoIds(),
-    reorderEnabled: sort !== "newest" && sort !== "oldest",
   };
 
   app.innerHTML = `

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.28.0"
+const Version = "3.28.1"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.28.1"
+const Version = "3.28.0"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
## Summary
- 3.28.0's chronological-sort DnD guard went too far: it hid the card drag handle entirely and skipped creating any Sortable instances when `sort=newest`/`sort=oldest` was active, so cards couldn't be dragged to a *different* lane, not just reordered within one.
- DOM neighbors under chronological order are still invalid manual-rank anchors, so same-lane reordering stays disabled (`Sortable`'s `sort: false` on each lane instance). The drag handle is now always rendered, and cross-lane drops append to the end of the target lane's rank order (`afterId`/`beforeId` both omitted) instead of trying to anchor off chronological neighbors.
- Bumped to 3.28.1 with a changelog entry.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run modules/features/drag-drop.test.ts modules/views/board-rendering.test.ts` (updated to cover the new sort:false + always-rendered-handle behavior; both pass)
- [x] `go build ./...`