### PR TITLE
smtp: use specific per-reason copy for activity update emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.28.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags) - see those releases.
 
+## [3.28.2] - 2026-07-27
+
+### Changed
+
+- **Activity email copy is reason-specific** - Opt-in board activity emails no longer use a generic "activity update" subject/body. Each mapped `board.refresh_needed` reason gets its own subject phrase (e.g. `card moved`, `sprint closed`) and body copy that names the actor when known (`Alex moved a card in …`), with a passive fallback when no display name is available. Actor names prefer the membership list join and fall back to `GetUser` for signed-in temporary-board link visitors who are not project members. Unauthenticated anonymous visitors still produce no activity email (`actorUserId` unset).
+
 ## [3.28.1] - 2026-07-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.28.1-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.28.2-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/internal/httpapi/email_notify.go
+++ b/internal/httpapi/email_notify.go
@@ -65,31 +65,38 @@ const (
 	emailCategoryAddedToProject  emailCategory = "addedToProject"
 )
 
-// refreshReasonCategory maps board.refresh_needed's `reason` string to a
-// notification category. Reasons absent from this map (e.g. purely-cosmetic
-// or wall-note reasons) never generate email.
-var refreshReasonCategory = map[string]emailCategory{
-	"todo_created":       emailCategoryCardActivity,
-	"todo_updated":       emailCategoryCardActivity,
-	"todo_moved":         emailCategoryCardActivity,
-	"todo_deleted":       emailCategoryCardActivity,
-	"todo_links_updated": emailCategoryCardActivity,
+// reasonInfo maps board.refresh_needed's `reason` string to a notification
+// category plus the copy used to describe it. Reasons absent from this map
+// (e.g. purely-cosmetic or wall-note reasons) never generate email.
+type reasonInfo struct {
+	category emailCategory
+	subject  string // short phrase for the subject line, e.g. "card moved"
+	actorLed string // phrase following the actor's name, e.g. "moved a card"
+	passive  string // fallback phrase when no actor name is available, e.g. "A card was moved"
+}
 
-	"sprint_created":   emailCategorySprintActivity,
-	"sprint_updated":   emailCategorySprintActivity,
-	"sprint_deleted":   emailCategorySprintActivity,
-	"sprint_activated": emailCategorySprintActivity,
-	"sprint_closed":    emailCategorySprintActivity,
+var refreshReasonInfo = map[string]reasonInfo{
+	"todo_created":       {emailCategoryCardActivity, "card created", "created a card", "A card was created"},
+	"todo_updated":       {emailCategoryCardActivity, "card updated", "updated a card", "A card was updated"},
+	"todo_moved":         {emailCategoryCardActivity, "card moved", "moved a card", "A card was moved"},
+	"todo_deleted":       {emailCategoryCardActivity, "card deleted", "deleted a card", "A card was deleted"},
+	"todo_links_updated": {emailCategoryCardActivity, "card links updated", "updated a card's links", "A card's links were updated"},
 
-	"project_updated":          emailCategoryProjectActivity,
-	"project_deleted":          emailCategoryProjectActivity,
-	"project_settings_updated": emailCategoryProjectActivity,
-	"board_claimed":            emailCategoryProjectActivity,
-	"workflow_column_added":    emailCategoryProjectActivity,
-	"workflow_column_updated":  emailCategoryProjectActivity,
-	"workflow_column_deleted":  emailCategoryProjectActivity,
-	"tag_color_updated":        emailCategoryProjectActivity,
-	"tag_deleted":              emailCategoryProjectActivity,
+	"sprint_created":   {emailCategorySprintActivity, "sprint created", "created a sprint", "A sprint was created"},
+	"sprint_updated":   {emailCategorySprintActivity, "sprint updated", "updated a sprint", "A sprint was updated"},
+	"sprint_deleted":   {emailCategorySprintActivity, "sprint deleted", "deleted a sprint", "A sprint was deleted"},
+	"sprint_activated": {emailCategorySprintActivity, "sprint activated", "activated a sprint", "A sprint was activated"},
+	"sprint_closed":    {emailCategorySprintActivity, "sprint closed", "closed a sprint", "A sprint was closed"},
+
+	"project_updated":          {emailCategoryProjectActivity, "project updated", "updated the project", "The project was updated"},
+	"project_deleted":          {emailCategoryProjectActivity, "project deleted", "deleted the project", "The project was deleted"},
+	"project_settings_updated": {emailCategoryProjectActivity, "project settings updated", "updated the project settings", "The project settings were updated"},
+	"board_claimed":            {emailCategoryProjectActivity, "board claimed", "claimed the board", "The board was claimed"},
+	"workflow_column_added":    {emailCategoryProjectActivity, "workflow column added", "added a workflow column", "A workflow column was added"},
+	"workflow_column_updated":  {emailCategoryProjectActivity, "workflow column updated", "updated a workflow column", "A workflow column was updated"},
+	"workflow_column_deleted":  {emailCategoryProjectActivity, "workflow column deleted", "deleted a workflow column", "A workflow column was deleted"},
+	"tag_color_updated":        {emailCategoryProjectActivity, "tag color updated", "updated a tag color", "A tag color was updated"},
+	"tag_deleted":              {emailCategoryProjectActivity, "tag deleted", "deleted a tag", "A tag was deleted"},
 }
 
 func (n *emailNotifier) OnEvent(_ context.Context, e eventbus.Event) {
@@ -177,10 +184,11 @@ func (n *emailNotifier) handleRefreshNeeded(ctx context.Context, e eventbus.Even
 }
 
 func (n *emailNotifier) handleActivity(ctx context.Context, projectID int64, reason string, actorUserID int64, excluded map[int64]bool) {
-	category, ok := refreshReasonCategory[reason]
+	info, ok := refreshReasonInfo[reason]
 	if !ok {
 		return
 	}
+	category := info.category
 	if actorUserID == 0 {
 		return // no known actor to authorize the ListProjectMembers lookup as
 	}
@@ -194,7 +202,16 @@ func (n *emailNotifier) handleActivity(ctx context.Context, projectID int64, rea
 		return
 	}
 
-	subject := fmt.Sprintf("%s: activity update", proj.Name)
+	action := info.passive
+	if actor, err := n.store.GetUser(ctx, actorUserID); err == nil && actor.Name != "" {
+		action = actor.Name + " " + info.actorLed
+	}
+
+	subject := fmt.Sprintf("%s: %s", proj.Name, info.subject)
+	body := fmt.Sprintf(
+		"%s in %s.\n\nView the board:\n%s\n",
+		action, proj.Name, n.projectURL(proj.Slug),
+	)
 	for _, m := range members {
 		if m.UserID == actorUserID || excluded[m.UserID] {
 			continue // skip the person who made the change
@@ -203,10 +220,6 @@ func (n *emailNotifier) handleActivity(ctx context.Context, projectID int64, rea
 		if err != nil || !pref.Enabled || !categoryEnabled(pref, category) || m.Email == "" {
 			continue
 		}
-		body := fmt.Sprintf(
-			"There was activity in %s.\n\nView the board:\n%s\n",
-			proj.Name, n.projectURL(proj.Slug),
-		)
 		n.enqueueActivity(projectID, category, m.UserID, mailDelivery{
 			To: m.Email, Subject: subject, Body: body,
 			LogRef: fmt.Sprintf("email-notify category=%s user=%d", category, m.UserID),

--- a/internal/httpapi/email_notify.go
+++ b/internal/httpapi/email_notify.go
@@ -202,9 +202,26 @@ func (n *emailNotifier) handleActivity(ctx context.Context, projectID int64, rea
 		return
 	}
 
+	// Prefer the actor name already joined into ListProjectMembers. Fall back to
+	// GetUser only when the actor is absent from members (Temporary Boards bypass
+	// role checks, so a signed-in link visitor can act without a membership row).
 	action := info.passive
-	if actor, err := n.store.GetUser(ctx, actorUserID); err == nil && actor.Name != "" {
-		action = actor.Name + " " + info.actorLed
+	actorName := ""
+	actorInMembers := false
+	for _, m := range members {
+		if m.UserID == actorUserID {
+			actorInMembers = true
+			actorName = m.Name
+			break
+		}
+	}
+	if !actorInMembers {
+		if actor, err := n.store.GetUser(ctx, actorUserID); err == nil {
+			actorName = actor.Name
+		}
+	}
+	if actorName != "" {
+		action = actorName + " " + info.actorLed
 	}
 
 	subject := fmt.Sprintf("%s: %s", proj.Name, info.subject)

--- a/internal/httpapi/email_notify_corrections_test.go
+++ b/internal/httpapi/email_notify_corrections_test.go
@@ -23,6 +23,7 @@ type emailNotifyFakeStore struct {
 	prefErrs     map[int64]error
 	projectCalls int
 	memberCalls  int
+	userCalls    int
 }
 
 func (s *emailNotifyFakeStore) GetEmailNotifyPref(_ context.Context, userID int64) (store.EmailNotifyPref, error) {
@@ -47,6 +48,7 @@ func (s *emailNotifyFakeStore) GetProject(_ context.Context, _ int64) (store.Pro
 func (s *emailNotifyFakeStore) GetUser(_ context.Context, userID int64) (store.User, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.userCalls++
 	u, ok := s.users[userID]
 	if !ok {
 		return store.User{}, store.ErrNotFound
@@ -273,5 +275,82 @@ func TestEmailNotifier_ProjectDeletionUsesSnapshotOnly(t *testing.T) {
 	}
 	if st.projectCalls != 0 || st.memberCalls != 0 {
 		t.Fatalf("post-delete notifier queried deleted project state: project=%d members=%d", st.projectCalls, st.memberCalls)
+	}
+}
+
+func TestEmailNotifier_ActivityActorNameFromMembersSkipsGetUser(t *testing.T) {
+	st := newEmailNotifyFake()
+	st.members[0].Name = "Alex"
+	st.users[1] = store.User{ID: 1, Email: "actor@example.com", Name: "ShouldNotBeUsed"}
+	q := newMailQueue(discardLogger())
+	n := newEmailNotifier(st, q, "https://scrumboy.example.com", true, discardLogger())
+
+	n.handle(context.Background(), refreshEvent(t, 1, "todo_moved"))
+
+	got := q.Drain()
+	if len(got) != 2 {
+		t.Fatalf("expected emails to non-actor members, got %+v", got)
+	}
+	for _, m := range got {
+		if !strings.Contains(m.Body, "Alex moved a card in Roadmap.") {
+			t.Fatalf("expected member-sourced actor name, got %q", m.Body)
+		}
+	}
+	if st.userCalls != 0 {
+		t.Fatalf("expected no GetUser when actor is in members, got %d calls", st.userCalls)
+	}
+}
+
+func TestEmailNotifier_ActivityActorNameFallsBackToGetUser(t *testing.T) {
+	st := newEmailNotifyFake()
+	// Actor can authorize ListProjectMembers on Temporary Boards without a membership row.
+	st.members = []store.ProjectMember{
+		{UserID: 2, Email: "assignee@example.com", Name: "Assignee"},
+		{UserID: 3, Email: "member@example.com", Name: "Member"},
+	}
+	st.users[1] = store.User{ID: 1, Email: "visitor@example.com", Name: "Visitor"}
+	q := newMailQueue(discardLogger())
+	n := newEmailNotifier(st, q, "https://scrumboy.example.com", true, discardLogger())
+
+	n.handle(context.Background(), refreshEvent(t, 1, "todo_moved"))
+
+	got := q.Drain()
+	if len(got) != 2 {
+		t.Fatalf("expected emails to members, got %+v", got)
+	}
+	for _, m := range got {
+		if !strings.Contains(m.Body, "Visitor moved a card in Roadmap.") {
+			t.Fatalf("expected GetUser-sourced actor name, got %q", m.Body)
+		}
+	}
+	if st.userCalls != 1 {
+		t.Fatalf("expected one GetUser fallback for non-member actor, got %d calls", st.userCalls)
+	}
+}
+
+func TestEmailNotifier_ActivityPassiveCopyWhenActorNameUnavailable(t *testing.T) {
+	st := newEmailNotifyFake()
+	// Valid actor ID and membership, but no usable display name.
+	st.members[0].Name = ""
+	st.users[1] = store.User{ID: 1, Email: "actor@example.com", Name: ""}
+	q := newMailQueue(discardLogger())
+	n := newEmailNotifier(st, q, "https://scrumboy.example.com", true, discardLogger())
+
+	n.handle(context.Background(), refreshEvent(t, 1, "sprint_closed"))
+
+	got := q.Drain()
+	if len(got) != 2 {
+		t.Fatalf("expected emails to still send without an actor name, got %+v", got)
+	}
+	for _, m := range got {
+		if m.Subject != "Roadmap: sprint closed" {
+			t.Fatalf("unexpected subject: %q", m.Subject)
+		}
+		if !strings.Contains(m.Body, "A sprint was closed in Roadmap.") {
+			t.Fatalf("expected passive body, got %q", m.Body)
+		}
+		if strings.Contains(m.Body, "closed a sprint") {
+			t.Fatalf("expected no actor-led phrasing, got %q", m.Body)
+		}
 	}
 }

--- a/internal/httpapi/email_notify_corrections_test.go
+++ b/internal/httpapi/email_notify_corrections_test.go
@@ -129,7 +129,7 @@ func TestEmailNotifier_AssignmentAndActivityAreIndependent(t *testing.T) {
 	if !strings.Contains(byRecipient["assignee@example.com"].Subject, "Assigned to you") {
 		t.Fatalf("expected assignment category for assignee, got %+v", got)
 	}
-	if !strings.Contains(byRecipient["member@example.com"].Subject, "activity update") {
+	if !strings.Contains(byRecipient["member@example.com"].Subject, "card created") {
 		t.Fatalf("expected card activity for other member, got %+v", got)
 	}
 	if _, ok := byRecipient["actor@example.com"]; ok {
@@ -146,7 +146,7 @@ func TestEmailNotifier_UnassignmentStillProcessesActivity(t *testing.T) {
 	n.handle(context.Background(), assignedEvent(t, 1, nil, "todo_updated"))
 
 	got := q.Drain()
-	if len(got) != 1 || got[0].To != "assignee@example.com" || !strings.Contains(got[0].Subject, "activity update") {
+	if len(got) != 1 || got[0].To != "assignee@example.com" || !strings.Contains(got[0].Subject, "card updated") {
 		t.Fatalf("expected one card-activity delivery after unassignment, got %+v", got)
 	}
 }

--- a/internal/httpapi/email_notify_endtoend_test.go
+++ b/internal/httpapi/email_notify_endtoend_test.go
@@ -130,7 +130,7 @@ func TestEmailNotify_EndToEnd_TodoAssignedOverRealSMTP(t *testing.T) {
 	if !strings.Contains(first["assignee-e2e@example.com"], "Assigned to you") {
 		t.Fatalf("expected assignment delivery to assignee, got %+v", msgs)
 	}
-	if !strings.Contains(first["member-e2e@example.com"], "activity update") {
+	if !strings.Contains(first["member-e2e@example.com"], "card created") {
 		t.Fatalf("expected card activity delivery to other member, got %+v", msgs)
 	}
 	localID := int64(todo["localId"].(float64))
@@ -149,7 +149,7 @@ func TestEmailNotify_EndToEnd_TodoAssignedOverRealSMTP(t *testing.T) {
 		if strings.Contains(message.Subject, "Assigned to you") {
 			assignmentByRecipient[message.To]++
 		}
-		if strings.Contains(message.Subject, "activity update") {
+		if strings.Contains(message.Subject, "card created") || strings.Contains(message.Subject, "card updated") {
 			activityByRecipient[message.To]++
 		}
 		if message.To == "owner-e2e@example.com" {

--- a/internal/httpapi/email_notify_test.go
+++ b/internal/httpapi/email_notify_test.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -269,6 +270,54 @@ func TestEmailNotifier_RefreshNeeded_DebouncesBurstsPerProjectCategory(t *testin
 	got := drainAfterAsync(mq)
 	if len(got) != 1 {
 		t.Fatalf("expected exactly 1 email from a debounced burst, got %d: %+v", len(got), got)
+	}
+}
+
+func TestEmailNotifier_RefreshNeeded_CopyReflectsReasonAndActor(t *testing.T) {
+	st := newTestStore(t)
+	ctx := context.Background()
+	n, mq := newTestEmailNotifier(t, st, true)
+
+	owner, err := st.BootstrapUser(ctx, "owner-copy@example.com", "pass1234A!", "Alex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := st.CreateUser(ctx, "member-copy@example.com", "pass1234A!", "Member")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerCtx := store.WithUserID(ctx, owner.ID)
+	proj, err := st.CreateProject(ownerCtx, "Copy Project")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddProjectMember(ownerCtx, owner.ID, proj.ID, member.ID, store.RoleViewer); err != nil {
+		t.Fatal(err)
+	}
+
+	pref := store.DefaultEmailNotifyPref()
+	pref.Enabled = true
+	pref.SprintActivity = true
+	prefJSON, _ := json.Marshal(pref)
+	if err := st.SetUserPreference(ctx, member.ID, "emailNotifications", string(prefJSON)); err != nil {
+		t.Fatal(err)
+	}
+
+	payload, _ := json.Marshal(struct {
+		Reason      string `json:"reason"`
+		ActorUserID int64  `json:"actorUserId"`
+	}{Reason: "sprint_closed", ActorUserID: owner.ID})
+	n.OnEvent(ctx, eventbus.Event{Type: "board.refresh_needed", ProjectID: proj.ID, Payload: payload})
+
+	got := drainAfterAsync(mq)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 email, got %+v", got)
+	}
+	if got[0].Subject != "Copy Project: sprint closed" {
+		t.Fatalf("unexpected subject: %q", got[0].Subject)
+	}
+	if !strings.Contains(got[0].Body, "Alex closed a sprint in Copy Project.") {
+		t.Fatalf("expected actor-led body, got %q", got[0].Body)
 	}
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.28.1"
+const Version = "3.28.2"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
## Summary
- `board.refresh_needed` activity emails all shared one generic "activity update" subject/body regardless of what actually happened (card moved, sprint closed, etc.), even though the handler already has `reason`, `actorUserId`, and the project name in hand.
- Replaces `refreshReasonCategory` with `refreshReasonInfo`, which pairs each reason with its existing category plus subject/body copy (e.g. "card moved" / "A card was moved").
- When the actor's user record is available, the body leads with their name ("Alex moved a card in Acme.") instead of the passive fallback ("A card was moved in Acme.") — same specificity as the existing assignment email, no new plumbing (`GetUser` was already on `emailNotifyStore`).
- Stays with the existing plain-text `fmt.Sprintf` style; no templates, no digest/aggregation, no i18n — matches the "easy win" scope from the discussion.

Discussion: https://github.com/markrai/scrumboy/discussions/193

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Added `TestEmailNotifier_RefreshNeeded_CopyReflectsReasonAndActor` covering reason-specific subject/body and actor-name inclusion
- [x] Updated existing assertions in `email_notify_corrections_test.go` / `email_notify_endtoend_test.go` that checked for the old generic "activity update" copy