### PR TITLE
Refactor/todo creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.29.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags), **3.29.0** (MCP JSON-RPC error/`board_get` identity) - see those releases.
 
+## [3.29.3] - 2026-08-02
+
+### Changed
+
+- **Todo creates move behind application services** - REST and MCP todo
+  creates now share `internal/application/todo` command boundaries instead of
+  owning write logic in the transports. HTTP and MCP adapters stay thin
+  wrappers; permissions, validation, response shapes, and side effects are
+  preserved. Contract tests lock the migrated create paths.
+
 ## [3.29.2] - 2026-07-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.29.2-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.29.3-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/internal/application/todo/create.go
+++ b/internal/application/todo/create.go
@@ -1,0 +1,96 @@
+package todo
+
+import (
+	"context"
+
+	"scrumboy/internal/store"
+)
+
+// CreateValues contains the transport-neutral values shared by canonical REST
+// and MCP todo creation. Adapters retain transport-specific decoding and
+// compatibility normalization, while the store retains validation and
+// persistence normalization.
+type CreateValues struct {
+	Title            string
+	Body             string
+	Tags             []string
+	ColumnKey        string
+	EstimationPoints *int64
+	AssigneeUserID   *int64
+	SprintID         *int64
+}
+
+// ResolvedCreatePosition carries internal todo-row identities (store.Todo.ID)
+// that are ready for persistence. They are distinct from MCP's project-local
+// todo references.
+type ResolvedCreatePosition struct {
+	AfterTodoID  *int64
+	BeforeTodoID *int64
+}
+
+// CreateCommand contains transport-neutral create values and
+// persistence-ready position identities.
+type CreateCommand struct {
+	Values   CreateValues
+	Position ResolvedCreatePosition
+}
+
+// MCPCreateCommand retains project-local position identities until a prepared
+// MCP service resolves them within its bound project. It is not accepted by the
+// store-input materializer.
+type MCPCreateCommand struct {
+	Values        CreateValues
+	AfterLocalID  *int64
+	BeforeLocalID *int64
+}
+
+// CreateResult contains domain values for transport-owned projection.
+type CreateResult struct {
+	Project store.Project
+	Todo    store.Todo
+}
+
+// CreateStore is the single persistence capability shared by future REST and
+// MCP create services.
+type CreateStore interface {
+	CreateTodo(
+		ctx context.Context,
+		projectID int64,
+		in store.CreateTodoInput,
+		mode store.Mode,
+	) (store.Todo, error)
+}
+
+// MaterializeCreateInput converts a resolved command to the store's existing
+// create vocabulary. It defensively copies mutable values but intentionally
+// performs no access, validation, normalization, persistence, or publication.
+func MaterializeCreateInput(command CreateCommand) store.CreateTodoInput {
+	return store.CreateTodoInput{
+		Title:            command.Values.Title,
+		Body:             command.Values.Body,
+		Tags:             cloneCreateStrings(command.Values.Tags),
+		ColumnKey:        command.Values.ColumnKey,
+		EstimationPoints: cloneCreateInt64Ptr(command.Values.EstimationPoints),
+		SprintID:         cloneCreateInt64Ptr(command.Values.SprintID),
+		AssigneeUserID:   cloneCreateInt64Ptr(command.Values.AssigneeUserID),
+		AfterID:          cloneCreateInt64Ptr(command.Position.AfterTodoID),
+		BeforeID:         cloneCreateInt64Ptr(command.Position.BeforeTodoID),
+	}
+}
+
+func cloneCreateStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	cloned := make([]string, len(values))
+	copy(cloned, values)
+	return cloned
+}
+
+func cloneCreateInt64Ptr(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}

--- a/internal/application/todo/create_test.go
+++ b/internal/application/todo/create_test.go
@@ -1,0 +1,213 @@
+package todo
+
+import (
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+var _ CreateStore = (*store.Store)(nil)
+
+func TestMaterializeCreateInputMapsResolvedCommand(t *testing.T) {
+	estimation := int64(8)
+	assignee := int64(31)
+	sprint := int64(12)
+	afterTodoID := int64(104)
+	beforeTodoID := int64(209)
+	command := CreateCommand{
+		Values: CreateValues{
+			Title:            "create title",
+			Body:             "create body",
+			Tags:             []string{"backend", "urgent"},
+			ColumnKey:        "doing",
+			EstimationPoints: &estimation,
+			AssigneeUserID:   &assignee,
+			SprintID:         &sprint,
+		},
+		Position: ResolvedCreatePosition{
+			AfterTodoID:  &afterTodoID,
+			BeforeTodoID: &beforeTodoID,
+		},
+	}
+
+	in := MaterializeCreateInput(command)
+
+	if in.Title != command.Values.Title || in.Body != command.Values.Body || in.ColumnKey != command.Values.ColumnKey {
+		t.Fatalf("scalar values were not mapped exactly: %+v", in)
+	}
+	if !reflect.DeepEqual(in.Tags, command.Values.Tags) {
+		t.Fatalf("tags = %#v, want %#v", in.Tags, command.Values.Tags)
+	}
+	assertCopiedCreatePointer(t, "estimation", in.EstimationPoints, command.Values.EstimationPoints, estimation)
+	assertCopiedCreatePointer(t, "assignee", in.AssigneeUserID, command.Values.AssigneeUserID, assignee)
+	assertCopiedCreatePointer(t, "sprint", in.SprintID, command.Values.SprintID, sprint)
+	assertCopiedCreatePointer(t, "after todo ID", in.AfterID, command.Position.AfterTodoID, afterTodoID)
+	assertCopiedCreatePointer(t, "before todo ID", in.BeforeID, command.Position.BeforeTodoID, beforeTodoID)
+}
+
+func TestMaterializeCreateInputPreservesNilOptionalValues(t *testing.T) {
+	in := MaterializeCreateInput(CreateCommand{})
+
+	if in.Tags != nil {
+		t.Fatalf("nil tags became %#v", in.Tags)
+	}
+	if in.EstimationPoints != nil || in.AssigneeUserID != nil || in.SprintID != nil || in.AfterID != nil || in.BeforeID != nil {
+		t.Fatalf("nil optional values were not preserved: %+v", in)
+	}
+}
+
+func TestMaterializeCreateInputPreservesNonnilEmptyTags(t *testing.T) {
+	tags := []string{}
+	in := MaterializeCreateInput(CreateCommand{Values: CreateValues{Tags: tags}})
+
+	if in.Tags == nil || len(in.Tags) != 0 {
+		t.Fatalf("empty tags = %#v, want nonnil empty slice", in.Tags)
+	}
+}
+
+func TestMaterializeCreateInputDoesNotNormalizeValues(t *testing.T) {
+	estimation := int64(-99)
+	command := CreateCommand{Values: CreateValues{
+		Title:            "  untrimmed title  ",
+		Body:             "  untrimmed body  ",
+		Tags:             []string{" Alpha ", "alpha", "Alpha"},
+		ColumnKey:        "MiXeD_Lane",
+		EstimationPoints: &estimation,
+	}}
+
+	in := MaterializeCreateInput(command)
+
+	if in.Title != command.Values.Title || in.Body != command.Values.Body || in.ColumnKey != command.Values.ColumnKey {
+		t.Fatalf("materializer normalized scalar values: %+v", in)
+	}
+	if !reflect.DeepEqual(in.Tags, command.Values.Tags) {
+		t.Fatalf("materializer normalized tags: got %#v, want %#v", in.Tags, command.Values.Tags)
+	}
+	assertCreatePointerValue(t, "estimation", in.EstimationPoints, estimation)
+}
+
+func TestMaterializeCreateInputDoesNotAliasSourcesOrResult(t *testing.T) {
+	estimation := int64(5)
+	assignee := int64(17)
+	sprint := int64(9)
+	afterTodoID := int64(301)
+	beforeTodoID := int64(405)
+	tags := []string{"source-tag"}
+	command := CreateCommand{
+		Values: CreateValues{
+			Tags:             tags,
+			EstimationPoints: &estimation,
+			AssigneeUserID:   &assignee,
+			SprintID:         &sprint,
+		},
+		Position: ResolvedCreatePosition{
+			AfterTodoID:  &afterTodoID,
+			BeforeTodoID: &beforeTodoID,
+		},
+	}
+	in := MaterializeCreateInput(command)
+
+	tags[0] = "mutated source tag"
+	estimation = 105
+	assignee = 117
+	sprint = 109
+	afterTodoID = 1301
+	beforeTodoID = 1405
+	if in.Tags[0] != "source-tag" || *in.EstimationPoints != 5 || *in.AssigneeUserID != 17 || *in.SprintID != 9 || *in.AfterID != 301 || *in.BeforeID != 405 {
+		t.Fatalf("materialized input changed after source mutation: %+v", in)
+	}
+
+	secondEstimation := int64(6)
+	secondAssignee := int64(18)
+	secondSprint := int64(10)
+	secondAfter := int64(501)
+	secondBefore := int64(605)
+	second := CreateCommand{
+		Values: CreateValues{
+			Tags:             []string{"second-source-tag"},
+			EstimationPoints: &secondEstimation,
+			AssigneeUserID:   &secondAssignee,
+			SprintID:         &secondSprint,
+		},
+		Position: ResolvedCreatePosition{
+			AfterTodoID:  &secondAfter,
+			BeforeTodoID: &secondBefore,
+		},
+	}
+	secondInput := MaterializeCreateInput(second)
+	secondInput.Tags[0] = "mutated result tag"
+	*secondInput.EstimationPoints = 206
+	*secondInput.AssigneeUserID = 218
+	*secondInput.SprintID = 210
+	*secondInput.AfterID = 1501
+	*secondInput.BeforeID = 1605
+	if second.Values.Tags[0] != "second-source-tag" || secondEstimation != 6 || secondAssignee != 18 || secondSprint != 10 || secondAfter != 501 || secondBefore != 605 {
+		t.Fatalf("command changed after materialized result mutation: %+v", second)
+	}
+}
+
+func TestCreateCommandsKeepResolvedAndLocalPositionIdentitiesSeparate(t *testing.T) {
+	afterLocalID := int64(7)
+	beforeLocalID := int64(8)
+	mcpCommand := MCPCreateCommand{
+		Values:        CreateValues{Title: "MCP create"},
+		AfterLocalID:  &afterLocalID,
+		BeforeLocalID: &beforeLocalID,
+	}
+	if mcpCommand.AfterLocalID == nil || *mcpCommand.AfterLocalID != 7 || mcpCommand.BeforeLocalID == nil || *mcpCommand.BeforeLocalID != 8 {
+		t.Fatalf("MCP command lost project-local position identities: %+v", mcpCommand)
+	}
+
+	// Same numeric values on purpose: separation is structural (distinct command
+	// types / field names), not "local IDs happen to differ from store IDs".
+	afterTodoID := int64(7)
+	beforeTodoID := int64(8)
+	resolved := CreateCommand{
+		Values: mcpCommand.Values,
+		Position: ResolvedCreatePosition{
+			AfterTodoID:  &afterTodoID,
+			BeforeTodoID: &beforeTodoID,
+		},
+	}
+	if _, ok := any(mcpCommand).(CreateCommand); ok {
+		t.Fatal("MCPCreateCommand must not be assignable to CreateCommand")
+	}
+	if _, ok := any(resolved).(MCPCreateCommand); ok {
+		t.Fatal("CreateCommand must not be assignable to MCPCreateCommand")
+	}
+
+	in := MaterializeCreateInput(resolved)
+	if in.AfterID == nil || *in.AfterID != 7 || in.BeforeID == nil || *in.BeforeID != 8 {
+		t.Fatalf("resolved internal identities were not materialized: %+v", in)
+	}
+}
+
+func TestCreateResultCarriesApplicationDomainValues(t *testing.T) {
+	result := CreateResult{
+		Project: store.Project{ID: 14, Slug: "create-project"},
+		Todo:    store.Todo{ID: 82, LocalID: 3, ProjectID: 14},
+	}
+
+	if result.Project.ID != 14 || result.Project.Slug != "create-project" || result.Todo.ID != 82 || result.Todo.LocalID != 3 || result.Todo.ProjectID != 14 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func assertCopiedCreatePointer(t *testing.T, name string, got, source *int64, want int64) {
+	t.Helper()
+	assertCreatePointerValue(t, name, got, want)
+	if got == source {
+		t.Fatalf("%s pointer aliases its source", name)
+	}
+}
+
+func assertCreatePointerValue(t *testing.T, name string, got *int64, want int64) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("%s pointer is nil, want %d", name, want)
+	}
+	if *got != want {
+		t.Fatalf("%s = %d, want %d", name, *got, want)
+	}
+}

--- a/internal/application/todo/mcp_create.go
+++ b/internal/application/todo/mcp_create.go
@@ -1,0 +1,160 @@
+package todo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"scrumboy/internal/store"
+)
+
+// MCPCreateAccessStore resolves the slug access boundary before MCP create
+// normalization and data-dependent position policy run.
+type MCPCreateAccessStore interface {
+	GetProjectContextBySlug(ctx context.Context, slug string, mode store.Mode) (store.ProjectContext, error)
+}
+
+// MCPCreateLookupStore resolves project-local position references within the
+// project bound during preparation.
+type MCPCreateLookupStore interface {
+	GetTodoByLocalID(ctx context.Context, projectID int64, localID int64, mode store.Mode) (store.Todo, error)
+}
+
+type MCPCreateServiceDependencies struct {
+	Access MCPCreateAccessStore
+	Lookup MCPCreateLookupStore
+	Create CreateStore
+}
+
+// MCPCreateService owns slug access, project-scoped local-anchor resolution,
+// and create persistence. It deliberately has no refresh dependency; MCP
+// realtime behavior remains limited to effects published by the store.
+type MCPCreateService struct {
+	access MCPCreateAccessStore
+	lookup MCPCreateLookupStore
+	create CreateStore
+}
+
+func NewMCPCreateService(deps MCPCreateServiceDependencies) *MCPCreateService {
+	return &MCPCreateService{
+		access: deps.Access,
+		lookup: deps.Lookup,
+		create: deps.Create,
+	}
+}
+
+// SlugCreateTarget identifies the slug whose access must be resolved before
+// adapter-owned lane preparation and service-owned local-anchor policy run.
+type SlugCreateTarget struct {
+	Slug string
+	Mode store.Mode
+}
+
+// PreparedMCPCreate binds the access context and value copies of the resolved
+// project context and mode to position resolution and persistence.
+type PreparedMCPCreate struct {
+	ctx            context.Context
+	service        *MCPCreateService
+	projectContext store.ProjectContext
+	mode           store.Mode
+}
+
+func (s *MCPCreateService) Prepare(ctx context.Context, target SlugCreateTarget) (*PreparedMCPCreate, error) {
+	projectContext, err := s.access.GetProjectContextBySlug(ctx, target.Slug, target.Mode)
+	if err != nil {
+		return nil, err
+	}
+	return &PreparedMCPCreate{
+		ctx:            ctx,
+		service:        s,
+		projectContext: projectContext,
+		mode:           target.Mode,
+	}, nil
+}
+
+type MCPCreateValidationKind string
+
+const (
+	MCPCreateInvalidLocalReference  MCPCreateValidationKind = "invalid_local_reference"
+	MCPCreateReferenceInWrongColumn MCPCreateValidationKind = "reference_in_wrong_column"
+)
+
+// MCPCreateValidationError identifies MCP-only local-position failures without
+// coupling application policy to MCP status codes or error envelopes.
+type MCPCreateValidationError struct {
+	Kind       MCPCreateValidationKind
+	Field      string
+	LocalID    int64
+	HasLocalID bool
+}
+
+func (e *MCPCreateValidationError) Error() string {
+	return fmt.Sprintf("MCP todo create validation failed: %s", e.Kind)
+}
+
+// Create resolves MCP's project-local anchors in after-before order and then
+// performs exactly one create with persistence-ready internal identities.
+func (c *PreparedMCPCreate) Create(command MCPCreateCommand) (CreateResult, error) {
+	project := c.projectContext.Project
+	afterTodo, err := c.resolveLocalTodoForColumn(command.AfterLocalID, "afterLocalId", command.Values.ColumnKey)
+	if err != nil {
+		return CreateResult{}, err
+	}
+	beforeTodo, err := c.resolveLocalTodoForColumn(command.BeforeLocalID, "beforeLocalId", command.Values.ColumnKey)
+	if err != nil {
+		return CreateResult{}, err
+	}
+
+	position := ResolvedCreatePosition{}
+	if afterTodo != nil {
+		position.AfterTodoID = cloneCreateInt64Ptr(&afterTodo.ID)
+	}
+	if beforeTodo != nil {
+		position.BeforeTodoID = cloneCreateInt64Ptr(&beforeTodo.ID)
+	}
+	input := MaterializeCreateInput(CreateCommand{
+		Values:   command.Values,
+		Position: position,
+	})
+	created, err := c.service.create.CreateTodo(c.ctx, project.ID, input, c.mode)
+	if err != nil {
+		return CreateResult{}, err
+	}
+	return CreateResult{Project: project, Todo: created}, nil
+}
+
+func (c *PreparedMCPCreate) resolveLocalTodoForColumn(localID *int64, field, targetColumnKey string) (*store.Todo, error) {
+	if localID == nil {
+		return nil, nil
+	}
+	if *localID <= 0 {
+		return nil, &MCPCreateValidationError{
+			Kind:    MCPCreateInvalidLocalReference,
+			Field:   field,
+			LocalID: *localID,
+		}
+	}
+
+	projectID := c.projectContext.Project.ID
+	todo, err := c.service.lookup.GetTodoByLocalID(c.ctx, projectID, *localID, c.mode)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, &MCPCreateValidationError{
+				Kind:       MCPCreateInvalidLocalReference,
+				Field:      field,
+				LocalID:    *localID,
+				HasLocalID: true,
+			}
+		}
+		return nil, err
+	}
+	if todo.ColumnKey != targetColumnKey {
+		return nil, &MCPCreateValidationError{
+			Kind:       MCPCreateReferenceInWrongColumn,
+			Field:      field,
+			LocalID:    *localID,
+			HasLocalID: true,
+		}
+	}
+	return &todo, nil
+}

--- a/internal/application/todo/mcp_create_test.go
+++ b/internal/application/todo/mcp_create_test.go
@@ -1,0 +1,469 @@
+package todo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+var (
+	_ MCPCreateAccessStore = (*store.Store)(nil)
+	_ MCPCreateLookupStore = (*store.Store)(nil)
+	_ CreateStore          = (*store.Store)(nil)
+)
+
+type mcpCreateAccessCall struct {
+	ctx  context.Context
+	slug string
+	mode store.Mode
+}
+
+type mcpCreateAccessFake struct {
+	calls          []mcpCreateAccessCall
+	projectContext store.ProjectContext
+	err            error
+	trace          *[]string
+}
+
+func (f *mcpCreateAccessFake) GetProjectContextBySlug(ctx context.Context, slug string, mode store.Mode) (store.ProjectContext, error) {
+	f.calls = append(f.calls, mcpCreateAccessCall{ctx: ctx, slug: slug, mode: mode})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "access")
+	}
+	if f.err != nil {
+		return store.ProjectContext{}, f.err
+	}
+	if err := ctx.Err(); err != nil {
+		return store.ProjectContext{}, err
+	}
+	return f.projectContext, nil
+}
+
+type mcpCreateLookupCall struct {
+	ctx       context.Context
+	projectID int64
+	localID   int64
+	mode      store.Mode
+}
+
+type mcpCreateLookupFake struct {
+	calls []mcpCreateLookupCall
+	todos map[int64]store.Todo
+	errs  map[int64]error
+	trace *[]string
+}
+
+func (f *mcpCreateLookupFake) GetTodoByLocalID(ctx context.Context, projectID int64, localID int64, mode store.Mode) (store.Todo, error) {
+	f.calls = append(f.calls, mcpCreateLookupCall{ctx: ctx, projectID: projectID, localID: localID, mode: mode})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, fmt.Sprintf("lookup:%d", localID))
+	}
+	if err := ctx.Err(); err != nil {
+		return store.Todo{}, err
+	}
+	if err := f.errs[localID]; err != nil {
+		return store.Todo{}, err
+	}
+	todo, ok := f.todos[localID]
+	if !ok {
+		return store.Todo{}, store.ErrNotFound
+	}
+	return todo, nil
+}
+
+type mcpCreateStoreCall struct {
+	ctx       context.Context
+	projectID int64
+	input     store.CreateTodoInput
+	mode      store.Mode
+}
+
+type mcpCreateStoreFake struct {
+	calls []mcpCreateStoreCall
+	todo  store.Todo
+	err   error
+	trace *[]string
+}
+
+func (f *mcpCreateStoreFake) CreateTodo(ctx context.Context, projectID int64, input store.CreateTodoInput, mode store.Mode) (store.Todo, error) {
+	f.calls = append(f.calls, mcpCreateStoreCall{ctx: ctx, projectID: projectID, input: input, mode: mode})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "create")
+	}
+	if f.err != nil {
+		return store.Todo{}, f.err
+	}
+	if err := ctx.Err(); err != nil {
+		return store.Todo{}, err
+	}
+	return f.todo, nil
+}
+
+func TestMCPCreateServicePrepareBindsAccessTargetAndCopiesProjectContext(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx := context.WithValue(context.Background(), key, "bound")
+	trace := []string{}
+	access := &mcpCreateAccessFake{
+		projectContext: store.ProjectContext{
+			Project: store.Project{ID: 7, Slug: "canonical"},
+			Role:    store.RoleMaintainer,
+		},
+		trace: &trace,
+	}
+	lookup := &mcpCreateLookupFake{trace: &trace}
+	creates := &mcpCreateStoreFake{trace: &trace}
+	service := NewMCPCreateService(MCPCreateServiceDependencies{Access: access, Lookup: lookup, Create: creates})
+	target := SlugCreateTarget{Slug: "requested", Mode: store.ModeFull}
+
+	prepared, err := service.Prepare(ctx, target)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if len(access.calls) != 1 {
+		t.Fatalf("access calls = %d, want 1", len(access.calls))
+	}
+	call := access.calls[0]
+	if call.ctx != ctx || call.ctx.Value(key) != "bound" || call.slug != "requested" || call.mode != store.ModeFull {
+		t.Fatalf("access call = %+v, want bound context, requested slug, full mode", call)
+	}
+	if len(lookup.calls) != 0 || len(creates.calls) != 0 {
+		t.Fatalf("preparation performed data work: lookups=%d creates=%d", len(lookup.calls), len(creates.calls))
+	}
+
+	access.projectContext.Project.ID = 99
+	access.projectContext.Project.Slug = "mutated"
+	access.projectContext.Role = store.RoleViewer
+	target.Slug = "mutated"
+	target.Mode = store.ModeAnonymous
+	if prepared.projectContext.Project.ID != 7 || prepared.projectContext.Project.Slug != "canonical" || prepared.projectContext.Role != store.RoleMaintainer || prepared.mode != store.ModeFull {
+		t.Fatalf("prepared target changed after source mutation: %+v mode=%q", prepared.projectContext, prepared.mode)
+	}
+	if !reflect.DeepEqual(trace, []string{"access"}) {
+		t.Fatalf("call trace = %#v, want access only", trace)
+	}
+}
+
+func TestMCPCreateServiceAccessFailureReturnsNoCapability(t *testing.T) {
+	wantErr := errors.New("access failed")
+	trace := []string{}
+	access := &mcpCreateAccessFake{err: wantErr, trace: &trace}
+	lookup := &mcpCreateLookupFake{trace: &trace}
+	creates := &mcpCreateStoreFake{trace: &trace}
+	service := NewMCPCreateService(MCPCreateServiceDependencies{Access: access, Lookup: lookup, Create: creates})
+
+	prepared, err := service.Prepare(context.Background(), SlugCreateTarget{Slug: "hidden", Mode: store.ModeFull})
+	if err != wantErr {
+		t.Fatalf("Prepare error = %v, want identical error %v", err, wantErr)
+	}
+	if prepared != nil {
+		t.Fatalf("prepared capability = %+v, want nil", prepared)
+	}
+	if len(access.calls) != 1 || len(lookup.calls) != 0 || len(creates.calls) != 0 {
+		t.Fatalf("calls after access failure: access=%d lookup=%d create=%d", len(access.calls), len(lookup.calls), len(creates.calls))
+	}
+	if !reflect.DeepEqual(trace, []string{"access"}) {
+		t.Fatalf("call trace = %#v, want access only", trace)
+	}
+}
+
+func TestMCPCreateServiceResolvesAnchorsInOrderAndMaterializesOnce(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx := context.WithValue(context.Background(), key, "bound")
+	trace := []string{}
+	access := &mcpCreateAccessFake{
+		projectContext: store.ProjectContext{Project: store.Project{ID: 7, Slug: "canonical"}, Role: store.RoleMaintainer},
+		trace:          &trace,
+	}
+	lookup := &mcpCreateLookupFake{
+		todos: map[int64]store.Todo{
+			11: {ID: 101, ProjectID: 7, LocalID: 11, ColumnKey: "doing"},
+			12: {ID: 202, ProjectID: 7, LocalID: 12, ColumnKey: "doing"},
+		},
+		trace: &trace,
+	}
+	created := store.Todo{ID: 303, ProjectID: 7, LocalID: 13, Title: "created"}
+	creates := &mcpCreateStoreFake{todo: created, trace: &trace}
+	service := NewMCPCreateService(MCPCreateServiceDependencies{Access: access, Lookup: lookup, Create: creates})
+	prepared, err := service.Prepare(ctx, SlugCreateTarget{Slug: "requested", Mode: store.ModeFull})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	estimation := int64(8)
+	assignee := int64(42)
+	sprint := int64(12)
+	afterLocalID := int64(11)
+	beforeLocalID := int64(12)
+	tags := []string{"api", "urgent"}
+	command := MCPCreateCommand{
+		Values: CreateValues{
+			Title:            "created",
+			Body:             "body",
+			Tags:             tags,
+			ColumnKey:        "doing",
+			EstimationPoints: &estimation,
+			AssigneeUserID:   &assignee,
+			SprintID:         &sprint,
+		},
+		AfterLocalID:  &afterLocalID,
+		BeforeLocalID: &beforeLocalID,
+	}
+
+	result, err := prepared.Create(command)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(lookup.calls) != 2 {
+		t.Fatalf("lookup calls = %d, want 2", len(lookup.calls))
+	}
+	for i, wantLocalID := range []int64{11, 12} {
+		call := lookup.calls[i]
+		if call.ctx != ctx || call.ctx.Value(key) != "bound" || call.projectID != 7 || call.localID != wantLocalID || call.mode != store.ModeFull {
+			t.Fatalf("lookup %d = %+v, want bound project/local/mode", i, call)
+		}
+	}
+	if len(creates.calls) != 1 {
+		t.Fatalf("create calls = %d, want 1", len(creates.calls))
+	}
+	createCall := creates.calls[0]
+	if createCall.ctx != ctx || createCall.projectID != 7 || createCall.mode != store.ModeFull {
+		t.Fatalf("create target = %+v, want bound context/project/mode", createCall)
+	}
+	assertMCPCreateInput(t, createCall.input, tags, estimation, assignee, sprint, 101, 202)
+	if !reflect.DeepEqual(trace, []string{"access", "lookup:11", "lookup:12", "create"}) {
+		t.Fatalf("call trace = %#v, want access, after lookup, before lookup, create", trace)
+	}
+
+	tags[0] = "mutated"
+	estimation = 80
+	assignee = 420
+	sprint = 120
+	afterLocalID = 111
+	beforeLocalID = 112
+	if !reflect.DeepEqual(createCall.input.Tags, []string{"api", "urgent"}) ||
+		*createCall.input.EstimationPoints != 8 ||
+		*createCall.input.AssigneeUserID != 42 ||
+		*createCall.input.SprintID != 12 ||
+		*createCall.input.AfterID != 101 ||
+		*createCall.input.BeforeID != 202 {
+		t.Fatalf("store input changed after command mutation: %+v", createCall.input)
+	}
+	if result.Project.ID != 7 || result.Project.Slug != "canonical" || !reflect.DeepEqual(result.Todo, created) {
+		t.Fatalf("result = %+v, want bound project and created todo", result)
+	}
+}
+
+func TestMCPCreateServiceLocalReferenceValidationAndLookupFailures(t *testing.T) {
+	tests := []struct {
+		name           string
+		command        MCPCreateCommand
+		todos          map[int64]store.Todo
+		errs           map[int64]error
+		wantKind       MCPCreateValidationKind
+		wantField      string
+		wantLocalID    int64
+		wantHasLocalID bool
+		wantErr        error
+		wantTrace      []string
+		wantLookups    int
+	}{
+		{
+			name:        "nonpositive after reference",
+			command:     mcpCreateTestCommand(mcpCreateTestInt64(0), nil),
+			wantKind:    MCPCreateInvalidLocalReference,
+			wantField:   "afterLocalId",
+			wantTrace:   []string{"access"},
+			wantLookups: 0,
+		},
+		{
+			name:           "missing after wins before validation",
+			command:        mcpCreateTestCommand(mcpCreateTestInt64(999), mcpCreateTestInt64(0)),
+			wantKind:       MCPCreateInvalidLocalReference,
+			wantField:      "afterLocalId",
+			wantLocalID:    999,
+			wantHasLocalID: true,
+			wantTrace:      []string{"access", "lookup:999"},
+			wantLookups:    1,
+		},
+		{
+			name:           "wrong column",
+			command:        mcpCreateTestCommand(mcpCreateTestInt64(11), nil),
+			todos:          map[int64]store.Todo{11: {ID: 101, ProjectID: 7, LocalID: 11, ColumnKey: "testing"}},
+			wantKind:       MCPCreateReferenceInWrongColumn,
+			wantField:      "afterLocalId",
+			wantLocalID:    11,
+			wantHasLocalID: true,
+			wantTrace:      []string{"access", "lookup:11"},
+			wantLookups:    1,
+		},
+		{
+			name:        "unauthorized lookup passes through",
+			command:     mcpCreateTestCommand(nil, mcpCreateTestInt64(12)),
+			errs:        map[int64]error{12: store.ErrUnauthorized},
+			wantErr:     store.ErrUnauthorized,
+			wantTrace:   []string{"access", "lookup:12"},
+			wantLookups: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trace := []string{}
+			access := &mcpCreateAccessFake{
+				projectContext: store.ProjectContext{Project: store.Project{ID: 7}},
+				trace:          &trace,
+			}
+			lookup := &mcpCreateLookupFake{todos: tt.todos, errs: tt.errs, trace: &trace}
+			creates := &mcpCreateStoreFake{trace: &trace}
+			prepared, err := NewMCPCreateService(MCPCreateServiceDependencies{Access: access, Lookup: lookup, Create: creates}).Prepare(
+				context.Background(),
+				SlugCreateTarget{Slug: "requested", Mode: store.ModeFull},
+			)
+			if err != nil {
+				t.Fatalf("Prepare: %v", err)
+			}
+
+			result, err := prepared.Create(tt.command)
+			if tt.wantErr != nil {
+				if err != tt.wantErr {
+					t.Fatalf("Create error = %v, want identical error %v", err, tt.wantErr)
+				}
+			} else {
+				var validationErr *MCPCreateValidationError
+				if !errors.As(err, &validationErr) {
+					t.Fatalf("Create error = %T %v, want MCPCreateValidationError", err, err)
+				}
+				if validationErr.Kind != tt.wantKind || validationErr.Field != tt.wantField || validationErr.LocalID != tt.wantLocalID || validationErr.HasLocalID != tt.wantHasLocalID {
+					t.Fatalf("validation error = %+v, want kind=%q field=%q local=%d hasLocal=%v", validationErr, tt.wantKind, tt.wantField, tt.wantLocalID, tt.wantHasLocalID)
+				}
+			}
+			if !reflect.DeepEqual(result, CreateResult{}) {
+				t.Fatalf("result = %+v, want zero value", result)
+			}
+			if len(lookup.calls) != tt.wantLookups || len(creates.calls) != 0 {
+				t.Fatalf("calls = lookups %d creates %d, want lookups %d creates 0", len(lookup.calls), len(creates.calls), tt.wantLookups)
+			}
+			if !reflect.DeepEqual(trace, tt.wantTrace) {
+				t.Fatalf("call trace = %#v, want %#v", trace, tt.wantTrace)
+			}
+		})
+	}
+}
+
+func TestMCPCreateServiceStoreFailureReturnsSameErrorWithoutRetry(t *testing.T) {
+	wantErr := errors.New("create failed")
+	trace := []string{}
+	access := &mcpCreateAccessFake{
+		projectContext: store.ProjectContext{Project: store.Project{ID: 7}},
+		trace:          &trace,
+	}
+	lookup := &mcpCreateLookupFake{trace: &trace}
+	creates := &mcpCreateStoreFake{err: wantErr, trace: &trace}
+	prepared, err := NewMCPCreateService(MCPCreateServiceDependencies{Access: access, Lookup: lookup, Create: creates}).Prepare(
+		context.Background(),
+		SlugCreateTarget{Slug: "requested", Mode: store.ModeFull},
+	)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	result, err := prepared.Create(mcpCreateTestCommand(nil, nil))
+	if err != wantErr {
+		t.Fatalf("Create error = %v, want identical error %v", err, wantErr)
+	}
+	if !reflect.DeepEqual(result, CreateResult{}) {
+		t.Fatalf("result = %+v, want zero value", result)
+	}
+	if len(lookup.calls) != 0 || len(creates.calls) != 1 {
+		t.Fatalf("calls = lookups %d creates %d, want 0 and 1", len(lookup.calls), len(creates.calls))
+	}
+	if !reflect.DeepEqual(trace, []string{"access", "create"}) {
+		t.Fatalf("call trace = %#v, want access then create", trace)
+	}
+}
+
+func TestMCPCreateServiceCancellationAfterPreparationUsesBoundContext(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), key, "bound"))
+	trace := []string{}
+	access := &mcpCreateAccessFake{
+		projectContext: store.ProjectContext{Project: store.Project{ID: 7}},
+		trace:          &trace,
+	}
+	lookup := &mcpCreateLookupFake{trace: &trace}
+	creates := &mcpCreateStoreFake{trace: &trace}
+	prepared, err := NewMCPCreateService(MCPCreateServiceDependencies{Access: access, Lookup: lookup, Create: creates}).Prepare(
+		ctx,
+		SlugCreateTarget{Slug: "requested", Mode: store.ModeFull},
+	)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	cancel()
+
+	_, err = prepared.Create(mcpCreateTestCommand(mcpCreateTestInt64(11), nil))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Create error = %v, want context canceled", err)
+	}
+	if len(lookup.calls) != 1 {
+		t.Fatalf("lookup calls = %d, want 1", len(lookup.calls))
+	}
+	if got := lookup.calls[0].ctx; got != ctx || got.Value(key) != "bound" || !errors.Is(got.Err(), context.Canceled) {
+		t.Fatalf("lookup context = %v, want bound cancelled context", got)
+	}
+	if len(creates.calls) != 0 {
+		t.Fatalf("create calls = %d, want 0", len(creates.calls))
+	}
+	if !reflect.DeepEqual(trace, []string{"access", "lookup:11"}) {
+		t.Fatalf("call trace = %#v, want access then lookup", trace)
+	}
+}
+
+func mcpCreateTestCommand(afterLocalID, beforeLocalID *int64) MCPCreateCommand {
+	return MCPCreateCommand{
+		Values: CreateValues{
+			Title:     "created",
+			ColumnKey: "doing",
+		},
+		AfterLocalID:  afterLocalID,
+		BeforeLocalID: beforeLocalID,
+	}
+}
+
+func mcpCreateTestInt64(value int64) *int64 {
+	return &value
+}
+
+func assertMCPCreateInput(
+	t *testing.T,
+	input store.CreateTodoInput,
+	wantTags []string,
+	wantEstimation int64,
+	wantAssignee int64,
+	wantSprint int64,
+	wantAfter int64,
+	wantBefore int64,
+) {
+	t.Helper()
+	if input.Title != "created" || input.Body != "body" || input.ColumnKey != "doing" {
+		t.Fatalf("scalar values = title %q body %q column %q", input.Title, input.Body, input.ColumnKey)
+	}
+	if !reflect.DeepEqual(input.Tags, wantTags) {
+		t.Fatalf("tags = %#v, want %#v", input.Tags, wantTags)
+	}
+	assertCreatePointerValue(t, "estimation", input.EstimationPoints, wantEstimation)
+	assertCreatePointerValue(t, "assignee", input.AssigneeUserID, wantAssignee)
+	assertCreatePointerValue(t, "sprint", input.SprintID, wantSprint)
+	assertCreatePointerValue(t, "after todo ID", input.AfterID, wantAfter)
+	assertCreatePointerValue(t, "before todo ID", input.BeforeID, wantBefore)
+	if len(input.Tags) > 0 && len(wantTags) > 0 && &input.Tags[0] == &wantTags[0] {
+		t.Fatal("materialized tags alias the MCP command")
+	}
+}

--- a/internal/application/todo/rest_create.go
+++ b/internal/application/todo/rest_create.go
@@ -1,0 +1,76 @@
+package todo
+
+import (
+	"context"
+
+	"scrumboy/internal/store"
+)
+
+const RefreshReasonTodoCreated = "todo_created"
+
+// CreateServiceDependencies names the persistence and ancillary capabilities
+// used by the canonical REST create use case.
+type CreateServiceDependencies struct {
+	Create  CreateStore
+	Refresh BoardRefreshPublisher
+}
+
+// CreateService owns REST create persistence and post-commit direct-refresh
+// gating. Assignment-event publication remains owned by the store.
+type CreateService struct {
+	create  CreateStore
+	refresh BoardRefreshPublisher
+}
+
+func NewCreateService(deps CreateServiceDependencies) *CreateService {
+	refresh := deps.Refresh
+	if refresh == nil {
+		refresh = nopBoardRefreshPublisher{}
+	}
+	return &CreateService{create: deps.Create, refresh: refresh}
+}
+
+// ResolvedCreateTarget carries the project context already authorized by the
+// shared REST board router. Preparation intentionally performs no slug lookup.
+type ResolvedCreateTarget struct {
+	ProjectContext store.ProjectContext
+	Mode           store.Mode
+}
+
+// PreparedCreate binds the request context and value copies of the authorized
+// project context and mode to the subsequent mutation.
+type PreparedCreate struct {
+	ctx            context.Context
+	service        *CreateService
+	projectContext store.ProjectContext
+	mode           store.Mode
+}
+
+// Prepare binds an already-resolved REST board target without performing
+// persistence or repeating route-owned access resolution.
+func (s *CreateService) Prepare(ctx context.Context, target ResolvedCreateTarget) *PreparedCreate {
+	return &PreparedCreate{
+		ctx:            ctx,
+		service:        s,
+		projectContext: target.ProjectContext,
+		mode:           target.Mode,
+	}
+}
+
+// Create expects an adapter-prepared command whose lane and internal position
+// identities are ready for persistence. Other values remain unnormalized so
+// the store retains its existing validation and normalization policy.
+func (c *PreparedCreate) Create(command CreateCommand) (CreateResult, error) {
+	project := c.projectContext.Project
+	input := MaterializeCreateInput(command)
+	created, err := c.service.create.CreateTodo(c.ctx, project.ID, input, c.mode)
+	if err != nil {
+		return CreateResult{}, err
+	}
+
+	if !created.AssignmentChanged {
+		c.service.refresh.PublishBoardRefresh(c.ctx, project.ID, RefreshReasonTodoCreated)
+	}
+
+	return CreateResult{Project: project, Todo: created}, nil
+}

--- a/internal/application/todo/rest_create_test.go
+++ b/internal/application/todo/rest_create_test.go
@@ -1,0 +1,298 @@
+package todo
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+type restCreateStoreCall struct {
+	ctx       context.Context
+	projectID int64
+	input     store.CreateTodoInput
+	mode      store.Mode
+}
+
+type restCreateStoreFake struct {
+	calls []restCreateStoreCall
+	todo  store.Todo
+	err   error
+	trace *[]string
+}
+
+func (f *restCreateStoreFake) CreateTodo(
+	ctx context.Context,
+	projectID int64,
+	input store.CreateTodoInput,
+	mode store.Mode,
+) (store.Todo, error) {
+	f.calls = append(f.calls, restCreateStoreCall{
+		ctx:       ctx,
+		projectID: projectID,
+		input:     input,
+		mode:      mode,
+	})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "create")
+	}
+	if f.err != nil {
+		return store.Todo{}, f.err
+	}
+	if err := ctx.Err(); err != nil {
+		return store.Todo{}, err
+	}
+	return f.todo, nil
+}
+
+type restCreateRefreshCall struct {
+	ctx       context.Context
+	projectID int64
+	reason    string
+}
+
+type restCreateRefreshFake struct {
+	calls []restCreateRefreshCall
+	trace *[]string
+}
+
+func (f *restCreateRefreshFake) PublishBoardRefresh(ctx context.Context, projectID int64, reason string) {
+	f.calls = append(f.calls, restCreateRefreshCall{ctx: ctx, projectID: projectID, reason: reason})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "refresh")
+	}
+}
+
+func TestCreateServicePreparedCreateBindsTargetAndMaterializesAdapterPreparedCommand(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx := context.WithValue(context.Background(), key, "bound")
+
+	estimation := int64(8)
+	assignee := int64(42)
+	sprint := int64(12)
+	afterTodoID := int64(104)
+	beforeTodoID := int64(209)
+	tags := []string{"api", "urgent"}
+	command := CreateCommand{
+		Values: CreateValues{
+			Title:            "create title",
+			Body:             "create body",
+			Tags:             tags,
+			ColumnKey:        "doing",
+			EstimationPoints: &estimation,
+			AssigneeUserID:   &assignee,
+			SprintID:         &sprint,
+		},
+		Position: ResolvedCreatePosition{
+			AfterTodoID:  &afterTodoID,
+			BeforeTodoID: &beforeTodoID,
+		},
+	}
+	created := store.Todo{ID: 71, ProjectID: 7, LocalID: 4, Title: "create title", AssignmentChanged: false}
+	trace := []string{}
+	creates := &restCreateStoreFake{todo: created, trace: &trace}
+	refresh := &restCreateRefreshFake{trace: &trace}
+	service := NewCreateService(CreateServiceDependencies{Create: creates, Refresh: refresh})
+	target := ResolvedCreateTarget{
+		ProjectContext: store.ProjectContext{
+			Project: store.Project{ID: 7, Slug: "canonical"},
+			Role:    store.RoleMaintainer,
+		},
+		Mode: store.ModeFull,
+	}
+	prepared := service.Prepare(ctx, target)
+
+	target.ProjectContext.Project.ID = 99
+	target.ProjectContext.Project.Slug = "mutated"
+	target.ProjectContext.Role = store.RoleViewer
+	target.Mode = store.ModeAnonymous
+
+	result, err := prepared.Create(command)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(creates.calls) != 1 {
+		t.Fatalf("create calls = %d, want 1", len(creates.calls))
+	}
+	call := creates.calls[0]
+	if call.ctx != ctx || call.ctx.Value(key) != "bound" {
+		t.Fatalf("create context = %v, want prepared context", call.ctx)
+	}
+	if call.projectID != 7 || call.mode != store.ModeFull {
+		t.Fatalf("create target = project %d mode %q, want project 7 mode %q", call.projectID, call.mode, store.ModeFull)
+	}
+	if prepared.projectContext.Role != store.RoleMaintainer {
+		t.Fatalf("prepared role = %q, want %q", prepared.projectContext.Role, store.RoleMaintainer)
+	}
+	assertAdapterPreparedCreateInput(t, call.input, tags, estimation, assignee, sprint, afterTodoID, beforeTodoID)
+
+	tags[0] = "mutated"
+	estimation = 80
+	assignee = 420
+	sprint = 120
+	afterTodoID = 1040
+	beforeTodoID = 2090
+	if !reflect.DeepEqual(call.input.Tags, []string{"api", "urgent"}) ||
+		*call.input.EstimationPoints != 8 ||
+		*call.input.AssigneeUserID != 42 ||
+		*call.input.SprintID != 12 ||
+		*call.input.AfterID != 104 ||
+		*call.input.BeforeID != 209 {
+		t.Fatalf("store input changed after command mutation: %+v", call.input)
+	}
+
+	if result.Project.ID != 7 || result.Project.Slug != "canonical" || !reflect.DeepEqual(result.Todo, created) {
+		t.Fatalf("result = %+v, want copied project and created todo", result)
+	}
+	if len(refresh.calls) != 1 {
+		t.Fatalf("refresh calls = %d, want 1", len(refresh.calls))
+	}
+	if got := refresh.calls[0]; got.ctx != ctx || got.projectID != 7 || got.reason != RefreshReasonTodoCreated {
+		t.Fatalf("refresh call = %+v, want bound context, project 7, reason %q", got, RefreshReasonTodoCreated)
+	}
+	if !reflect.DeepEqual(trace, []string{"create", "refresh"}) {
+		t.Fatalf("call trace = %#v, want create then refresh", trace)
+	}
+}
+
+func TestCreateServiceAssignmentChangedSuppressesDirectRefreshDespiteNilRequestedAssignee(t *testing.T) {
+	created := store.Todo{ID: 81, ProjectID: 7, LocalID: 5, AssignmentChanged: true}
+	trace := []string{}
+	creates := &restCreateStoreFake{todo: created, trace: &trace}
+	refresh := &restCreateRefreshFake{trace: &trace}
+	prepared := NewCreateService(CreateServiceDependencies{Create: creates, Refresh: refresh}).Prepare(
+		context.Background(),
+		ResolvedCreateTarget{ProjectContext: store.ProjectContext{Project: store.Project{ID: 7}}, Mode: store.ModeFull},
+	)
+
+	result, err := prepared.Create(CreateCommand{Values: CreateValues{
+		Title:          "created",
+		ColumnKey:      "backlog",
+		AssigneeUserID: nil,
+	}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(creates.calls) != 1 {
+		t.Fatalf("create calls = %d, want 1", len(creates.calls))
+	}
+	if len(refresh.calls) != 0 {
+		t.Fatalf("direct refresh calls = %d, want 0 for AssignmentChanged", len(refresh.calls))
+	}
+	if !reflect.DeepEqual(trace, []string{"create"}) {
+		t.Fatalf("call trace = %#v, want only create", trace)
+	}
+	if result.Project.ID != 7 || !reflect.DeepEqual(result.Todo, created) {
+		t.Fatalf("result = %+v, want successful assigned create", result)
+	}
+}
+
+func TestCreateServiceStoreFailureReturnsSameErrorAndSkipsRefresh(t *testing.T) {
+	wantErr := errors.New("create failed")
+	trace := []string{}
+	creates := &restCreateStoreFake{err: wantErr, trace: &trace}
+	refresh := &restCreateRefreshFake{trace: &trace}
+	prepared := NewCreateService(CreateServiceDependencies{Create: creates, Refresh: refresh}).Prepare(
+		context.Background(),
+		ResolvedCreateTarget{ProjectContext: store.ProjectContext{Project: store.Project{ID: 7}}, Mode: store.ModeFull},
+	)
+
+	result, err := prepared.Create(CreateCommand{Values: CreateValues{Title: "created", ColumnKey: "backlog"}})
+	if err != wantErr {
+		t.Fatalf("Create error = %v, want identical error %v", err, wantErr)
+	}
+	if !reflect.DeepEqual(result, CreateResult{}) {
+		t.Fatalf("result = %+v, want zero value", result)
+	}
+	if len(creates.calls) != 1 {
+		t.Fatalf("create calls = %d, want 1", len(creates.calls))
+	}
+	if len(refresh.calls) != 0 {
+		t.Fatalf("refresh calls = %d, want 0", len(refresh.calls))
+	}
+	if !reflect.DeepEqual(trace, []string{"create"}) {
+		t.Fatalf("call trace = %#v, want only create", trace)
+	}
+}
+
+func TestCreateServiceCancellationAfterPreparationUsesBoundContext(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), key, "bound"))
+	trace := []string{}
+	creates := &restCreateStoreFake{trace: &trace}
+	refresh := &restCreateRefreshFake{trace: &trace}
+	prepared := NewCreateService(CreateServiceDependencies{Create: creates, Refresh: refresh}).Prepare(
+		ctx,
+		ResolvedCreateTarget{ProjectContext: store.ProjectContext{Project: store.Project{ID: 7}}, Mode: store.ModeFull},
+	)
+	cancel()
+
+	_, err := prepared.Create(CreateCommand{Values: CreateValues{Title: "created", ColumnKey: "backlog"}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Create error = %v, want context canceled", err)
+	}
+	if len(creates.calls) != 1 {
+		t.Fatalf("create calls = %d, want 1", len(creates.calls))
+	}
+	if got := creates.calls[0].ctx; got != ctx || got.Value(key) != "bound" || !errors.Is(got.Err(), context.Canceled) {
+		t.Fatalf("store context = %v, want bound cancelled context", got)
+	}
+	if len(refresh.calls) != 0 {
+		t.Fatalf("refresh calls = %d, want 0", len(refresh.calls))
+	}
+	if !reflect.DeepEqual(trace, []string{"create"}) {
+		t.Fatalf("call trace = %#v, want only create", trace)
+	}
+}
+
+func TestCreateServiceNilRefreshDependencyIsNoOp(t *testing.T) {
+	created := store.Todo{ID: 91, ProjectID: 7, LocalID: 6, AssignmentChanged: false}
+	creates := &restCreateStoreFake{todo: created}
+	prepared := NewCreateService(CreateServiceDependencies{Create: creates}).Prepare(
+		context.Background(),
+		ResolvedCreateTarget{ProjectContext: store.ProjectContext{Project: store.Project{ID: 7}}, Mode: store.ModeFull},
+	)
+
+	result, err := prepared.Create(CreateCommand{Values: CreateValues{Title: "created", ColumnKey: "backlog"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(creates.calls) != 1 {
+		t.Fatalf("create calls = %d, want 1", len(creates.calls))
+	}
+	if !reflect.DeepEqual(result.Todo, created) || result.Project.ID != 7 {
+		t.Fatalf("result = %+v, want successful create", result)
+	}
+}
+
+func assertAdapterPreparedCreateInput(
+	t *testing.T,
+	input store.CreateTodoInput,
+	wantTags []string,
+	wantEstimation int64,
+	wantAssignee int64,
+	wantSprint int64,
+	wantAfter int64,
+	wantBefore int64,
+) {
+	t.Helper()
+	if input.Title != "create title" || input.Body != "create body" || input.ColumnKey != "doing" {
+		t.Fatalf("scalar values = title %q body %q column %q", input.Title, input.Body, input.ColumnKey)
+	}
+	if !reflect.DeepEqual(input.Tags, wantTags) {
+		t.Fatalf("tags = %#v, want %#v", input.Tags, wantTags)
+	}
+	assertCreatePointerValue(t, "estimation", input.EstimationPoints, wantEstimation)
+	assertCreatePointerValue(t, "assignee", input.AssigneeUserID, wantAssignee)
+	assertCreatePointerValue(t, "sprint", input.SprintID, wantSprint)
+	assertCreatePointerValue(t, "after todo ID", input.AfterID, wantAfter)
+	assertCreatePointerValue(t, "before todo ID", input.BeforeID, wantBefore)
+
+	if len(input.Tags) > 0 && len(wantTags) > 0 && &input.Tags[0] == &wantTags[0] {
+		t.Fatal("materialized tags alias the adapter-prepared command")
+	}
+}

--- a/internal/httpapi/routing_board.go
+++ b/internal/httpapi/routing_board.go
@@ -344,23 +344,28 @@ func (s *Server) handleBoardTodoRoutes(w http.ResponseWriter, r *http.Request, r
 			columnKey = store.DefaultColumnBacklog
 		}
 
-		var afterID, beforeID *int64
+		position := todoapp.ResolvedCreatePosition{}
 		if in.Position != nil {
-			afterID = in.Position.AfterID
-			beforeID = in.Position.BeforeID
+			position.AfterTodoID = in.Position.AfterID
+			position.BeforeTodoID = in.Position.BeforeID
 		}
 
-		todo, err := s.store.CreateTodo(s.requestContext(r), project.ID, store.CreateTodoInput{
-			Title:            in.Title,
-			Body:             in.Body,
-			Tags:             in.Tags,
-			ColumnKey:        columnKey,
-			EstimationPoints: in.EstimationPoints,
-			SprintID:         in.SprintID,
-			AssigneeUserID:   in.AssigneeUserID,
-			AfterID:          afterID,
-			BeforeID:         beforeID,
-		}, s.storeMode())
+		prepared := s.todoCreates.Prepare(s.requestContext(r), todoapp.ResolvedCreateTarget{
+			ProjectContext: *pc,
+			Mode:           s.storeMode(),
+		})
+		result, err := prepared.Create(todoapp.CreateCommand{
+			Values: todoapp.CreateValues{
+				Title:            in.Title,
+				Body:             in.Body,
+				Tags:             in.Tags,
+				ColumnKey:        columnKey,
+				EstimationPoints: in.EstimationPoints,
+				AssigneeUserID:   in.AssigneeUserID,
+				SprintID:         in.SprintID,
+			},
+			Position: position,
+		})
 		if err != nil {
 			if errors.Is(err, store.ErrUnauthorized) {
 				writeError(w, http.StatusForbidden, "FORBIDDEN", "forbidden", nil)
@@ -369,10 +374,7 @@ func (s *Server) handleBoardTodoRoutes(w http.ResponseWriter, r *http.Request, r
 			writeStoreErr(w, err, true)
 			return true
 		}
-		if !todo.AssignmentChanged {
-			s.emitRefreshNeeded(s.requestContext(r), project.ID, "todo_created")
-		}
-		writeJSON(w, http.StatusCreated, todoToJSON(todo))
+		writeJSON(w, http.StatusCreated, todoToJSON(result.Todo))
 		return true
 	}
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -95,6 +95,7 @@ type Options struct {
 type Server struct {
 	store       storeAPI
 	boardReads  *boardapp.ReadService
+	todoCreates *todoapp.CreateService
 	todoMoves   *todoapp.MoveService
 	todoUpdates *todoapp.UpdateService
 
@@ -260,7 +261,6 @@ type storeAPI interface {
 	GetTagColor(ctx context.Context, userID int64, tagID int64) (*string, error)
 	DeleteTag(ctx context.Context, userID int64, tagID int64, isAnonymousBoard bool) error
 
-	CreateTodo(ctx context.Context, projectID int64, in store.CreateTodoInput, mode store.Mode) (store.Todo, error)
 	CreateSprint(ctx context.Context, projectID int64, name string, plannedStartAt, plannedEndAt time.Time) (store.Sprint, error)
 	ListSprints(ctx context.Context, projectID int64) ([]store.Sprint, error)
 	HasSprints(ctx context.Context, projectID int64) (bool, error)
@@ -279,6 +279,7 @@ type storeAPI interface {
 	MoveTodo(ctx context.Context, todoID int64, toColumnKey string, afterID, beforeID *int64, mode store.Mode) (store.Todo, error)
 	GetTodoByLocalID(ctx context.Context, projectID, localID int64, mode store.Mode) (store.Todo, error)
 	DeleteTodoByLocalID(ctx context.Context, projectID, localID int64, mode store.Mode) error
+	todoapp.CreateStore
 	todoapp.UpdateStore
 	todoapp.MoveStore
 	AddLink(ctx context.Context, projectID, fromLocalID, toLocalID int64, linkType string, mode store.Mode) error
@@ -579,6 +580,10 @@ func NewServer(st storeAPI, opts Options) *Server {
 	}
 	boardRefreshPublisher := todoapp.BoardRefreshPublisherFunc(func(ctx context.Context, projectID int64, reason string) {
 		server.emitRefreshNeeded(ctx, projectID, reason)
+	})
+	server.todoCreates = todoapp.NewCreateService(todoapp.CreateServiceDependencies{
+		Create:  st,
+		Refresh: boardRefreshPublisher,
 	})
 	server.todoMoves = todoapp.NewMoveService(todoapp.MoveServiceDependencies{
 		Move:    st,

--- a/internal/httpapi/todo_create_transport_contract_test.go
+++ b/internal/httpapi/todo_create_transport_contract_test.go
@@ -1,0 +1,499 @@
+package httpapi
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"scrumboy/internal/store"
+)
+
+func todoCreateRESTPayload(title string) map[string]any {
+	return map[string]any{
+		"title": title,
+		"body":  "created through REST",
+		"tags":  []string{"create-contract"},
+	}
+}
+
+func createTodoThroughREST(t *testing.T, client *http.Client, baseURL, slug string, payload map[string]any) todoJSON {
+	t.Helper()
+	var created todoJSON
+	resp, body := doJSON(t, client, http.MethodPost, baseURL+"/api/board/"+slug+"/todos", payload, &created)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("POST create status=%d body=%s", resp.StatusCode, body)
+	}
+	return created
+}
+
+func countTodoCreateAudits(t *testing.T, db *sql.DB, todoID int64) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM audit_events
+		WHERE action = 'todo_created' AND target_type = 'todo' AND target_id = ?
+	`, todoID).Scan(&count); err != nil {
+		t.Fatalf("count todo_created audits: %v", err)
+	}
+	return count
+}
+
+func countProjectTodoCreateAudits(t *testing.T, db *sql.DB, projectID int64) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM audit_events WHERE project_id = ? AND action = 'todo_created'`, projectID).Scan(&count); err != nil {
+		t.Fatalf("count project todo_created audits: %v", err)
+	}
+	return count
+}
+
+func countTodoCreateAssignmentRows(t *testing.T, db *sql.DB, todoID int64) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM todo_assignee_events WHERE todo_id = ?`, todoID).Scan(&count); err != nil {
+		t.Fatalf("count create assignment rows: %v", err)
+	}
+	return count
+}
+
+func countProjectTodos(t *testing.T, db *sql.DB, projectID int64) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM todos WHERE project_id = ?`, projectID).Scan(&count); err != nil {
+		t.Fatalf("count project todos: %v", err)
+	}
+	return count
+}
+
+func assertTodoCreateRESTEvents(t *testing.T, events []todoUpdateWireEvent, projectID int64, refreshReason string, wantAssigned int) {
+	t.Helper()
+	var refreshes, assigned []todoUpdateWireEvent
+	for _, event := range events {
+		switch event.Type {
+		case "refresh_needed":
+			refreshes = append(refreshes, event)
+		case "todo.assigned":
+			assigned = append(assigned, event)
+		default:
+			t.Fatalf("unexpected create event type; events=%+v", events)
+		}
+	}
+	if len(refreshes) != 1 || refreshes[0].ProjectID != projectID || refreshes[0].Reason != refreshReason {
+		t.Fatalf("create refresh mismatch: want one project=%d reason=%q, events=%+v", projectID, refreshReason, events)
+	}
+	if len(assigned) != wantAssigned {
+		t.Fatalf("create structured assignment count=%d want=%d; events=%+v", len(assigned), wantAssigned, events)
+	}
+	for _, event := range refreshes {
+		if refreshReason == "todo_assigned" && event.Reason == "todo_created" {
+			t.Fatalf("assigned create also emitted todo_created; events=%+v", events)
+		}
+	}
+}
+
+func createTodoCreateProject(t *testing.T, st *store.Store, ownerID int64, name string) (store.Project, context.Context) {
+	t.Helper()
+	ctx := store.WithUserID(context.Background(), ownerID)
+	project, err := st.CreateProject(ctx, name)
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	return project, ctx
+}
+
+func createTodoCreateFixture(t *testing.T, st *store.Store, ctx context.Context, projectID int64, title, columnKey string) store.Todo {
+	t.Helper()
+	todo, err := st.CreateTodo(ctx, projectID, store.CreateTodoInput{Title: title, ColumnKey: columnKey}, store.ModeFull)
+	if err != nil {
+		t.Fatalf("create todo fixture: %v", err)
+	}
+	return todo
+}
+
+func TestTodoCreateRESTRealtimeContracts(t *testing.T) {
+	t.Run("unassigned create emits exactly one todo_created refresh", func(t *testing.T) {
+		ts, db, cleanup := newTestHTTPServer(t, "full")
+		defer cleanup()
+		st := wireTodoUpdatePublisher(t, ts)
+		client := newCookieClient(t)
+		owner := bootstrapUserClient(t, client, ts.URL, "Owner", "rest-create-owner@example.com", "password123")
+		ownerID := int64(owner["id"].(float64))
+		project, _ := createTodoCreateProject(t, st, ownerID, "REST create refresh")
+		stream := subscribeTodoUpdateEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+
+		created := createTodoThroughREST(t, client, ts.URL, project.Slug, todoCreateRESTPayload("unassigned create"))
+		events := collectTodoUpdateEvents(t, stream)
+		assertTodoCreateRESTEvents(t, events, project.ID, "todo_created", 0)
+		if got := countTodoCreateAudits(t, db, created.ID); got != 1 {
+			t.Fatalf("todo_created audit count=%d want=1", got)
+		}
+		if got := countTodoCreateAssignmentRows(t, db, created.ID); got != 0 {
+			t.Fatalf("unassigned create ledger rows=%d want=0", got)
+		}
+	})
+
+	t.Run("assigned create emits one assigned refresh and one structured event", func(t *testing.T) {
+		ts, db, cleanup := newTestHTTPServer(t, "full")
+		defer cleanup()
+		st := wireTodoUpdatePublisher(t, ts)
+		client := newCookieClient(t)
+		owner := bootstrapUserClient(t, client, ts.URL, "Owner", "rest-create-assigned-owner@example.com", "password123")
+		ownerID := int64(owner["id"].(float64))
+		project, ownerCtx := createTodoCreateProject(t, st, ownerID, "REST assigned create")
+		assigneeID, _ := createUserAPI(t, client, ts.URL, "Assignee", "rest-create-assignee@example.com", "password123")
+		if err := st.AddProjectMember(ownerCtx, ownerID, project.ID, assigneeID, store.RoleViewer); err != nil {
+			t.Fatalf("add assignee: %v", err)
+		}
+		stream := subscribeTodoUpdateEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+
+		payload := todoCreateRESTPayload("assigned create")
+		payload["assigneeUserId"] = assigneeID
+		created := createTodoThroughREST(t, client, ts.URL, project.Slug, payload)
+		events := collectTodoUpdateEvents(t, stream)
+		assertTodoCreateRESTEvents(t, events, project.ID, "todo_assigned", 1)
+
+		var assigned todoUpdateWireEvent
+		for _, event := range events {
+			if event.Type == "todo.assigned" {
+				assigned = event
+			}
+		}
+		if assigned.ProjectSlug != project.Slug || assigned.Payload.TodoID != created.ID || assigned.Payload.AssigneeID != assigneeID || assigned.Payload.ActorUserID != ownerID {
+			t.Fatalf("assigned create payload mismatch: %+v", assigned)
+		}
+		if got := countTodoCreateAudits(t, db, created.ID); got != 1 {
+			t.Fatalf("assigned create audit count=%d want=1", got)
+		}
+		// Create currently publishes the assignment event but does not insert an
+		// initial todo_assignee_events ledger row. Characterize that distinction.
+		if got := countTodoCreateAssignmentRows(t, db, created.ID); got != 0 {
+			t.Fatalf("assigned create ledger rows=%d want=0", got)
+		}
+	})
+
+	t.Run("store validation failure is realtime silent", func(t *testing.T) {
+		ts, db, cleanup := newTestHTTPServer(t, "full")
+		defer cleanup()
+		st := wireTodoUpdatePublisher(t, ts)
+		client := newCookieClient(t)
+		owner := bootstrapUserClient(t, client, ts.URL, "Owner", "rest-create-failure-owner@example.com", "password123")
+		ownerID := int64(owner["id"].(float64))
+		project, _ := createTodoCreateProject(t, st, ownerID, "REST create failure")
+		stream := subscribeTodoUpdateEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+
+		var envelope apiErrorEnvelope
+		resp, body := doJSON(t, client, http.MethodPost, ts.URL+"/api/board/"+project.Slug+"/todos", todoCreateRESTPayload(""), &envelope)
+		if resp.StatusCode != http.StatusBadRequest || envelope.Error.Code != "VALIDATION_ERROR" {
+			t.Fatalf("invalid create status=%d envelope=%+v body=%s", resp.StatusCode, envelope, body)
+		}
+		if events := collectTodoUpdateEvents(t, stream); len(events) != 0 {
+			t.Fatalf("failed create emitted events: %+v", events)
+		}
+		if got := countProjectTodos(t, db, project.ID); got != 0 {
+			t.Fatalf("failed create persisted todos=%d", got)
+		}
+		if got := countProjectTodoCreateAudits(t, db, project.ID); got != 0 {
+			t.Fatalf("failed create audit count=%d", got)
+		}
+	})
+}
+
+func TestTodoCreateRESTPositionIdentityAndOrdering(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServer(t, "full")
+	defer cleanup()
+	st := wireTodoUpdatePublisher(t, ts)
+	client := newCookieClient(t)
+	owner := bootstrapUserClient(t, client, ts.URL, "Owner", "rest-create-position-owner@example.com", "password123")
+	ownerID := int64(owner["id"].(float64))
+
+	t.Run("route position uses internal todo IDs rather than project-local IDs", func(t *testing.T) {
+		foreign, foreignCtx := createTodoCreateProject(t, st, ownerID, "REST position foreign")
+		foreignTodo := createTodoCreateFixture(t, st, foreignCtx, foreign.ID, "foreign local one", store.DefaultColumnBacklog)
+		project, ctx := createTodoCreateProject(t, st, ownerID, "REST position identity")
+		anchor := createTodoCreateFixture(t, st, ctx, project.ID, "target local one", store.DefaultColumnBacklog)
+		if anchor.LocalID != foreignTodo.LocalID || anchor.ID == anchor.LocalID {
+			t.Fatalf("fixture must distinguish identity: target=%+v foreign=%+v", anchor, foreignTodo)
+		}
+
+		payload := todoCreateRESTPayload("local ID must not resolve")
+		payload["position"] = map[string]any{"afterId": anchor.LocalID}
+		var envelope apiErrorEnvelope
+		resp, body := doJSON(t, client, http.MethodPost, ts.URL+"/api/board/"+project.Slug+"/todos", payload, &envelope)
+		if resp.StatusCode != http.StatusNotFound || envelope.Error.Code != "NOT_FOUND" {
+			t.Fatalf("local-ID anchor status=%d envelope=%+v body=%s", resp.StatusCode, envelope, body)
+		}
+
+		payload = todoCreateRESTPayload("internal ID resolves")
+		payload["position"] = map[string]any{"afterId": anchor.ID}
+		created := createTodoThroughREST(t, client, ts.URL, project.Slug, payload)
+		if created.Rank <= anchor.Rank {
+			t.Fatalf("created rank=%d want after anchor rank=%d", created.Rank, anchor.Rank)
+		}
+
+		payload = todoCreateRESTPayload("foreign internal ID")
+		payload["position"] = map[string]any{"afterId": foreignTodo.ID}
+		resp, body = doJSON(t, client, http.MethodPost, ts.URL+"/api/board/"+project.Slug+"/todos", payload, &envelope)
+		if resp.StatusCode != http.StatusNotFound || envelope.Error.Code != "NOT_FOUND" {
+			t.Fatalf("foreign anchor status=%d envelope=%+v body=%s", resp.StatusCode, envelope, body)
+		}
+	})
+
+	t.Run("ordered and reversed two-anchor contracts", func(t *testing.T) {
+		project, ctx := createTodoCreateProject(t, st, ownerID, "REST position ordering")
+		after := createTodoCreateFixture(t, st, ctx, project.ID, "after", store.DefaultColumnBacklog)
+		before := createTodoCreateFixture(t, st, ctx, project.ID, "before", store.DefaultColumnBacklog)
+
+		payload := todoCreateRESTPayload("between")
+		payload["position"] = map[string]any{"afterId": after.ID, "beforeId": before.ID}
+		created := createTodoThroughREST(t, client, ts.URL, project.Slug, payload)
+		if created.Rank <= after.Rank || created.Rank >= before.Rank {
+			t.Fatalf("between rank=%d want %d < rank < %d", created.Rank, after.Rank, before.Rank)
+		}
+
+		payload = todoCreateRESTPayload("reversed")
+		payload["position"] = map[string]any{"afterId": before.ID, "beforeId": after.ID}
+		var envelope apiErrorEnvelope
+		resp, body := doJSON(t, client, http.MethodPost, ts.URL+"/api/board/"+project.Slug+"/todos", payload, &envelope)
+		if resp.StatusCode != http.StatusConflict || envelope.Error.Code != "CONFLICT" {
+			t.Fatalf("reversed anchors status=%d envelope=%+v body=%s", resp.StatusCode, envelope, body)
+		}
+	})
+
+	t.Run("wrong-column internal anchor is not found", func(t *testing.T) {
+		project, ctx := createTodoCreateProject(t, st, ownerID, "REST position column")
+		anchor := createTodoCreateFixture(t, st, ctx, project.ID, "doing anchor", store.DefaultColumnDoing)
+		payload := todoCreateRESTPayload("backlog target")
+		payload["position"] = map[string]any{"afterId": anchor.ID}
+		var envelope apiErrorEnvelope
+		resp, body := doJSON(t, client, http.MethodPost, ts.URL+"/api/board/"+project.Slug+"/todos", payload, &envelope)
+		if resp.StatusCode != http.StatusNotFound || envelope.Error.Code != "NOT_FOUND" {
+			t.Fatalf("wrong-column anchor status=%d envelope=%+v body=%s", resp.StatusCode, envelope, body)
+		}
+	})
+}
+
+func TestTodoCreateRESTAccessLaneRoleAndModeContracts(t *testing.T) {
+	t.Run("access precedes malformed JSON", func(t *testing.T) {
+		ts, db, cleanup := newTestHTTPServer(t, "full")
+		defer cleanup()
+		st := wireTodoUpdatePublisher(t, ts)
+		ownerClient := newCookieClient(t)
+		owner := bootstrapUserClient(t, ownerClient, ts.URL, "Owner", "rest-create-order-owner@example.com", "password123")
+		ownerID := int64(owner["id"].(float64))
+		project, ownerCtx := createTodoCreateProject(t, st, ownerID, "REST create access ordering")
+
+		assertNotFoundBeforeJSON := func(t *testing.T, client *http.Client, slug string) {
+			t.Helper()
+			req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/board/"+slug+"/todos", strings.NewReader("{"))
+			if err != nil {
+				t.Fatalf("new malformed request: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Scrumboy", "1")
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("malformed create request: %v", err)
+			}
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read malformed response: %v", err)
+			}
+			var envelope apiErrorEnvelope
+			if err := json.Unmarshal(body, &envelope); err != nil {
+				t.Fatalf("decode error body %q: %v", body, err)
+			}
+			if resp.StatusCode != http.StatusNotFound || envelope.Error.Code != "NOT_FOUND" {
+				t.Fatalf("status=%d envelope=%+v body=%s", resp.StatusCode, envelope, body)
+			}
+		}
+
+		assertNotFoundBeforeJSON(t, newCookieClient(t), project.Slug)
+		temporary, err := st.CreateAnonymousBoard(ownerCtx)
+		if err != nil {
+			t.Fatalf("create Temporary Board: %v", err)
+		}
+		if _, err := db.Exec(`UPDATE projects SET expires_at = ? WHERE id = ?`, time.Now().Add(-time.Hour).UnixMilli(), temporary.ID); err != nil {
+			t.Fatalf("expire Temporary Board: %v", err)
+		}
+		assertNotFoundBeforeJSON(t, ownerClient, temporary.Slug)
+		if got := countProjectTodos(t, db, project.ID); got != 0 {
+			t.Fatalf("access-ordering failures persisted todos=%d", got)
+		}
+	})
+
+	t.Run("lane normalization and projection", func(t *testing.T) {
+		ts, _, cleanup := newTestHTTPServer(t, "full")
+		defer cleanup()
+		st := wireTodoUpdatePublisher(t, ts)
+		client := newCookieClient(t)
+		owner := bootstrapUserClient(t, client, ts.URL, "Owner", "rest-create-lane-owner@example.com", "password123")
+		ownerID := int64(owner["id"].(float64))
+		project, ctx := createTodoCreateProject(t, st, ownerID, "REST create lanes")
+		custom, err := st.AddWorkflowColumn(ctx, project.ID, "Review")
+		if err != nil {
+			t.Fatalf("add custom lane: %v", err)
+		}
+
+		created := createTodoThroughREST(t, client, ts.URL, project.Slug, map[string]any{"title": "default lane"})
+		if created.ColumnKey != store.DefaultColumnBacklog || created.Status != "BACKLOG" || created.ProjectID != project.ID || created.LocalID != 1 {
+			t.Fatalf("default projection=%+v", created)
+		}
+
+		payload := todoCreateRESTPayload("column wins")
+		payload["columnKey"] = custom.Key
+		payload["status"] = "DONE"
+		created = createTodoThroughREST(t, client, ts.URL, project.Slug, payload)
+		if created.ColumnKey != custom.Key || created.DoneAt != nil {
+			t.Fatalf("column/status precedence projection=%+v", created)
+		}
+
+		payload = todoCreateRESTPayload("status fallback")
+		payload["status"] = "IN_PROGRESS"
+		created = createTodoThroughREST(t, client, ts.URL, project.Slug, payload)
+		if created.ColumnKey != store.DefaultColumnDoing {
+			t.Fatalf("status fallback projection=%+v", created)
+		}
+
+		payload = todoCreateRESTPayload("done projection")
+		payload["columnKey"] = "DONE"
+		created = createTodoThroughREST(t, client, ts.URL, project.Slug, payload)
+		if created.ColumnKey != store.DefaultColumnDone || created.DoneAt == nil {
+			t.Fatalf("done projection=%+v", created)
+		}
+	})
+
+	t.Run("durable roles", func(t *testing.T) {
+		ts, _, cleanup := newTestHTTPServer(t, "full")
+		defer cleanup()
+		st := wireTodoUpdatePublisher(t, ts)
+		ownerClient := newCookieClient(t)
+		owner := bootstrapUserClient(t, ownerClient, ts.URL, "Owner", "rest-create-role-owner@example.com", "password123")
+		ownerID := int64(owner["id"].(float64))
+		project, ctx := createTodoCreateProject(t, st, ownerID, "REST create roles")
+		maintainerID, maintainer := createUserAPI(t, ownerClient, ts.URL, "Maintainer", "rest-create-maintainer@example.com", "password123")
+		contributorID, contributor := createUserAPI(t, ownerClient, ts.URL, "Contributor", "rest-create-contributor@example.com", "password123")
+		viewerID, viewer := createUserAPI(t, ownerClient, ts.URL, "Viewer", "rest-create-viewer@example.com", "password123")
+		for id, role := range map[int64]store.ProjectRole{maintainerID: store.RoleMaintainer, contributorID: store.RoleContributor, viewerID: store.RoleViewer} {
+			if err := st.AddProjectMember(ctx, ownerID, project.ID, id, role); err != nil {
+				t.Fatalf("add member %d: %v", id, err)
+			}
+		}
+
+		created := createTodoThroughREST(t, maintainer, ts.URL, project.Slug, todoCreateRESTPayload("maintainer create"))
+		if created.Title != "maintainer create" {
+			t.Fatalf("maintainer result=%+v", created)
+		}
+		for name, blocked := range map[string]struct {
+			client     *http.Client
+			wantStatus int
+			wantCode   string
+		}{
+			"contributor": {client: contributor, wantStatus: http.StatusForbidden, wantCode: "FORBIDDEN"},
+			"viewer":      {client: viewer, wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND"},
+		} {
+			t.Run(name, func(t *testing.T) {
+				var envelope apiErrorEnvelope
+				resp, body := doJSON(t, blocked.client, http.MethodPost, ts.URL+"/api/board/"+project.Slug+"/todos", todoCreateRESTPayload(name+" blocked"), &envelope)
+				if resp.StatusCode != blocked.wantStatus || envelope.Error.Code != blocked.wantCode {
+					t.Fatalf("status=%d envelope=%+v body=%s", resp.StatusCode, envelope, body)
+				}
+			})
+		}
+	})
+
+	t.Run("Temporary Board link holder refreshes persisted activity", func(t *testing.T) {
+		ts, db, cleanup := newTestHTTPServer(t, "full")
+		defer cleanup()
+		st := wireTodoUpdatePublisher(t, ts)
+		ownerClient := newCookieClient(t)
+		owner := bootstrapUserClient(t, ownerClient, ts.URL, "Owner", "rest-create-temp-owner@example.com", "password123")
+		ownerID := int64(owner["id"].(float64))
+		_, outsider := createUserAPI(t, ownerClient, ts.URL, "Outsider", "rest-create-temp-outsider@example.com", "password123")
+		ctx := store.WithUserID(context.Background(), ownerID)
+		project, err := st.CreateAnonymousBoard(ctx)
+		if err != nil {
+			t.Fatalf("create Temporary Board: %v", err)
+		}
+		activityBefore := time.Now().UTC().Add(-6 * time.Minute).UnixMilli()
+		expiresBefore := time.Now().UTC().Add(24 * time.Hour).UnixMilli()
+		if _, err := db.Exec(`UPDATE projects SET last_activity_at = ?, expires_at = ? WHERE id = ?`, activityBefore, expiresBefore, project.ID); err != nil {
+			t.Fatalf("set activity baseline: %v", err)
+		}
+
+		created := createTodoThroughREST(t, outsider, ts.URL, project.Slug, todoCreateRESTPayload("Temporary link-holder create"))
+		if created.ProjectID != project.ID {
+			t.Fatalf("Temporary Board result=%+v", created)
+		}
+		var activityAfter, expiresAfter int64
+		if err := db.QueryRow(`SELECT last_activity_at, expires_at FROM projects WHERE id = ?`, project.ID).Scan(&activityAfter, &expiresAfter); err != nil {
+			t.Fatalf("read activity after create: %v", err)
+		}
+		if activityAfter <= activityBefore || expiresAfter <= expiresBefore {
+			t.Fatalf("create did not refresh activity: activity %d->%d expires %d->%d", activityBefore, activityAfter, expiresBefore, expiresAfter)
+		}
+	})
+
+	t.Run("Anonymous Board permits unassigned create and rejects assignment", func(t *testing.T) {
+		ts, _, cleanup := newTestHTTPServer(t, "anonymous")
+		defer cleanup()
+		st := wireTodoUpdatePublisher(t, ts)
+		project, err := st.CreateAnonymousBoard(context.Background())
+		if err != nil {
+			t.Fatalf("create Anonymous Board: %v", err)
+		}
+		created := createTodoThroughREST(t, ts.Client(), ts.URL, project.Slug, todoCreateRESTPayload("anonymous create"))
+		if created.AssigneeUserId != nil {
+			t.Fatalf("anonymous create assignee=%v", *created.AssigneeUserId)
+		}
+
+		payload := todoCreateRESTPayload("anonymous assigned")
+		payload["assigneeUserId"] = int64(1)
+		var envelope apiErrorEnvelope
+		resp, body := doJSON(t, ts.Client(), http.MethodPost, ts.URL+"/api/board/"+project.Slug+"/todos", payload, &envelope)
+		if resp.StatusCode != http.StatusBadRequest || envelope.Error.Code != "VALIDATION_ERROR" {
+			t.Fatalf("anonymous assignment status=%d envelope=%+v body=%s", resp.StatusCode, envelope, body)
+		}
+	})
+}
+
+func TestTodoCreateRESTResponseCarriesExistingFields(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServer(t, "full")
+	defer cleanup()
+	st := wireTodoUpdatePublisher(t, ts)
+	client := newCookieClient(t)
+	owner := bootstrapUserClient(t, client, ts.URL, "Owner", "rest-create-projection-owner@example.com", "password123")
+	ownerID := int64(owner["id"].(float64))
+	project, ctx := createTodoCreateProject(t, st, ownerID, "REST create projection")
+	now := time.Now().UTC()
+	sprint, err := st.CreateSprint(ctx, project.ID, "Create sprint", now, now.Add(7*24*time.Hour))
+	if err != nil {
+		t.Fatalf("create sprint: %v", err)
+	}
+	points := int64(5)
+	payload := map[string]any{
+		"title":            "  projected title  ",
+		"body":             "projected body",
+		"tags":             []string{"Alpha", "Beta"},
+		"columnKey":        "testing",
+		"estimationPoints": points,
+		"sprintId":         sprint.ID,
+	}
+	created := createTodoThroughREST(t, client, ts.URL, project.Slug, payload)
+	if created.Title != "projected title" || created.Body != "projected body" || created.ColumnKey != store.DefaultColumnTesting {
+		t.Fatalf("basic create projection=%+v", created)
+	}
+	if created.EstimationPoints == nil || *created.EstimationPoints != points || created.SprintId == nil || *created.SprintId != sprint.ID {
+		t.Fatalf("nullable create projection=%+v", created)
+	}
+	if fmt.Sprint(created.Tags) != "[alpha beta]" {
+		t.Fatalf("tag projection=%v want normalized tags", created.Tags)
+	}
+}

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -24,7 +24,7 @@ type storeAPI interface {
 	GetUserByOAuthAccessToken(ctx context.Context, rawToken, expectedResource string) (store.User, error)
 	ListProjects(ctx context.Context) ([]store.ProjectListEntry, error)
 	todoapp.MCPMoveAccessStore
-	CreateTodo(ctx context.Context, projectID int64, in store.CreateTodoInput, mode store.Mode) (store.Todo, error)
+	todoapp.CreateStore
 	todoapp.MCPMoveLookupStore
 	SearchTodosForLinkPicker(ctx context.Context, projectID int64, q string, limit int, excludeLocalIDs []int64, mode store.Mode) ([]store.TodoLinkTarget, error)
 	AddLink(ctx context.Context, projectID, fromLocalID, toLocalID int64, linkType string, mode store.Mode) error
@@ -91,6 +91,7 @@ type Options struct {
 type Adapter struct {
 	store        storeAPI
 	boardReads   *boardapp.MCPBoardReadService
+	todoCreates  *todoapp.MCPCreateService
 	todoMoves    *todoapp.MCPMoveService
 	todoUpdates  *todoapp.MCPUpdateService
 	mode         string
@@ -124,6 +125,11 @@ func New(st storeAPI, opts Options) *Adapter {
 			ReportActivityRefreshFailure: func(_ context.Context, projectID int64, err error) {
 				logger.Printf("mcp: board activity refresh failed project_id=%d: %v", projectID, err)
 			},
+		}),
+		todoCreates: todoapp.NewMCPCreateService(todoapp.MCPCreateServiceDependencies{
+			Access: st,
+			Lookup: st,
+			Create: st,
 		}),
 		todoMoves: todoapp.NewMCPMoveService(todoapp.MCPMoveServiceDependencies{
 			Access: st,

--- a/internal/mcp/todo_create_error_mapping_test.go
+++ b/internal/mcp/todo_create_error_mapping_test.go
@@ -48,6 +48,20 @@ func TestMapMCPCreateErrorPreservesLocalReferenceDetails(t *testing.T) {
 			wantDetails: map[string]any{"field": "afterLocalId", "localId": int64(41)},
 		},
 		{
+			name: "missing positive before reference includes local ID",
+			err: &todoapp.MCPCreateValidationError{
+				Kind:       todoapp.MCPCreateInvalidLocalReference,
+				Field:      "beforeLocalId",
+				LocalID:    42,
+				HasLocalID: true,
+			},
+			wantMessage: "invalid local todo reference",
+			wantDetails: map[string]any{
+				"field":   "beforeLocalId",
+				"localId": int64(42),
+			},
+		},
+		{
 			name: "wrong-column reference includes local ID",
 			err: &todoapp.MCPCreateValidationError{
 				Kind:       todoapp.MCPCreateReferenceInWrongColumn,

--- a/internal/mcp/todo_create_error_mapping_test.go
+++ b/internal/mcp/todo_create_error_mapping_test.go
@@ -1,0 +1,84 @@
+package mcp
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	todoapp "scrumboy/internal/application/todo"
+	"scrumboy/internal/store"
+)
+
+func TestMapMCPCreateErrorPreservesLocalReferenceDetails(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantMessage string
+		wantDetails map[string]any
+	}{
+		{
+			name: "nonpositive after reference omits local ID",
+			err: &todoapp.MCPCreateValidationError{
+				Kind:    todoapp.MCPCreateInvalidLocalReference,
+				Field:   "afterLocalId",
+				LocalID: -7,
+			},
+			wantMessage: "invalid local todo reference",
+			wantDetails: map[string]any{"field": "afterLocalId"},
+		},
+		{
+			name: "nonpositive before reference omits local ID",
+			err: &todoapp.MCPCreateValidationError{
+				Kind:    todoapp.MCPCreateInvalidLocalReference,
+				Field:   "beforeLocalId",
+				LocalID: 0,
+			},
+			wantMessage: "invalid local todo reference",
+			wantDetails: map[string]any{"field": "beforeLocalId"},
+		},
+		{
+			name: "missing positive reference includes local ID",
+			err: &todoapp.MCPCreateValidationError{
+				Kind:       todoapp.MCPCreateInvalidLocalReference,
+				Field:      "afterLocalId",
+				LocalID:    41,
+				HasLocalID: true,
+			},
+			wantMessage: "invalid local todo reference",
+			wantDetails: map[string]any{"field": "afterLocalId", "localId": int64(41)},
+		},
+		{
+			name: "wrong-column reference includes local ID",
+			err: &todoapp.MCPCreateValidationError{
+				Kind:       todoapp.MCPCreateReferenceInWrongColumn,
+				Field:      "beforeLocalId",
+				LocalID:    17,
+				HasLocalID: true,
+			},
+			wantMessage: "position reference must be in target column",
+			wantDetails: map[string]any{"field": "beforeLocalId", "localId": int64(17)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapMCPCreateError(tt.err)
+			if got.Status != http.StatusBadRequest || got.Code != CodeValidationError || got.Message != tt.wantMessage {
+				t.Fatalf("mapMCPCreateError() = status %d code %q message %q, want %d %q %q", got.Status, got.Code, got.Message, http.StatusBadRequest, CodeValidationError, tt.wantMessage)
+			}
+			if !reflect.DeepEqual(got.Details, tt.wantDetails) {
+				t.Fatalf("mapMCPCreateError() details = %#v, want %#v", got.Details, tt.wantDetails)
+			}
+		})
+	}
+}
+
+func TestMapMCPCreateErrorPreservesPrivilegedAuthorizationMapping(t *testing.T) {
+	got := mapMCPCreateError(store.ErrUnauthorized)
+	if got.Status != http.StatusForbidden || got.Code != CodeForbidden || got.Message != "forbidden" {
+		t.Fatalf("mapMCPCreateError(ErrUnauthorized) = status %d code %q message %q, want %d %q %q", got.Status, got.Code, got.Message, http.StatusForbidden, CodeForbidden, "forbidden")
+	}
+	if got.Details != nil {
+		t.Fatalf("mapMCPCreateError(ErrUnauthorized) details = %#v, want nil", got.Details)
+	}
+}

--- a/internal/mcp/todo_create_transport_contract_test.go
+++ b/internal/mcp/todo_create_transport_contract_test.go
@@ -1,0 +1,630 @@
+package mcp_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"scrumboy/internal/store"
+)
+
+func todoCreateMCPArgs(projectSlug, title string) map[string]any {
+	return map[string]any{
+		"projectSlug": projectSlug,
+		"title":       title,
+		"body":        "created through MCP",
+		"tags":        []string{"create-contract"},
+	}
+}
+
+func callTodoCreateMCP(t *testing.T, client *http.Client, baseURL, transport, tool string, args map[string]any) (*http.Response, map[string]any) {
+	t.Helper()
+	return callTodoUpdateMCP(t, client, baseURL, transport, tool, args)
+}
+
+func assertTodoCreateMCPSuccess(t *testing.T, transport string, response map[string]any, projectSlug string, localID int64) map[string]any {
+	t.Helper()
+	todo := assertTodoUpdateMCPSuccess(t, transport, response, projectSlug, localID)
+	if _, ok := todo["id"]; ok {
+		t.Fatalf("MCP create exposed global todo id: %+v", todo)
+	}
+	return todo
+}
+
+func createTodoCreateMCPProject(t *testing.T, st *store.Store, ownerID int64, name string) (store.Project, context.Context) {
+	t.Helper()
+	ctx := store.WithUserID(context.Background(), ownerID)
+	project, err := st.CreateProject(ctx, name)
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	return project, ctx
+}
+
+func createTodoCreateMCPFixture(t *testing.T, st *store.Store, ctx context.Context, projectID int64, title, columnKey string) store.Todo {
+	t.Helper()
+	todo, err := st.CreateTodo(ctx, projectID, store.CreateTodoInput{Title: title, ColumnKey: columnKey}, store.ModeFull)
+	if err != nil {
+		t.Fatalf("create todo fixture: %v", err)
+	}
+	return todo
+}
+
+func todoCreateMCPAuditCount(t *testing.T, db *sql.DB, todoID int64) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM audit_events
+		WHERE action = 'todo_created' AND target_type = 'todo' AND target_id = ?
+	`, todoID).Scan(&count); err != nil {
+		t.Fatalf("count MCP todo_created audits: %v", err)
+	}
+	return count
+}
+
+func todoCreateMCPProjectAuditCount(t *testing.T, db *sql.DB, projectID int64) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM audit_events WHERE project_id = ? AND action = 'todo_created'`, projectID).Scan(&count); err != nil {
+		t.Fatalf("count MCP project create audits: %v", err)
+	}
+	return count
+}
+
+func todoCreateMCPAssignmentCount(t *testing.T, db *sql.DB, todoID int64) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM todo_assignee_events WHERE todo_id = ?`, todoID).Scan(&count); err != nil {
+		t.Fatalf("count MCP create assignment rows: %v", err)
+	}
+	return count
+}
+
+func assertTodoCreateMCPLegacyError(t *testing.T, response map[string]any, wantCode, wantMessage string) map[string]any {
+	t.Helper()
+	if got, want := sortedMapKeys(response), []string{"error", "ok"}; !reflect.DeepEqual(got, want) || response["ok"] != false {
+		t.Fatalf("legacy error envelope=%+v keys=%v want=%v", response, got, want)
+	}
+	errorBody := response["error"].(map[string]any)
+	if errorBody["code"] != wantCode || errorBody["message"] != wantMessage {
+		t.Fatalf("legacy error=%+v want code=%q message=%q", errorBody, wantCode, wantMessage)
+	}
+	return errorBody
+}
+
+func assertTodoCreateMCPJSONRPCError(t *testing.T, response map[string]any, wantCode, wantMessage string) map[string]any {
+	t.Helper()
+	if got, want := sortedMapKeys(response), []string{"id", "jsonrpc", "result"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("JSON-RPC error envelope keys=%v want=%v response=%+v", got, want, response)
+	}
+	result := response["result"].(map[string]any)
+	if got, want := sortedMapKeys(result), []string{"content", "isError", "structuredContent"}; !reflect.DeepEqual(got, want) || result["isError"] != true {
+		t.Fatalf("JSON-RPC tool error result=%+v", result)
+	}
+	structured := result["structuredContent"].(map[string]any)
+	if structured["code"] != wantCode || structured["message"] != wantMessage {
+		t.Fatalf("JSON-RPC structured error=%+v want code=%q message=%q", structured, wantCode, wantMessage)
+	}
+	content := result["content"].([]any)
+	if len(content) != 1 || content[0].(map[string]any)["text"] != wantMessage {
+		t.Fatalf("JSON-RPC text error=%+v want=%q", content, wantMessage)
+	}
+	return structured
+}
+
+func TestTodoCreateMCPTransportAliasMatrix(t *testing.T) {
+	ts, db, st, cleanup := newTodoUpdateMCPServer(t, "full")
+	defer cleanup()
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	ownerID := firstUserID(t, db)
+
+	for index, tc := range []struct {
+		tool      string
+		transport string
+	}{
+		{tool: "todos_create", transport: "legacy"},
+		{tool: "todos.create", transport: "legacy"},
+		{tool: "todos_create", transport: "jsonrpc"},
+		{tool: "todos.create", transport: "jsonrpc"},
+	} {
+		t.Run(tc.transport+"/"+tc.tool, func(t *testing.T) {
+			project, ctx := createTodoCreateMCPProject(t, st, ownerID, "MCP create matrix "+tc.transport+" "+tc.tool)
+			title := "created by " + tc.tool
+			resp, out := callTodoCreateMCP(t, client, ts.URL, tc.transport, tc.tool, todoCreateMCPArgs(project.Slug, title))
+			if tc.transport == "legacy" && resp.StatusCode != http.StatusOK {
+				t.Fatalf("legacy status=%d response=%+v", resp.StatusCode, out)
+			}
+			if tc.transport == "jsonrpc" && resp.StatusCode != http.StatusOK {
+				t.Fatalf("JSON-RPC status=%d response=%+v", resp.StatusCode, out)
+			}
+			returned := assertTodoCreateMCPSuccess(t, tc.transport, out, project.Slug, 1)
+			if returned["title"] != title || returned["columnKey"] != store.DefaultColumnBacklog {
+				t.Fatalf("matrix result=%+v", returned)
+			}
+			persisted, err := st.GetTodoByLocalID(ctx, project.ID, 1, store.ModeFull)
+			if err != nil {
+				t.Fatalf("read created todo: %v", err)
+			}
+			if persisted.Title != title || todoCreateMCPAuditCount(t, db, persisted.ID) != 1 {
+				t.Fatalf("matrix persistence=%+v audits=%d index=%d", persisted, todoCreateMCPAuditCount(t, db, persisted.ID), index)
+			}
+		})
+	}
+
+	t.Run("JSON-RPC dotted alias preserves tool-error envelope", func(t *testing.T) {
+		resp, out := callTodoCreateMCP(t, client, ts.URL, "jsonrpc", "todos.create", todoCreateMCPArgs("missing-project", "never created"))
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("JSON-RPC tool error HTTP status=%d", resp.StatusCode)
+		}
+		assertTodoCreateMCPJSONRPCError(t, out, "NOT_FOUND", "not found")
+	})
+}
+
+func TestTodoCreateMCPRealtimeContracts(t *testing.T) {
+	ts, db, st, cleanup := newTodoUpdateMCPServer(t, "full")
+	defer cleanup()
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	ownerID := firstUserID(t, db)
+	project, ownerCtx := createTodoCreateMCPProject(t, st, ownerID, "MCP create realtime")
+	stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+	defer stream.close()
+
+	t.Run("unassigned create is realtime silent", func(t *testing.T) {
+		resp, out := callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", todoCreateMCPArgs(project.Slug, "MCP unassigned create"))
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPSuccess(t, "legacy", out, project.Slug, 1)
+		persisted, err := st.GetTodoByLocalID(ownerCtx, project.ID, 1, store.ModeFull)
+		if err != nil {
+			t.Fatalf("read unassigned create: %v", err)
+		}
+		if todoCreateMCPAuditCount(t, db, persisted.ID) != 1 || todoCreateMCPAssignmentCount(t, db, persisted.ID) != 0 {
+			t.Fatalf("unassigned effects audits=%d ledger=%d", todoCreateMCPAuditCount(t, db, persisted.ID), todoCreateMCPAssignmentCount(t, db, persisted.ID))
+		}
+		assertNoTodoUpdateMCPEvents(t, collectTodoUpdateMCPEvents(t, stream))
+	})
+
+	t.Run("assigned create uses the production store callback exactly once", func(t *testing.T) {
+		assignee, err := st.CreateUser(context.Background(), "mcp-create-assignee@example.com", "password123", "Assignee")
+		if err != nil {
+			t.Fatalf("create assignee: %v", err)
+		}
+		if err := st.AddProjectMember(ownerCtx, ownerID, project.ID, assignee.ID, store.RoleViewer); err != nil {
+			t.Fatalf("add assignee: %v", err)
+		}
+		args := todoCreateMCPArgs(project.Slug, "MCP assigned create")
+		args["assigneeUserId"] = assignee.ID
+		resp, out := callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", args)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPSuccess(t, "legacy", out, project.Slug, 2)
+		persisted, err := st.GetTodoByLocalID(ownerCtx, project.ID, 2, store.ModeFull)
+		if err != nil {
+			t.Fatalf("read assigned create: %v", err)
+		}
+		events := collectTodoUpdateMCPEvents(t, stream)
+		assertTodoUpdateMCPAssignmentEvents(t, events, project, persisted, assignee.ID, ownerID)
+		for _, event := range events {
+			if event.Type == "refresh_needed" && event.Reason == "todo_created" {
+				t.Fatalf("assigned MCP create emitted todo_created: %+v", events)
+			}
+		}
+		if todoCreateMCPAuditCount(t, db, persisted.ID) != 1 {
+			t.Fatalf("assigned create audit count=%d", todoCreateMCPAuditCount(t, db, persisted.ID))
+		}
+		// The current create path publishes an assignment event but does not
+		// create an initial todo_assignee_events ledger row.
+		if todoCreateMCPAssignmentCount(t, db, persisted.ID) != 0 {
+			t.Fatalf("assigned create ledger count=%d want=0", todoCreateMCPAssignmentCount(t, db, persisted.ID))
+		}
+	})
+
+	t.Run("store validation failure is realtime silent", func(t *testing.T) {
+		auditsBefore := todoCreateMCPProjectAuditCount(t, db, project.ID)
+		resp, out := callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", todoCreateMCPArgs(project.Slug, ""))
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPLegacyError(t, out, "VALIDATION_ERROR", "validation: invalid title")
+		assertNoTodoUpdateMCPEvents(t, collectTodoUpdateMCPEvents(t, stream))
+		if after := todoCreateMCPProjectAuditCount(t, db, project.ID); after != auditsBefore {
+			t.Fatalf("failed create audits %d->%d", auditsBefore, after)
+		}
+	})
+}
+
+func TestTodoCreateMCPPositionContracts(t *testing.T) {
+	ts, db, st, cleanup := newTodoUpdateMCPServer(t, "full")
+	defer cleanup()
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	ownerID := firstUserID(t, db)
+
+	t.Run("after local ID resolves in target project", func(t *testing.T) {
+		project, ctx := createTodoCreateMCPProject(t, st, ownerID, "MCP create after")
+		_ = createTodoCreateMCPFixture(t, st, ctx, project.ID, "first", store.DefaultColumnBacklog)
+		anchor := createTodoCreateMCPFixture(t, st, ctx, project.ID, "last", store.DefaultColumnBacklog)
+		args := todoCreateMCPArgs(project.Slug, "after last")
+		args["position"] = map[string]any{"afterLocalId": anchor.LocalID}
+		resp, out := callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", args)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPSuccess(t, "legacy", out, project.Slug, 3)
+		persisted, err := st.GetTodoByLocalID(ctx, project.ID, 3, store.ModeFull)
+		if err != nil {
+			t.Fatalf("read after-position create: %v", err)
+		}
+		if persisted.Rank <= anchor.Rank {
+			t.Fatalf("after rank=%d anchor=%d", persisted.Rank, anchor.Rank)
+		}
+	})
+
+	t.Run("before local ID resolves in target project", func(t *testing.T) {
+		project, ctx := createTodoCreateMCPProject(t, st, ownerID, "MCP create before")
+		anchor := createTodoCreateMCPFixture(t, st, ctx, project.ID, "first", store.DefaultColumnBacklog)
+		args := todoCreateMCPArgs(project.Slug, "before first")
+		args["position"] = map[string]any{"beforeLocalId": anchor.LocalID}
+		resp, out := callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", args)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPSuccess(t, "legacy", out, project.Slug, 2)
+		persisted, err := st.GetTodoByLocalID(ctx, project.ID, 2, store.ModeFull)
+		if err != nil {
+			t.Fatalf("read before-position create: %v", err)
+		}
+		if persisted.Rank >= anchor.Rank {
+			t.Fatalf("before rank=%d anchor=%d", persisted.Rank, anchor.Rank)
+		}
+	})
+
+	t.Run("two local anchors preserve order and reversed anchors conflict", func(t *testing.T) {
+		project, ctx := createTodoCreateMCPProject(t, st, ownerID, "MCP create two anchors")
+		after := createTodoCreateMCPFixture(t, st, ctx, project.ID, "after", store.DefaultColumnBacklog)
+		before := createTodoCreateMCPFixture(t, st, ctx, project.ID, "before", store.DefaultColumnBacklog)
+		args := todoCreateMCPArgs(project.Slug, "between")
+		args["position"] = map[string]any{"afterLocalId": after.LocalID, "beforeLocalId": before.LocalID}
+		resp, out := callTodoCreateMCP(t, client, ts.URL, "jsonrpc", "todos_create", args)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPSuccess(t, "jsonrpc", out, project.Slug, 3)
+		persisted, err := st.GetTodoByLocalID(ctx, project.ID, 3, store.ModeFull)
+		if err != nil {
+			t.Fatalf("read two-anchor create: %v", err)
+		}
+		if persisted.Rank <= after.Rank || persisted.Rank >= before.Rank {
+			t.Fatalf("between rank=%d want %d < rank < %d", persisted.Rank, after.Rank, before.Rank)
+		}
+
+		args = todoCreateMCPArgs(project.Slug, "reversed")
+		args["position"] = map[string]any{"afterLocalId": before.LocalID, "beforeLocalId": after.LocalID}
+		resp, out = callTodoCreateMCP(t, client, ts.URL, "jsonrpc", "todos.create", args)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("JSON-RPC error HTTP status=%d", resp.StatusCode)
+		}
+		structured := assertTodoCreateMCPJSONRPCError(t, out, "CONFLICT", "conflict: afterId must come before beforeId")
+		if _, ok := structured["status"]; ok {
+			t.Fatalf("JSON-RPC error exposed HTTP status: %+v", structured)
+		}
+	})
+
+	t.Run("local anchor resolution is scoped to the target project", func(t *testing.T) {
+		foreign, foreignCtx := createTodoCreateMCPProject(t, st, ownerID, "MCP create foreign anchor")
+		_ = createTodoCreateMCPFixture(t, st, foreignCtx, foreign.ID, "foreign one", store.DefaultColumnBacklog)
+		foreignTwo := createTodoCreateMCPFixture(t, st, foreignCtx, foreign.ID, "foreign two", store.DefaultColumnBacklog)
+		project, ctx := createTodoCreateMCPProject(t, st, ownerID, "MCP create target anchor")
+		_ = createTodoCreateMCPFixture(t, st, ctx, project.ID, "target one", store.DefaultColumnBacklog)
+
+		args := todoCreateMCPArgs(project.Slug, "must not use foreign local ID")
+		args["position"] = map[string]any{"afterLocalId": foreignTwo.LocalID}
+		resp, out := callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", args)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		errorBody := assertTodoCreateMCPLegacyError(t, out, "VALIDATION_ERROR", "invalid local todo reference")
+		details := errorBody["details"].(map[string]any)
+		if details["field"] != "afterLocalId" || int64(details["localId"].(float64)) != foreignTwo.LocalID {
+			t.Fatalf("target-scoped error details=%+v", details)
+		}
+	})
+
+	t.Run("wrong column and after-before lookup precedence", func(t *testing.T) {
+		project, ctx := createTodoCreateMCPProject(t, st, ownerID, "MCP create invalid anchors")
+		doing := createTodoCreateMCPFixture(t, st, ctx, project.ID, "doing", store.DefaultColumnDoing)
+		args := todoCreateMCPArgs(project.Slug, "wrong column")
+		args["position"] = map[string]any{"afterLocalId": doing.LocalID}
+		resp, out := callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", args)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		errorBody := assertTodoCreateMCPLegacyError(t, out, "VALIDATION_ERROR", "position reference must be in target column")
+		if errorBody["details"].(map[string]any)["field"] != "afterLocalId" {
+			t.Fatalf("wrong-column details=%+v", errorBody)
+		}
+
+		args = todoCreateMCPArgs(project.Slug, "nonpositive anchor")
+		args["position"] = map[string]any{"afterLocalId": int64(0)}
+		resp, out = callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", args)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		errorBody = assertTodoCreateMCPLegacyError(t, out, "VALIDATION_ERROR", "invalid local todo reference")
+		details := errorBody["details"].(map[string]any)
+		if details["field"] != "afterLocalId" {
+			t.Fatalf("nonpositive-anchor details=%+v", details)
+		}
+		if _, ok := details["localId"]; ok {
+			t.Fatalf("nonpositive-anchor unexpectedly includes localId: %+v", details)
+		}
+
+		args = todoCreateMCPArgs(project.Slug, "after fails first")
+		args["position"] = map[string]any{"afterLocalId": int64(999), "beforeLocalId": int64(0)}
+		resp, out = callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", args)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		errorBody = assertTodoCreateMCPLegacyError(t, out, "VALIDATION_ERROR", "invalid local todo reference")
+		details = errorBody["details"].(map[string]any)
+		if details["field"] != "afterLocalId" || int64(details["localId"].(float64)) != 999 {
+			t.Fatalf("lookup precedence details=%+v", details)
+		}
+	})
+}
+
+func TestTodoCreateMCPPrecedenceRoleAndModeContracts(t *testing.T) {
+	t.Run("authentication envelope access and anchor precedence", func(t *testing.T) {
+		ts, db, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		defer cleanup()
+		client := newCookieClient(t, ts)
+		bootstrapUser(t, client, ts.URL)
+		ownerID := firstUserID(t, db)
+		project, _ := createTodoCreateMCPProject(t, st, ownerID, "MCP create precedence")
+
+		resp, out := callTodoCreateMCP(t, newStatelessClient(ts), ts.URL, "legacy", "todos_create", todoCreateMCPArgs(project.Slug, "never"))
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("auth status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPLegacyError(t, out, "AUTH_REQUIRED", "Sign-in required for this tool")
+
+		resp, out = callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", map[string]any{})
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("envelope status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPLegacyError(t, out, "VALIDATION_ERROR", "missing projectSlug")
+
+		// JSON-RPC applies the catalog's required title before dispatch. The
+		// legacy /mcp endpoint has no equivalent schema gate and reaches slug
+		// access with an empty decoded title.
+		resp, out = callTodoCreateMCP(t, client, ts.URL, "jsonrpc", "todos_create", map[string]any{"projectSlug": "missing-project"})
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("JSON-RPC validation HTTP status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPJSONRPCError(t, out, "VALIDATION_ERROR", "missing required field: title")
+
+		resp, out = callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", map[string]any{"projectSlug": "missing-project"})
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("legacy missing-title/access status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPLegacyError(t, out, "NOT_FOUND", "not found")
+
+		args := todoCreateMCPArgs("missing-project", "access first")
+		args["columnKey"] = "DONE"
+		args["position"] = map[string]any{"afterLocalId": int64(0)}
+		resp, out = callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", args)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("access status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPLegacyError(t, out, "NOT_FOUND", "not found")
+
+		temporary, err := st.CreateAnonymousBoard(store.WithUserID(context.Background(), ownerID))
+		if err != nil {
+			t.Fatalf("create Temporary Board: %v", err)
+		}
+		if _, err := db.Exec(`UPDATE projects SET expires_at = ? WHERE id = ?`, time.Now().Add(-time.Hour).UnixMilli(), temporary.ID); err != nil {
+			t.Fatalf("expire Temporary Board: %v", err)
+		}
+		args = todoCreateMCPArgs(temporary.Slug, "expired access first")
+		args["position"] = map[string]any{"afterLocalId": int64(0)}
+		resp, out = callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", args)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expired access status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPLegacyError(t, out, "NOT_FOUND", "not found")
+
+		args = todoCreateMCPArgs(project.Slug, "")
+		args["position"] = map[string]any{"afterLocalId": int64(999)}
+		resp, out = callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", args)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("anchor/store status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPLegacyError(t, out, "VALIDATION_ERROR", "invalid local todo reference")
+
+		resp, out = callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", todoCreateMCPArgs(project.Slug, ""))
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("store validation status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPLegacyError(t, out, "VALIDATION_ERROR", "validation: invalid title")
+		if got := todoCreateMCPProjectAuditCount(t, db, project.ID); got != 0 {
+			t.Fatalf("precedence failures created audits=%d", got)
+		}
+	})
+
+	t.Run("durable roles", func(t *testing.T) {
+		ts, db, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		defer cleanup()
+		ownerClient := newCookieClient(t, ts)
+		bootstrapUser(t, ownerClient, ts.URL)
+		ownerID := firstUserID(t, db)
+		project, ownerCtx := createTodoCreateMCPProject(t, st, ownerID, "MCP create roles")
+		maintainer, err := st.CreateUser(context.Background(), "mcp-create-maintainer@example.com", "password123", "Maintainer")
+		if err != nil {
+			t.Fatalf("create maintainer: %v", err)
+		}
+		contributor, err := st.CreateUser(context.Background(), "mcp-create-contributor@example.com", "password123", "Contributor")
+		if err != nil {
+			t.Fatalf("create contributor: %v", err)
+		}
+		viewer, err := st.CreateUser(context.Background(), "mcp-create-viewer@example.com", "password123", "Viewer")
+		if err != nil {
+			t.Fatalf("create viewer: %v", err)
+		}
+		for id, role := range map[int64]store.ProjectRole{maintainer.ID: store.RoleMaintainer, contributor.ID: store.RoleContributor, viewer.ID: store.RoleViewer} {
+			if err := st.AddProjectMember(ownerCtx, ownerID, project.ID, id, role); err != nil {
+				t.Fatalf("add member %d: %v", id, err)
+			}
+		}
+		maintainerClient := loginTodoUpdateMCPUser(t, ts, maintainer.Email, "password123")
+		contributorClient := loginTodoUpdateMCPUser(t, ts, contributor.Email, "password123")
+		viewerClient := loginTodoUpdateMCPUser(t, ts, viewer.Email, "password123")
+
+		resp, out := callTodoCreateMCP(t, maintainerClient, ts.URL, "legacy", "todos_create", todoCreateMCPArgs(project.Slug, "maintainer create"))
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("maintainer status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPSuccess(t, "legacy", out, project.Slug, 1)
+
+		for name, blocked := range map[string]struct {
+			client     *http.Client
+			wantStatus int
+			wantCode   string
+		}{
+			"contributor": {client: contributorClient, wantStatus: http.StatusForbidden, wantCode: "FORBIDDEN"},
+			"viewer":      {client: viewerClient, wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND"},
+		} {
+			t.Run(name, func(t *testing.T) {
+				resp, out := callTodoCreateMCP(t, blocked.client, ts.URL, "legacy", "todos_create", todoCreateMCPArgs(project.Slug, name+" blocked"))
+				if resp.StatusCode != blocked.wantStatus {
+					t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+				}
+				message := "forbidden"
+				if blocked.wantCode == "NOT_FOUND" {
+					message = "not found"
+				}
+				assertTodoCreateMCPLegacyError(t, out, blocked.wantCode, message)
+			})
+		}
+	})
+
+	t.Run("active Temporary Board authenticated link holder", func(t *testing.T) {
+		ts, db, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		defer cleanup()
+		ownerClient := newCookieClient(t, ts)
+		bootstrapUser(t, ownerClient, ts.URL)
+		ownerID := firstUserID(t, db)
+		outsider, err := st.CreateUser(context.Background(), "mcp-create-temp-outsider@example.com", "password123", "Outsider")
+		if err != nil {
+			t.Fatalf("create outsider: %v", err)
+		}
+		outsiderClient := loginTodoUpdateMCPUser(t, ts, outsider.Email, "password123")
+		project, err := st.CreateAnonymousBoard(store.WithUserID(context.Background(), ownerID))
+		if err != nil {
+			t.Fatalf("create Temporary Board: %v", err)
+		}
+		resp, out := callTodoCreateMCP(t, outsiderClient, ts.URL, "legacy", "todos_create", todoCreateMCPArgs(project.Slug, "Temporary link-holder create"))
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("Temporary Board status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPSuccess(t, "legacy", out, project.Slug, 1)
+	})
+
+	t.Run("Anonymous Mode capability precedes input", func(t *testing.T) {
+		ts, _, _, cleanup := newTodoUpdateMCPServer(t, "anonymous")
+		defer cleanup()
+		resp, out := callTodoCreateMCP(t, newStatelessClient(ts), ts.URL, "legacy", "todos_create", map[string]any{})
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoCreateMCPLegacyError(t, out, "CAPABILITY_UNAVAILABLE", "todos_create is unavailable in anonymous mode")
+	})
+}
+
+func TestTodoCreateMCPLaneAndFieldProjectionContracts(t *testing.T) {
+	ts, db, st, cleanup := newTodoUpdateMCPServer(t, "full")
+	defer cleanup()
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	ownerID := firstUserID(t, db)
+	project, ctx := createTodoCreateMCPProject(t, st, ownerID, "MCP create lane projection")
+	custom, err := st.AddWorkflowColumn(ctx, project.ID, "Review")
+	if err != nil {
+		t.Fatalf("add custom lane: %v", err)
+	}
+	now := time.Now().UTC()
+	sprint, err := st.CreateSprint(ctx, project.ID, "MCP create sprint", now, now.Add(7*24*time.Hour))
+	if err != nil {
+		t.Fatalf("create sprint: %v", err)
+	}
+
+	resp, out := callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", map[string]any{
+		"projectSlug": project.Slug,
+		"title":       "default lane",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("default status=%d response=%+v", resp.StatusCode, out)
+	}
+	created := assertTodoCreateMCPSuccess(t, "legacy", out, project.Slug, 1)
+	if created["columnKey"] != store.DefaultColumnBacklog {
+		t.Fatalf("default lane result=%+v", created)
+	}
+
+	points := int64(8)
+	args := map[string]any{
+		"projectSlug":      project.Slug,
+		"title":            "  projected title  ",
+		"body":             "projected body",
+		"tags":             []string{"Alpha", "Beta"},
+		"columnKey":        custom.Key,
+		"estimationPoints": points,
+		"sprintId":         sprint.ID,
+	}
+	resp, out = callTodoCreateMCP(t, client, ts.URL, "jsonrpc", "todos_create", args)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("custom status=%d response=%+v", resp.StatusCode, out)
+	}
+	created = assertTodoCreateMCPSuccess(t, "jsonrpc", out, project.Slug, 2)
+	if created["title"] != "projected title" || created["body"] != "projected body" || created["columnKey"] != custom.Key {
+		t.Fatalf("field projection=%+v", created)
+	}
+	if int64(created["estimationPoints"].(float64)) != points || int64(created["sprintId"].(float64)) != sprint.ID {
+		t.Fatalf("nullable field projection=%+v", created)
+	}
+	tags := created["tags"].([]any)
+	encodedTags, _ := json.Marshal(tags)
+	if string(encodedTags) != `["alpha","beta"]` {
+		t.Fatalf("tag projection=%s", encodedTags)
+	}
+
+	args = todoCreateMCPArgs(project.Slug, "done projection")
+	args["columnKey"] = "DONE"
+	resp, out = callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", args)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("done status=%d response=%+v", resp.StatusCode, out)
+	}
+	created = assertTodoCreateMCPSuccess(t, "legacy", out, project.Slug, 3)
+	if created["columnKey"] != store.DefaultColumnDone || created["doneAt"] == nil {
+		t.Fatalf("done projection=%+v", created)
+	}
+
+	args = todoCreateMCPArgs("missing-project", "unknown status")
+	args["status"] = "DONE"
+	resp, out = callTodoCreateMCP(t, client, ts.URL, "legacy", "todos_create", args)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("unknown status field=%d response=%+v", resp.StatusCode, out)
+	}
+	errorBody := assertTodoCreateMCPLegacyError(t, out, "VALIDATION_ERROR", "invalid input")
+	if !strings.Contains(errorBody["details"].(map[string]any)["detail"].(string), "unknown field") {
+		t.Fatalf("unknown status details=%+v", errorBody)
+	}
+}

--- a/internal/mcp/todos_tools.go
+++ b/internal/mcp/todos_tools.go
@@ -80,9 +80,12 @@ func (a *Adapter) handleTodosCreate(ctx context.Context, input any) (any, map[st
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "missing projectSlug", map[string]any{"field": "projectSlug"})
 	}
 
-	pc, pcErr := a.store.GetProjectContextBySlug(ctx, in.ProjectSlug, a.storeMode())
-	if pcErr != nil {
-		return nil, nil, mapStoreError(pcErr)
+	prepared, prepareErr := a.todoCreates.Prepare(ctx, todoapp.SlugCreateTarget{
+		Slug: in.ProjectSlug,
+		Mode: a.storeMode(),
+	})
+	if prepareErr != nil {
+		return nil, nil, mapStoreError(prepareErr)
 	}
 
 	columnKey := normalizeColumnKey(in.ColumnKey)
@@ -90,32 +93,54 @@ func (a *Adapter) handleTodosCreate(ctx context.Context, input any) (any, map[st
 		columnKey = store.DefaultColumnBacklog
 	}
 
-	afterID, beforeID, posErr := a.resolvePositionIDs(ctx, pc.Project.ID, in.Position, a.storeMode(), columnKey)
-	if posErr != nil {
-		return nil, nil, posErr
+	command := todoapp.MCPCreateCommand{
+		Values: todoapp.CreateValues{
+			Title:            in.Title,
+			Body:             in.Body,
+			Tags:             in.Tags,
+			ColumnKey:        columnKey,
+			EstimationPoints: in.EstimationPoints,
+			AssigneeUserID:   in.AssigneeUserId,
+			SprintID:         in.SprintId,
+		},
+	}
+	if in.Position != nil {
+		command.AfterLocalID = in.Position.AfterLocalId
+		command.BeforeLocalID = in.Position.BeforeLocalId
 	}
 
-	todo, createErr := a.store.CreateTodo(ctx, pc.Project.ID, store.CreateTodoInput{
-		Title:            in.Title,
-		Body:             in.Body,
-		Tags:             in.Tags,
-		ColumnKey:        columnKey,
-		EstimationPoints: in.EstimationPoints,
-		SprintID:         in.SprintId,
-		AssigneeUserID:   in.AssigneeUserId,
-		AfterID:          afterID,
-		BeforeID:         beforeID,
-	}, a.storeMode())
+	result, createErr := prepared.Create(command)
 	if createErr != nil {
-		if errors.Is(createErr, store.ErrUnauthorized) {
-			return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "forbidden", nil)
-		}
-		return nil, nil, mapStoreError(createErr)
+		return nil, nil, mapMCPCreateError(createErr)
 	}
 
 	return map[string]any{
-		"todo": todoToItem(in.ProjectSlug, todo),
+		"todo": todoToItem(in.ProjectSlug, result.Todo),
 	}, map[string]any{}, nil
+}
+
+func mapMCPCreateError(err error) *adapterError {
+	var validationErr *todoapp.MCPCreateValidationError
+	if errors.As(err, &validationErr) {
+		details := map[string]any{}
+		if validationErr.Field != "" {
+			details["field"] = validationErr.Field
+		}
+		if validationErr.HasLocalID {
+			details["localId"] = validationErr.LocalID
+		}
+
+		switch validationErr.Kind {
+		case todoapp.MCPCreateInvalidLocalReference:
+			return newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid local todo reference", details)
+		case todoapp.MCPCreateReferenceInWrongColumn:
+			return newAdapterError(http.StatusBadRequest, CodeValidationError, "position reference must be in target column", details)
+		}
+	}
+	if errors.Is(err, store.ErrUnauthorized) {
+		return newAdapterError(http.StatusForbidden, CodeForbidden, "forbidden", nil)
+	}
+	return mapStoreError(err)
 }
 
 func (a *Adapter) handleTodosGet(ctx context.Context, input any) (any, map[string]any, *adapterError) {
@@ -528,58 +553,6 @@ func buildUpdatePatch(patchRaw json.RawMessage) (todoapp.UpdatePatch, *adapterEr
 
 func isNullJSON(v json.RawMessage) bool {
 	return strings.TrimSpace(string(v)) == "null"
-}
-
-func (a *Adapter) resolvePositionIDs(ctx context.Context, projectID int64, position *struct {
-	AfterLocalId  *int64 `json:"afterLocalId"`
-	BeforeLocalId *int64 `json:"beforeLocalId"`
-}, mode store.Mode, columnKey string) (*int64, *int64, *adapterError) {
-	if position == nil {
-		return nil, nil, nil
-	}
-
-	afterTodo, err := a.resolveLocalTodoForColumn(ctx, projectID, position.AfterLocalId, "afterLocalId", mode, columnKey)
-	if err != nil {
-		return nil, nil, err
-	}
-	beforeTodo, err := a.resolveLocalTodoForColumn(ctx, projectID, position.BeforeLocalId, "beforeLocalId", mode, columnKey)
-	if err != nil {
-		return nil, nil, err
-	}
-	var afterID, beforeID *int64
-	if afterTodo != nil {
-		id := afterTodo.ID
-		afterID = &id
-	}
-	if beforeTodo != nil {
-		id := beforeTodo.ID
-		beforeID = &id
-	}
-	return afterID, beforeID, nil
-}
-
-func (a *Adapter) resolveLocalTodoForColumn(ctx context.Context, projectID int64, localID *int64, field string, mode store.Mode, targetColumnKey string) (*store.Todo, *adapterError) {
-	if localID == nil {
-		return nil, nil
-	}
-	if *localID <= 0 {
-		return nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid local todo reference", map[string]any{"field": field})
-	}
-
-	todo, err := a.store.GetTodoByLocalID(ctx, projectID, *localID, mode)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			return nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid local todo reference", map[string]any{"field": field, "localId": *localID})
-		}
-		if errors.Is(err, store.ErrUnauthorized) {
-			return nil, newAdapterError(http.StatusForbidden, CodeForbidden, "forbidden", nil)
-		}
-		return nil, mapStoreError(err)
-	}
-	if todo.ColumnKey != targetColumnKey {
-		return nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "position reference must be in target column", map[string]any{"field": field, "localId": *localID})
-	}
-	return &todo, nil
 }
 
 func todoToItem(projectSlug string, todo store.Todo) todoItem {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.29.2"
+const Version = "3.29.3"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
Route REST and MCP todo creates through a shared application service: Same write-side pattern as update/move: contract-test first, then a transport-neutral create boundary, prepared REST/MCP services, and thin adapters - behavior preserved.