### PR TITLE
Repoint Dockerfile base images to mirror.gcr.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # runs on the host arch. With CGO disabled the build cross-compiles to the
 # requested TARGETARCH natively -- no QEMU emulation of the compiler, so multi
 # -arch builds stay fast.
-FROM --platform=$BUILDPLATFORM golang:1.25.12-alpine@sha256:56961d79ea8129efddcc0b8643fd8a5416b4e6228cfd477e3fd61deb2672c587 AS build
+FROM --platform=$BUILDPLATFORM mirror.gcr.io/library/golang:1.25.12-alpine@sha256:56961d79ea8129efddcc0b8643fd8a5416b4e6228cfd477e3fd61deb2672c587 AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -14,7 +14,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -trimpath -ldflags="-s -w" -o /out/scrumboy ./cmd/scrumboy
 
-FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
+FROM mirror.gcr.io/library/alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
 
 RUN mkdir -p /data
 ENV BIND_ADDR=:8080 \


### PR DESCRIPTION
## Summary
- The build (`golang:1.25.12-alpine`) and runtime (`alpine:3.20`) base images in `Dockerfile` were pulled implicitly from `docker.io`, which is subject to Docker Hub's anonymous-pull rate limit (`429 Too Many Requests` from `registry-1.docker.io`) and was intermittently breaking builds.
- Repointed both `FROM` lines to `mirror.gcr.io/library/...`, Google's free, unauthenticated read-through cache of Docker Hub. Digests are unchanged (identical image content), so this is a drop-in swap with no behavior change.
- Checked `docker-compose.yml` (build-context only, no `image:` lines) and `.github/workflows/docker-publish.yml` (only marketplace GitHub Actions, no docker.io image pulls) — neither needs changes.

## Test plan
- [x] `grep` confirmed no other Dockerfiles or docker.io image references in the repo
- [ ] CI build (relies on this PR's own workflow run)