### PR TITLE
use absolute overlay on desktop for .no-results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.29.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags), **3.29.0** (MCP JSON-RPC error/`board_get` identity) - see those releases.
 
+## [3.29.1] - 2026-07-31
+
+### Fixed
+
+- **Empty-search "no results" no longer appears as an extra desktop lane** - After the auto-fit board grid change, the "No todos found matching …" message was a grid sibling of the columns and stole a lane track (or compressed columns when spanning). On desktop/tablet (`min-width: 621px`) it is absolutely positioned over the board so lane layout is unchanged. Mobile flex layout is unchanged.
+
 ## [3.29.0] - 2026-07-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.29.0-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.29.1-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/internal/httpapi/web/modules/views/board-i18n.test.ts
+++ b/internal/httpapi/web/modules/views/board-i18n.test.ts
@@ -404,7 +404,7 @@ describe("board i18n locale switching", () => {
     const activeTagChip = document.querySelector("[data-tag='bug']");
     expect(searchInput?.value).toBe("needle");
     expect(activeTagChip?.classList.contains("chip--active")).toBe(true);
-    expect(document.querySelector(".no-results")?.textContent).toBe('No todos found matching "needle"');
+    expect(document.querySelector(".board > .no-results")?.textContent).toBe('No todos found matching "needle"');
 
     await i18n.setLocale("pseudo");
     await flushPromises();
@@ -412,7 +412,7 @@ describe("board i18n locale switching", () => {
     expect((document.getElementById("searchInput") as HTMLInputElement | null)?.value).toBe("needle");
     expect(document.querySelector("[data-tag='bug']")?.classList.contains("chip--active")).toBe(true);
     expect(document.querySelector(".filters__label")?.textContent).toBe("[!! Tags: !!]");
-    expect(document.querySelector(".no-results")?.textContent).toBe('[!! No todos found matching "needle" !!]');
+    expect(document.querySelector(".board > .no-results")?.textContent).toBe('[!! No todos found matching "needle" !!]');
     expect(apiFetchMock).not.toHaveBeenCalled();
   });
 

--- a/internal/httpapi/web/modules/views/board-no-results-layout.test.ts
+++ b/internal/httpapi/web/modules/views/board-no-results-layout.test.ts
@@ -1,0 +1,70 @@
+// Guards desktop empty-search layout: .no-results must leave the auto-fit
+// grid (absolute overlay) so lanes are not compressed. Mobile flex layout is
+// unchanged (min-width 621px only).
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const stylesSource = readFileSync(join(__dirname, "..", "..", "styles.css"), "utf8");
+const boardSource = readFileSync(join(__dirname, "board.ts"), "utf8");
+const renderingSource = readFileSync(join(__dirname, "board-rendering.ts"), "utf8");
+
+function mediaBlock(css: string, query: string): string | null {
+  const start = css.search(new RegExp(`@media\\s*\\(\\s*${query}\\s*\\)\\s*\\{`));
+  if (start < 0) return null;
+  const open = css.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}") {
+      depth--;
+      if (depth === 0) return css.slice(open + 1, i);
+    }
+  }
+  return null;
+}
+
+function mediaBlockContaining(css: string, query: string, needle: string): string | null {
+  const re = new RegExp(`@media\\s*\\(\\s*${query}\\s*\\)\\s*\\{`, "g");
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(css)) !== null) {
+    const open = css.indexOf("{", match.index);
+    let depth = 0;
+    for (let i = open; i < css.length; i++) {
+      if (css[i] === "{") depth++;
+      else if (css[i] === "}") {
+        depth--;
+        if (depth === 0) {
+          const body = css.slice(open + 1, i);
+          if (body.includes(needle)) return body;
+          break;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+describe("board empty-search no-results layout", () => {
+  it("overlays .no-results on desktop/tablet without participating in the grid", () => {
+    const desktop = mediaBlockContaining(stylesSource, "min-width:\\s*621px", ".board > .no-results");
+    expect(desktop).not.toBeNull();
+    expect(desktop!).toMatch(/\.board\s*>\s*\.no-results\s*\{[^}]*position:\s*absolute/);
+    expect(desktop!).not.toMatch(/\.board\s*>\s*\.no-results\s*\{[^}]*grid-column/);
+  });
+
+  it("does not add no-results layout rules inside the mobile board breakpoint", () => {
+    const mobile = mediaBlock(stylesSource, "max-width:\\s*620px");
+    expect(mobile).not.toBeNull();
+    expect(mobile!).not.toMatch(/\.no-results/);
+  });
+
+  it("still inserts .no-results as a direct child of .board", () => {
+    expect(renderingSource).toMatch(/class="no-results"/);
+    expect(boardSource).toMatch(/buildNoResultsHtml\(search\)/);
+    expect(boardSource).toMatch(/insertAdjacentHTML\("beforeend", buildNoResultsHtml\(search\)\)/);
+  });
+});

--- a/internal/httpapi/web/styles.css
+++ b/internal/httpapi/web/styles.css
@@ -4733,6 +4733,26 @@ label:has(input[type="radio"][name="importMode"]:disabled) {
   font-style: italic;
 }
 
+/* Desktop/tablet: keep .no-results out of the auto-fit grid so empty-search
+   messaging cannot steal a lane track or compress columns. Mobile (≤620px)
+   keeps .no-results as a normal flex sibling of .board. */
+@media (min-width: 621px) {
+  .board {
+    position: relative;
+  }
+
+  .board > .no-results {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    pointer-events: none;
+  }
+}
+
 /* ============================================
    BURNDOWN CHART
    ============================================ */

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.29.0"
+const Version = "3.29.1"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
On desktop/tablet, .no-results is now position: absolute over .board, so it’s out of the grid entirely and lanes stay at their normal widths. Mobile (≤620px) is unchanged.