### PR TITLE
Refactor/workflow column mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.29.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags), **3.29.0** (MCP JSON-RPC error/`board_get` identity) - see those releases.
 
+## [3.29.4] - 2026-08-02
+
+### Changed
+
+- **Workflow column mutations move behind application services** - REST and
+  MCP workflow column create, update, and delete now share
+  `internal/application/workflow` command boundaries instead of owning write
+  logic in the transports. HTTP and MCP adapters stay thin wrappers;
+  permissions, validation, response shapes, and REST board-refresh side
+  effects are preserved. Contract tests lock the migrated mutation paths.
+
 ## [3.29.3] - 2026-08-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.29.3-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.29.4-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/internal/application/workflow/mcp_mutation.go
+++ b/internal/application/workflow/mcp_mutation.go
@@ -10,12 +10,18 @@ import (
 
 var ErrWorkflowProjectionFailed = errors.New("workflow mutation projection failed")
 
+// ErrWorkflowProjectionColumnMissing identifies the internal inconsistency in
+// which a successful update is absent from the workflow returned immediately
+// afterward. It also satisfies ErrWorkflowProjectionFailed.
+var ErrWorkflowProjectionColumnMissing = errors.New("updated workflow column missing from projection")
+
 // workflowProjectionError marks failures that occur after a successful MCP
-// update mutation. Its cause remains available for diagnostics while adapters
-// must map the projection classification to an internal error.
+// update mutation. Its cause remains available so adapters can preserve their
+// established read-error mapping while distinguishing projection inconsistencies.
 type workflowProjectionError struct {
-	message string
-	cause   error
+	message        string
+	cause          error
+	classification error
 }
 
 func (e *workflowProjectionError) Error() string {
@@ -30,7 +36,7 @@ func (e *workflowProjectionError) Unwrap() error {
 }
 
 func (e *workflowProjectionError) Is(target error) bool {
-	return target == ErrWorkflowProjectionFailed
+	return target == ErrWorkflowProjectionFailed || target == e.classification
 }
 
 // MCPMutationAccessStore resolves the project-slug access boundary used by MCP
@@ -138,7 +144,8 @@ func (p *PreparedMCPMutation) Update(command UpdateCommand) (store.WorkflowColum
 		}
 	}
 	return store.WorkflowColumn{}, &workflowProjectionError{
-		message: fmt.Sprintf("updated workflow column %q not found in post-read", command.Key),
+		message:        fmt.Sprintf("updated workflow column %q not found in post-read", command.Key),
+		classification: ErrWorkflowProjectionColumnMissing,
 	}
 }
 

--- a/internal/application/workflow/mcp_mutation.go
+++ b/internal/application/workflow/mcp_mutation.go
@@ -1,0 +1,149 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"scrumboy/internal/store"
+)
+
+var ErrWorkflowProjectionFailed = errors.New("workflow mutation projection failed")
+
+// workflowProjectionError marks failures that occur after a successful MCP
+// update mutation. Its cause remains available for diagnostics while adapters
+// must map the projection classification to an internal error.
+type workflowProjectionError struct {
+	message string
+	cause   error
+}
+
+func (e *workflowProjectionError) Error() string {
+	if e.cause != nil {
+		return fmt.Sprintf("%s: %v", e.message, e.cause)
+	}
+	return e.message
+}
+
+func (e *workflowProjectionError) Unwrap() error {
+	return e.cause
+}
+
+func (e *workflowProjectionError) Is(target error) bool {
+	return target == ErrWorkflowProjectionFailed
+}
+
+// MCPMutationAccessStore resolves the project-slug access boundary used by MCP
+// workflow mutations.
+type MCPMutationAccessStore interface {
+	GetProjectContextBySlug(
+		ctx context.Context,
+		slug string,
+		mode store.Mode,
+	) (store.ProjectContext, error)
+}
+
+type MCPMutationServiceDependencies struct {
+	Access    MCPMutationAccessStore
+	Mutations MutationStore
+	Workflow  WorkflowReadStore
+}
+
+// MCPMutationService owns MCP project access, role authorization, workflow
+// persistence, and update post-read projection. It deliberately has no refresh
+// or event dependency.
+type MCPMutationService struct {
+	access    MCPMutationAccessStore
+	mutations MutationStore
+	workflow  WorkflowReadStore
+}
+
+func NewMCPMutationService(deps MCPMutationServiceDependencies) *MCPMutationService {
+	return &MCPMutationService{
+		access:    deps.Access,
+		mutations: deps.Mutations,
+		workflow:  deps.Workflow,
+	}
+}
+
+// MCPMutationTarget identifies the slug whose access must be resolved after
+// transport authentication, capability checks, and semantic validation.
+type MCPMutationTarget struct {
+	ProjectSlug string
+	Mode        store.Mode
+}
+
+// PreparedMCPMutation binds the exact access context and resolved project ID to
+// subsequent workflow mutations.
+type PreparedMCPMutation struct {
+	ctx       context.Context
+	service   *MCPMutationService
+	projectID int64
+}
+
+// Prepare resolves slug access exactly once and authorizes from the role in the
+// returned ProjectContext. Unlike REST, MCP performs no second role lookup.
+func (s *MCPMutationService) Prepare(
+	ctx context.Context,
+	target MCPMutationTarget,
+) (*PreparedMCPMutation, error) {
+	projectContext, err := s.access.GetProjectContextBySlug(ctx, target.ProjectSlug, target.Mode)
+	if err != nil {
+		return nil, err
+	}
+	if !projectContext.Role.HasMinimumRole(store.RoleMaintainer) {
+		return nil, ErrMaintainerRequired
+	}
+	return &PreparedMCPMutation{
+		ctx:       ctx,
+		service:   s,
+		projectID: projectContext.Project.ID,
+	}, nil
+}
+
+// Create persists one adapter-prepared command and returns the created column
+// without performing a projection read or publishing realtime events.
+func (p *PreparedMCPMutation) Create(command CreateCommand) (store.WorkflowColumn, error) {
+	column, err := p.service.mutations.AddWorkflowColumn(p.ctx, p.projectID, command.Name)
+	if err != nil {
+		return store.WorkflowColumn{}, err
+	}
+	return column, nil
+}
+
+// Update persists before reading the workflow used by MCP response projection.
+// Post-write read and lookup failures are classified separately while retaining
+// any underlying store cause.
+func (p *PreparedMCPMutation) Update(command UpdateCommand) (store.WorkflowColumn, error) {
+	if err := p.service.mutations.UpdateWorkflowColumn(
+		p.ctx,
+		p.projectID,
+		command.Key,
+		command.Name,
+		command.Color,
+	); err != nil {
+		return store.WorkflowColumn{}, err
+	}
+
+	workflow, err := p.service.workflow.GetProjectWorkflow(p.ctx, p.projectID)
+	if err != nil {
+		return store.WorkflowColumn{}, &workflowProjectionError{
+			message: "read updated workflow",
+			cause:   err,
+		}
+	}
+	for _, column := range workflow {
+		if column.Key == command.Key {
+			return column, nil
+		}
+	}
+	return store.WorkflowColumn{}, &workflowProjectionError{
+		message: fmt.Sprintf("updated workflow column %q not found in post-read", command.Key),
+	}
+}
+
+// Delete persists one adapter-prepared command without a projection read or
+// realtime publication.
+func (p *PreparedMCPMutation) Delete(command DeleteCommand) error {
+	return p.service.mutations.DeleteWorkflowColumn(p.ctx, p.projectID, command.Key)
+}

--- a/internal/application/workflow/mcp_mutation_test.go
+++ b/internal/application/workflow/mcp_mutation_test.go
@@ -1,0 +1,481 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+var _ MCPMutationAccessStore = (*store.Store)(nil)
+
+type mcpMutationTestContextKey struct{}
+
+type mcpMutationAccessCall struct {
+	ctx  context.Context
+	slug string
+	mode store.Mode
+}
+
+type mcpMutationStoreCall struct {
+	operation string
+	ctx       context.Context
+	projectID int64
+	key       string
+	name      string
+	color     string
+}
+
+type mcpMutationReadCall struct {
+	ctx       context.Context
+	projectID int64
+}
+
+type mcpMutationFake struct {
+	trace []string
+
+	accessCalls    []mcpMutationAccessCall
+	projectContext store.ProjectContext
+	accessErr      error
+
+	mutationCalls   []mcpMutationStoreCall
+	createResult    store.WorkflowColumn
+	createErr       error
+	updateErr       error
+	deleteErr       error
+	honorContextErr bool
+
+	readCalls []mcpMutationReadCall
+	workflow  []store.WorkflowColumn
+	readErr   error
+}
+
+func (f *mcpMutationFake) GetProjectContextBySlug(
+	ctx context.Context,
+	slug string,
+	mode store.Mode,
+) (store.ProjectContext, error) {
+	f.trace = append(f.trace, "access")
+	f.accessCalls = append(f.accessCalls, mcpMutationAccessCall{ctx: ctx, slug: slug, mode: mode})
+	if f.accessErr != nil {
+		return store.ProjectContext{}, f.accessErr
+	}
+	return f.projectContext, nil
+}
+
+func (f *mcpMutationFake) AddWorkflowColumn(
+	ctx context.Context,
+	projectID int64,
+	name string,
+) (store.WorkflowColumn, error) {
+	f.trace = append(f.trace, "create")
+	f.mutationCalls = append(f.mutationCalls, mcpMutationStoreCall{
+		operation: "create",
+		ctx:       ctx,
+		projectID: projectID,
+		name:      name,
+	})
+	if f.honorContextErr && ctx.Err() != nil {
+		return store.WorkflowColumn{}, ctx.Err()
+	}
+	return f.createResult, f.createErr
+}
+
+func (f *mcpMutationFake) UpdateWorkflowColumn(
+	ctx context.Context,
+	projectID int64,
+	key string,
+	name string,
+	color string,
+) error {
+	f.trace = append(f.trace, "update")
+	f.mutationCalls = append(f.mutationCalls, mcpMutationStoreCall{
+		operation: "update",
+		ctx:       ctx,
+		projectID: projectID,
+		key:       key,
+		name:      name,
+		color:     color,
+	})
+	if f.honorContextErr && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return f.updateErr
+}
+
+func (f *mcpMutationFake) DeleteWorkflowColumn(
+	ctx context.Context,
+	projectID int64,
+	key string,
+) error {
+	f.trace = append(f.trace, "delete")
+	f.mutationCalls = append(f.mutationCalls, mcpMutationStoreCall{
+		operation: "delete",
+		ctx:       ctx,
+		projectID: projectID,
+		key:       key,
+	})
+	if f.honorContextErr && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return f.deleteErr
+}
+
+func (f *mcpMutationFake) GetProjectWorkflow(
+	ctx context.Context,
+	projectID int64,
+) ([]store.WorkflowColumn, error) {
+	f.trace = append(f.trace, "read")
+	f.readCalls = append(f.readCalls, mcpMutationReadCall{ctx: ctx, projectID: projectID})
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	return f.workflow, nil
+}
+
+func newMCPMutationTestService(f *mcpMutationFake) *MCPMutationService {
+	return NewMCPMutationService(MCPMutationServiceDependencies{
+		Access:    f,
+		Mutations: f,
+		Workflow:  f,
+	})
+}
+
+func mcpMutationContext(marker string) context.Context {
+	return context.WithValue(context.Background(), mcpMutationTestContextKey{}, marker)
+}
+
+func assertMCPMutationTrace(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("call trace=%v want=%v", got, want)
+	}
+}
+
+func TestMCPMutationPrepareAccessAndRole(t *testing.T) {
+	accessFailure := errors.New("access failed")
+	tests := []struct {
+		name         string
+		role         store.ProjectRole
+		accessErr    error
+		wantErr      error
+		wantPrepared bool
+	}{
+		{name: "access failure", accessErr: accessFailure, wantErr: accessFailure},
+		{name: "contributor", role: store.RoleContributor, wantErr: ErrMaintainerRequired},
+		{name: "viewer", role: store.RoleViewer, wantErr: ErrMaintainerRequired},
+		{name: "maintainer", role: store.RoleMaintainer, wantPrepared: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &mcpMutationFake{
+				projectContext: store.ProjectContext{
+					Project: store.Project{ID: 71},
+					Role:    tt.role,
+				},
+				accessErr: tt.accessErr,
+			}
+			service := newMCPMutationTestService(fake)
+			ctx := mcpMutationContext(tt.name)
+
+			prepared, err := service.Prepare(ctx, MCPMutationTarget{
+				ProjectSlug: "  requested-slug  ",
+				Mode:        store.ModeFull,
+			})
+			if err != tt.wantErr {
+				t.Fatalf("Prepare error=%v want=%v", err, tt.wantErr)
+			}
+			if (prepared != nil) != tt.wantPrepared {
+				t.Fatalf("prepared=%v wantPresent=%v", prepared, tt.wantPrepared)
+			}
+			if len(fake.accessCalls) != 1 {
+				t.Fatalf("access calls=%d want=1", len(fake.accessCalls))
+			}
+			call := fake.accessCalls[0]
+			if call.ctx != ctx || call.slug != "  requested-slug  " || call.mode != store.ModeFull {
+				t.Fatalf("access call=%+v", call)
+			}
+			if got := call.ctx.Value(mcpMutationTestContextKey{}); got != tt.name {
+				t.Fatalf("context marker=%v want=%q", got, tt.name)
+			}
+			if len(fake.mutationCalls) != 0 || len(fake.readCalls) != 0 {
+				t.Fatalf("preparation caused work: mutations=%+v reads=%+v", fake.mutationCalls, fake.readCalls)
+			}
+			assertMCPMutationTrace(t, fake.trace, "access")
+		})
+	}
+}
+
+func TestPreparedMCPMutationBindsContextAndResolvedProjectID(t *testing.T) {
+	fake := &mcpMutationFake{
+		projectContext: store.ProjectContext{
+			Project: store.Project{ID: 101},
+			Role:    store.RoleMaintainer,
+		},
+	}
+	service := newMCPMutationTestService(fake)
+	ctx := mcpMutationContext("bound")
+	target := MCPMutationTarget{ProjectSlug: "project", Mode: store.ModeFull}
+	prepared, err := service.Prepare(ctx, target)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	target.ProjectSlug = "replacement"
+	target.Mode = store.ModeAnonymous
+	fake.projectContext.Project.ID = 202
+
+	if err := prepared.Delete(DeleteCommand{Key: "  review  "}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(fake.mutationCalls) != 1 {
+		t.Fatalf("mutation calls=%d want=1", len(fake.mutationCalls))
+	}
+	call := fake.mutationCalls[0]
+	if call.operation != "delete" || call.ctx != ctx || call.projectID != 101 || call.key != "  review  " {
+		t.Fatalf("delete call=%+v", call)
+	}
+	if got := call.ctx.Value(mcpMutationTestContextKey{}); got != "bound" {
+		t.Fatalf("context marker=%v want=bound", got)
+	}
+	if len(fake.readCalls) != 0 {
+		t.Fatalf("read calls=%+v want none", fake.readCalls)
+	}
+	assertMCPMutationTrace(t, fake.trace, "access", "delete")
+}
+
+func TestPreparedMCPMutationCreate(t *testing.T) {
+	mutationFailure := errors.New("create failed")
+	wantColumn := store.WorkflowColumn{ID: 3, ProjectID: 31, Key: "review", Name: "Review", Color: "#123456", Position: 4}
+
+	t.Run("success", func(t *testing.T) {
+		fake := &mcpMutationFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 31}, Role: store.RoleMaintainer},
+			createResult:   wantColumn,
+		}
+		prepared, err := newMCPMutationTestService(fake).Prepare(
+			mcpMutationContext("create"),
+			MCPMutationTarget{ProjectSlug: "project", Mode: store.ModeFull},
+		)
+		if err != nil {
+			t.Fatalf("Prepare: %v", err)
+		}
+
+		got, err := prepared.Create(CreateCommand{Name: "  Review  "})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if got != wantColumn {
+			t.Fatalf("column=%+v want=%+v", got, wantColumn)
+		}
+		if len(fake.mutationCalls) != 1 || fake.mutationCalls[0].name != "  Review  " {
+			t.Fatalf("mutation calls=%+v", fake.mutationCalls)
+		}
+		if len(fake.readCalls) != 0 {
+			t.Fatalf("read calls=%+v want none", fake.readCalls)
+		}
+		assertMCPMutationTrace(t, fake.trace, "access", "create")
+	})
+
+	t.Run("mutation failure", func(t *testing.T) {
+		fake := &mcpMutationFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 32}, Role: store.RoleMaintainer},
+			createErr:      mutationFailure,
+		}
+		prepared, err := newMCPMutationTestService(fake).Prepare(
+			mcpMutationContext("create failure"),
+			MCPMutationTarget{ProjectSlug: "project", Mode: store.ModeFull},
+		)
+		if err != nil {
+			t.Fatalf("Prepare: %v", err)
+		}
+
+		got, err := prepared.Create(CreateCommand{Name: "Review"})
+		if err != mutationFailure {
+			t.Fatalf("Create error=%v want=%v", err, mutationFailure)
+		}
+		if got != (store.WorkflowColumn{}) {
+			t.Fatalf("column=%+v want zero", got)
+		}
+		if len(fake.mutationCalls) != 1 || len(fake.readCalls) != 0 {
+			t.Fatalf("mutations=%+v reads=%+v", fake.mutationCalls, fake.readCalls)
+		}
+		assertMCPMutationTrace(t, fake.trace, "access", "create")
+	})
+}
+
+func TestPreparedMCPMutationUpdate(t *testing.T) {
+	command := UpdateCommand{
+		Key:   "  review  ",
+		Name:  "  Ready for review  ",
+		Color: "  #A1B2C3  ",
+	}
+
+	t.Run("success mutates before projection read", func(t *testing.T) {
+		want := store.WorkflowColumn{ID: 9, ProjectID: 41, Key: command.Key, Name: "Ready", Color: "#A1B2C3", Position: 2}
+		fake := &mcpMutationFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 41}, Role: store.RoleMaintainer},
+			workflow: []store.WorkflowColumn{
+				{ID: 8, ProjectID: 41, Key: "other"},
+				want,
+			},
+		}
+		ctx := mcpMutationContext("update")
+		prepared, err := newMCPMutationTestService(fake).Prepare(
+			ctx,
+			MCPMutationTarget{ProjectSlug: "project", Mode: store.ModeFull},
+		)
+		if err != nil {
+			t.Fatalf("Prepare: %v", err)
+		}
+
+		got, err := prepared.Update(command)
+		if err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+		if got != want {
+			t.Fatalf("column=%+v want=%+v", got, want)
+		}
+		if len(fake.mutationCalls) != 1 {
+			t.Fatalf("update calls=%d want=1", len(fake.mutationCalls))
+		}
+		call := fake.mutationCalls[0]
+		if call.operation != "update" || call.ctx != ctx || call.projectID != 41 ||
+			call.key != command.Key || call.name != command.Name || call.color != command.Color {
+			t.Fatalf("update call=%+v", call)
+		}
+		if len(fake.readCalls) != 1 || fake.readCalls[0].ctx != ctx || fake.readCalls[0].projectID != 41 {
+			t.Fatalf("read calls=%+v", fake.readCalls)
+		}
+		assertMCPMutationTrace(t, fake.trace, "access", "update", "read")
+	})
+
+	t.Run("mutation failure skips read", func(t *testing.T) {
+		mutationFailure := errors.New("update failed")
+		fake := &mcpMutationFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 42}, Role: store.RoleMaintainer},
+			updateErr:      mutationFailure,
+		}
+		prepared, err := newMCPMutationTestService(fake).Prepare(
+			mcpMutationContext("update failure"),
+			MCPMutationTarget{ProjectSlug: "project", Mode: store.ModeFull},
+		)
+		if err != nil {
+			t.Fatalf("Prepare: %v", err)
+		}
+
+		got, err := prepared.Update(command)
+		if err != mutationFailure {
+			t.Fatalf("Update error=%v want=%v", err, mutationFailure)
+		}
+		if got != (store.WorkflowColumn{}) || len(fake.mutationCalls) != 1 || len(fake.readCalls) != 0 {
+			t.Fatalf("column=%+v mutations=%+v reads=%+v", got, fake.mutationCalls, fake.readCalls)
+		}
+		assertMCPMutationTrace(t, fake.trace, "access", "update")
+	})
+
+	t.Run("read failure is classified and preserves cause", func(t *testing.T) {
+		readFailure := fmt.Errorf("%w: workflow unavailable", store.ErrNotFound)
+		fake := &mcpMutationFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 43}, Role: store.RoleMaintainer},
+			readErr:        readFailure,
+		}
+		prepared, err := newMCPMutationTestService(fake).Prepare(
+			mcpMutationContext("read failure"),
+			MCPMutationTarget{ProjectSlug: "project", Mode: store.ModeFull},
+		)
+		if err != nil {
+			t.Fatalf("Prepare: %v", err)
+		}
+
+		got, err := prepared.Update(command)
+		if !errors.Is(err, ErrWorkflowProjectionFailed) {
+			t.Fatalf("Update error=%v want projection classification", err)
+		}
+		if !errors.Is(err, readFailure) || !errors.Is(err, store.ErrNotFound) {
+			t.Fatalf("projection error lost read cause: %v", err)
+		}
+		if got != (store.WorkflowColumn{}) || len(fake.mutationCalls) != 1 || len(fake.readCalls) != 1 {
+			t.Fatalf("column=%+v mutations=%+v reads=%+v", got, fake.mutationCalls, fake.readCalls)
+		}
+		assertMCPMutationTrace(t, fake.trace, "access", "update", "read")
+	})
+
+	t.Run("missing updated column is projection failure", func(t *testing.T) {
+		fake := &mcpMutationFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 44}, Role: store.RoleMaintainer},
+			workflow:       []store.WorkflowColumn{{ID: 1, ProjectID: 44, Key: "other"}},
+		}
+		prepared, err := newMCPMutationTestService(fake).Prepare(
+			mcpMutationContext("missing column"),
+			MCPMutationTarget{ProjectSlug: "project", Mode: store.ModeFull},
+		)
+		if err != nil {
+			t.Fatalf("Prepare: %v", err)
+		}
+
+		got, err := prepared.Update(command)
+		if !errors.Is(err, ErrWorkflowProjectionFailed) {
+			t.Fatalf("Update error=%v want projection classification", err)
+		}
+		if errors.Unwrap(err) != nil {
+			t.Fatalf("missing-column projection error cause=%v want nil", errors.Unwrap(err))
+		}
+		if got != (store.WorkflowColumn{}) || len(fake.mutationCalls) != 1 || len(fake.readCalls) != 1 {
+			t.Fatalf("column=%+v mutations=%+v reads=%+v", got, fake.mutationCalls, fake.readCalls)
+		}
+		assertMCPMutationTrace(t, fake.trace, "access", "update", "read")
+	})
+}
+
+func TestPreparedMCPMutationDeleteFailure(t *testing.T) {
+	mutationFailure := errors.New("delete failed")
+	fake := &mcpMutationFake{
+		projectContext: store.ProjectContext{Project: store.Project{ID: 51}, Role: store.RoleMaintainer},
+		deleteErr:      mutationFailure,
+	}
+	prepared, err := newMCPMutationTestService(fake).Prepare(
+		mcpMutationContext("delete failure"),
+		MCPMutationTarget{ProjectSlug: "project", Mode: store.ModeFull},
+	)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	if err := prepared.Delete(DeleteCommand{Key: "  review  "}); err != mutationFailure {
+		t.Fatalf("Delete error=%v want=%v", err, mutationFailure)
+	}
+	if len(fake.mutationCalls) != 1 || fake.mutationCalls[0].key != "  review  " || len(fake.readCalls) != 0 {
+		t.Fatalf("mutations=%+v reads=%+v", fake.mutationCalls, fake.readCalls)
+	}
+	assertMCPMutationTrace(t, fake.trace, "access", "delete")
+}
+
+func TestPreparedMCPMutationUsesCancelledBoundContext(t *testing.T) {
+	fake := &mcpMutationFake{
+		projectContext:  store.ProjectContext{Project: store.Project{ID: 61}, Role: store.RoleMaintainer},
+		honorContextErr: true,
+	}
+	service := newMCPMutationTestService(fake)
+	ctx, cancel := context.WithCancel(mcpMutationContext("cancelled"))
+	prepared, err := service.Prepare(ctx, MCPMutationTarget{ProjectSlug: "project", Mode: store.ModeFull})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	cancel()
+
+	got, err := prepared.Update(UpdateCommand{Key: "review", Name: "Review", Color: "#123456"})
+	if err != context.Canceled {
+		t.Fatalf("Update error=%v want=%v", err, context.Canceled)
+	}
+	if got != (store.WorkflowColumn{}) || len(fake.mutationCalls) != 1 || len(fake.readCalls) != 0 {
+		t.Fatalf("column=%+v mutations=%+v reads=%+v", got, fake.mutationCalls, fake.readCalls)
+	}
+	if fake.mutationCalls[0].ctx != ctx {
+		t.Fatalf("mutation context was not bound context")
+	}
+	assertMCPMutationTrace(t, fake.trace, "access", "update")
+}

--- a/internal/application/workflow/mcp_mutation_test.go
+++ b/internal/application/workflow/mcp_mutation_test.go
@@ -421,6 +421,9 @@ func TestPreparedMCPMutationUpdate(t *testing.T) {
 		if !errors.Is(err, ErrWorkflowProjectionFailed) {
 			t.Fatalf("Update error=%v want projection classification", err)
 		}
+		if !errors.Is(err, ErrWorkflowProjectionColumnMissing) {
+			t.Fatalf("Update error=%v want missing-column classification", err)
+		}
 		if errors.Unwrap(err) != nil {
 			t.Fatalf("missing-column projection error cause=%v want nil", errors.Unwrap(err))
 		}

--- a/internal/application/workflow/mutation.go
+++ b/internal/application/workflow/mutation.go
@@ -1,0 +1,59 @@
+package workflow
+
+import (
+	"context"
+
+	"scrumboy/internal/store"
+)
+
+// CreateCommand contains values already prepared by the transport adapter for
+// creating a workflow column.
+type CreateCommand struct {
+	Name string
+}
+
+// UpdateCommand contains the adapter-prepared values for updating a workflow
+// column. It deliberately preserves values exactly as supplied by the adapter.
+type UpdateCommand struct {
+	Key   string
+	Name  string
+	Color string
+}
+
+// DeleteCommand identifies the workflow column to delete.
+type DeleteCommand struct {
+	Key string
+}
+
+// MutationStore is the persistence capability shared by future REST and MCP
+// workflow-column mutation services. Transport normalization and public
+// validation remain adapter-owned; the store remains authoritative for workflow
+// invariants, persistence validation, and transaction ownership.
+type MutationStore interface {
+	AddWorkflowColumn(
+		ctx context.Context,
+		projectID int64,
+		name string,
+	) (store.WorkflowColumn, error)
+	UpdateWorkflowColumn(
+		ctx context.Context,
+		projectID int64,
+		key string,
+		name string,
+		color string,
+	) error
+	DeleteWorkflowColumn(
+		ctx context.Context,
+		projectID int64,
+		key string,
+	) error
+}
+
+// WorkflowReadStore is kept separate from MutationStore because only the MCP
+// update projection requires a post-write workflow read.
+type WorkflowReadStore interface {
+	GetProjectWorkflow(
+		ctx context.Context,
+		projectID int64,
+	) ([]store.WorkflowColumn, error)
+}

--- a/internal/application/workflow/mutation_test.go
+++ b/internal/application/workflow/mutation_test.go
@@ -1,0 +1,6 @@
+package workflow
+
+import "scrumboy/internal/store"
+
+var _ MutationStore = (*store.Store)(nil)
+var _ WorkflowReadStore = (*store.Store)(nil)

--- a/internal/application/workflow/rest_mutation.go
+++ b/internal/application/workflow/rest_mutation.go
@@ -1,0 +1,153 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+
+	"scrumboy/internal/store"
+)
+
+const (
+	refreshReasonWorkflowColumnAdded   = "workflow_column_added"
+	refreshReasonWorkflowColumnUpdated = "workflow_column_updated"
+	refreshReasonWorkflowColumnDeleted = "workflow_column_deleted"
+)
+
+var (
+	ErrActorRequired      = errors.New("workflow mutation actor required")
+	ErrMaintainerRequired = errors.New("workflow mutation maintainer required")
+)
+
+// RESTMutationRoleStore is the explicit project-role lookup required by the
+// canonical REST workflow mutation boundary.
+type RESTMutationRoleStore interface {
+	GetProjectRole(
+		ctx context.Context,
+		projectID int64,
+		userID int64,
+	) (store.ProjectRole, error)
+}
+
+// BoardRefreshPublisher is the ancillary invalidation capability used by REST
+// workflow mutations. Publishing is best-effort and cannot change mutation
+// success.
+type BoardRefreshPublisher interface {
+	PublishBoardRefresh(ctx context.Context, projectID int64, reason string)
+}
+
+// BoardRefreshPublisherFunc adapts a function to BoardRefreshPublisher.
+type BoardRefreshPublisherFunc func(ctx context.Context, projectID int64, reason string)
+
+func (f BoardRefreshPublisherFunc) PublishBoardRefresh(ctx context.Context, projectID int64, reason string) {
+	if f != nil {
+		f(ctx, projectID, reason)
+	}
+}
+
+type nopBoardRefreshPublisher struct{}
+
+func (nopBoardRefreshPublisher) PublishBoardRefresh(context.Context, int64, string) {}
+
+// RESTMutationServiceDependencies names the authorization, persistence, and
+// ancillary capabilities used by canonical REST workflow mutations.
+type RESTMutationServiceDependencies struct {
+	Roles     RESTMutationRoleStore
+	Mutations MutationStore
+	Refresh   BoardRefreshPublisher
+}
+
+// RESTMutationService owns the explicit REST Maintainer gate, workflow
+// persistence sequencing, and post-commit board refresh publication.
+type RESTMutationService struct {
+	roles     RESTMutationRoleStore
+	mutations MutationStore
+	refresh   BoardRefreshPublisher
+}
+
+func NewRESTMutationService(deps RESTMutationServiceDependencies) *RESTMutationService {
+	refresh := deps.Refresh
+	if refresh == nil {
+		refresh = nopBoardRefreshPublisher{}
+	}
+	return &RESTMutationService{
+		roles:     deps.Roles,
+		mutations: deps.Mutations,
+		refresh:   refresh,
+	}
+}
+
+// ResolvedRESTMutationTarget carries only the project identity already resolved
+// by the shared REST board router. Preparation performs no slug lookup.
+type ResolvedRESTMutationTarget struct {
+	ProjectID int64
+}
+
+// PreparedRESTMutation binds the authorized project identity and exact request
+// context to subsequent workflow mutations.
+type PreparedRESTMutation struct {
+	ctx       context.Context
+	service   *RESTMutationService
+	projectID int64
+}
+
+// Prepare preserves the current REST authorization order: actor extraction and
+// an explicit fresh Maintainer-role lookup happen after router access but before
+// operation-specific parsing and validation.
+func (s *RESTMutationService) Prepare(
+	ctx context.Context,
+	target ResolvedRESTMutationTarget,
+) (*PreparedRESTMutation, error) {
+	userID, ok := store.UserIDFromContext(ctx)
+	if !ok {
+		return nil, ErrActorRequired
+	}
+
+	role, err := s.roles.GetProjectRole(ctx, target.ProjectID, userID)
+	if err != nil || !role.HasMinimumRole(store.RoleMaintainer) {
+		return nil, ErrMaintainerRequired
+	}
+
+	return &PreparedRESTMutation{
+		ctx:       ctx,
+		service:   s,
+		projectID: target.ProjectID,
+	}, nil
+}
+
+// Create persists one adapter-prepared create command and publishes the REST
+// invalidation only after persistence succeeds.
+func (p *PreparedRESTMutation) Create(command CreateCommand) (store.WorkflowColumn, error) {
+	column, err := p.service.mutations.AddWorkflowColumn(p.ctx, p.projectID, command.Name)
+	if err != nil {
+		return store.WorkflowColumn{}, err
+	}
+	p.service.refresh.PublishBoardRefresh(p.ctx, p.projectID, refreshReasonWorkflowColumnAdded)
+	return column, nil
+}
+
+// Update persists one adapter-prepared update command and publishes the REST
+// invalidation only after persistence succeeds.
+func (p *PreparedRESTMutation) Update(command UpdateCommand) error {
+	err := p.service.mutations.UpdateWorkflowColumn(
+		p.ctx,
+		p.projectID,
+		command.Key,
+		command.Name,
+		command.Color,
+	)
+	if err != nil {
+		return err
+	}
+	p.service.refresh.PublishBoardRefresh(p.ctx, p.projectID, refreshReasonWorkflowColumnUpdated)
+	return nil
+}
+
+// Delete persists one adapter-prepared delete command and publishes the REST
+// invalidation only after persistence succeeds.
+func (p *PreparedRESTMutation) Delete(command DeleteCommand) error {
+	if err := p.service.mutations.DeleteWorkflowColumn(p.ctx, p.projectID, command.Key); err != nil {
+		return err
+	}
+	p.service.refresh.PublishBoardRefresh(p.ctx, p.projectID, refreshReasonWorkflowColumnDeleted)
+	return nil
+}

--- a/internal/application/workflow/rest_mutation_test.go
+++ b/internal/application/workflow/rest_mutation_test.go
@@ -1,0 +1,457 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+var _ RESTMutationRoleStore = (*store.Store)(nil)
+
+type restMutationTestContextKey struct{}
+
+type restMutationCall struct {
+	operation string
+	ctx       context.Context
+	projectID int64
+	key       string
+	name      string
+	color     string
+}
+
+type restMutationRefreshCall struct {
+	ctx       context.Context
+	projectID int64
+	reason    string
+}
+
+type restMutationFake struct {
+	trace []string
+
+	role      store.ProjectRole
+	roleErr   error
+	roleCalls int
+	roleCtx   context.Context
+	rolePID   int64
+	roleUID   int64
+
+	mutationCalls   []restMutationCall
+	createResult    store.WorkflowColumn
+	createErr       error
+	updateErr       error
+	deleteErr       error
+	honorContextErr bool
+
+	refreshCalls []restMutationRefreshCall
+}
+
+func (f *restMutationFake) GetProjectRole(
+	ctx context.Context,
+	projectID int64,
+	userID int64,
+) (store.ProjectRole, error) {
+	f.trace = append(f.trace, "role")
+	f.roleCalls++
+	f.roleCtx = ctx
+	f.rolePID = projectID
+	f.roleUID = userID
+	return f.role, f.roleErr
+}
+
+func (f *restMutationFake) AddWorkflowColumn(
+	ctx context.Context,
+	projectID int64,
+	name string,
+) (store.WorkflowColumn, error) {
+	f.trace = append(f.trace, "create")
+	f.mutationCalls = append(f.mutationCalls, restMutationCall{
+		operation: "create",
+		ctx:       ctx,
+		projectID: projectID,
+		name:      name,
+	})
+	if f.honorContextErr && ctx.Err() != nil {
+		return store.WorkflowColumn{}, ctx.Err()
+	}
+	return f.createResult, f.createErr
+}
+
+func (f *restMutationFake) UpdateWorkflowColumn(
+	ctx context.Context,
+	projectID int64,
+	key string,
+	name string,
+	color string,
+) error {
+	f.trace = append(f.trace, "update")
+	f.mutationCalls = append(f.mutationCalls, restMutationCall{
+		operation: "update",
+		ctx:       ctx,
+		projectID: projectID,
+		key:       key,
+		name:      name,
+		color:     color,
+	})
+	if f.honorContextErr && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return f.updateErr
+}
+
+func (f *restMutationFake) DeleteWorkflowColumn(
+	ctx context.Context,
+	projectID int64,
+	key string,
+) error {
+	f.trace = append(f.trace, "delete")
+	f.mutationCalls = append(f.mutationCalls, restMutationCall{
+		operation: "delete",
+		ctx:       ctx,
+		projectID: projectID,
+		key:       key,
+	})
+	if f.honorContextErr && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return f.deleteErr
+}
+
+func (f *restMutationFake) PublishBoardRefresh(
+	ctx context.Context,
+	projectID int64,
+	reason string,
+) {
+	f.trace = append(f.trace, "refresh")
+	f.refreshCalls = append(f.refreshCalls, restMutationRefreshCall{
+		ctx:       ctx,
+		projectID: projectID,
+		reason:    reason,
+	})
+}
+
+func newRESTMutationTestService(f *restMutationFake) *RESTMutationService {
+	return NewRESTMutationService(RESTMutationServiceDependencies{
+		Roles:     f,
+		Mutations: f,
+		Refresh:   f,
+	})
+}
+
+func restMutationActorContext(userID int64, marker string) context.Context {
+	ctx := context.WithValue(context.Background(), restMutationTestContextKey{}, marker)
+	return store.WithUserID(ctx, userID)
+}
+
+func assertRESTMutationTrace(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("call trace=%v want=%v", got, want)
+	}
+}
+
+func TestRESTMutationPrepareAuthorization(t *testing.T) {
+	roleFailure := errors.New("role lookup failed")
+	tests := []struct {
+		name          string
+		withActor     bool
+		role          store.ProjectRole
+		roleErr       error
+		wantErr       error
+		wantPrepared  bool
+		wantRoleCalls int
+	}{
+		{
+			name:          "missing actor",
+			wantErr:       ErrActorRequired,
+			wantRoleCalls: 0,
+		},
+		{
+			name:          "contributor",
+			withActor:     true,
+			role:          store.RoleContributor,
+			wantErr:       ErrMaintainerRequired,
+			wantRoleCalls: 1,
+		},
+		{
+			name:          "viewer",
+			withActor:     true,
+			role:          store.RoleViewer,
+			wantErr:       ErrMaintainerRequired,
+			wantRoleCalls: 1,
+		},
+		{
+			name:          "role lookup error",
+			withActor:     true,
+			roleErr:       roleFailure,
+			wantErr:       ErrMaintainerRequired,
+			wantRoleCalls: 1,
+		},
+		{
+			name:          "maintainer",
+			withActor:     true,
+			role:          store.RoleMaintainer,
+			wantPrepared:  true,
+			wantRoleCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &restMutationFake{role: tt.role, roleErr: tt.roleErr}
+			service := newRESTMutationTestService(fake)
+			ctx := context.WithValue(context.Background(), restMutationTestContextKey{}, tt.name)
+			if tt.withActor {
+				ctx = store.WithUserID(ctx, 41)
+			}
+
+			prepared, err := service.Prepare(ctx, ResolvedRESTMutationTarget{ProjectID: 73})
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Prepare error=%v want=%v", err, tt.wantErr)
+			}
+			if (prepared != nil) != tt.wantPrepared {
+				t.Fatalf("prepared=%v wantPresent=%v", prepared, tt.wantPrepared)
+			}
+			if fake.roleCalls != tt.wantRoleCalls {
+				t.Fatalf("role calls=%d want=%d", fake.roleCalls, tt.wantRoleCalls)
+			}
+			if tt.wantRoleCalls == 1 {
+				if fake.roleCtx != ctx || fake.rolePID != 73 || fake.roleUID != 41 {
+					t.Fatalf("role call context/project/user mismatch: ctxSame=%v project=%d user=%d", fake.roleCtx == ctx, fake.rolePID, fake.roleUID)
+				}
+				assertRESTMutationTrace(t, fake.trace, "role")
+			} else {
+				assertRESTMutationTrace(t, fake.trace)
+			}
+			if len(fake.mutationCalls) != 0 || len(fake.refreshCalls) != 0 {
+				t.Fatalf("preparation caused side effects: mutations=%+v refreshes=%+v", fake.mutationCalls, fake.refreshCalls)
+			}
+		})
+	}
+}
+
+func TestPreparedRESTMutationBindsContextAndProjectIDByValue(t *testing.T) {
+	fake := &restMutationFake{role: store.RoleMaintainer}
+	service := newRESTMutationTestService(fake)
+	ctx := restMutationActorContext(51, "bound")
+	target := ResolvedRESTMutationTarget{ProjectID: 101}
+
+	prepared, err := service.Prepare(ctx, target)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	target.ProjectID = 202
+
+	if err := prepared.Delete(DeleteCommand{Key: "  review_queue  "}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(fake.mutationCalls) != 1 {
+		t.Fatalf("mutation calls=%d want=1", len(fake.mutationCalls))
+	}
+	call := fake.mutationCalls[0]
+	if call.operation != "delete" || call.projectID != 101 || call.key != "  review_queue  " || call.ctx != ctx {
+		t.Fatalf("delete call=%+v", call)
+	}
+	if got := call.ctx.Value(restMutationTestContextKey{}); got != "bound" {
+		t.Fatalf("bound context marker=%v want=bound", got)
+	}
+	if len(fake.refreshCalls) != 1 {
+		t.Fatalf("refresh calls=%d want=1", len(fake.refreshCalls))
+	}
+	refresh := fake.refreshCalls[0]
+	if refresh.ctx != ctx || refresh.projectID != 101 || refresh.reason != refreshReasonWorkflowColumnDeleted {
+		t.Fatalf("refresh=%+v", refresh)
+	}
+	assertRESTMutationTrace(t, fake.trace, "role", "delete", "refresh")
+}
+
+func TestPreparedRESTMutationCreate(t *testing.T) {
+	storeFailure := errors.New("create failed")
+	wantColumn := store.WorkflowColumn{
+		ID:        17,
+		ProjectID: 71,
+		Key:       "review_queue",
+		Name:      "Review Queue",
+		Color:     "#123456",
+		Position:  4,
+	}
+
+	t.Run("success persists before refresh", func(t *testing.T) {
+		fake := &restMutationFake{role: store.RoleMaintainer, createResult: wantColumn}
+		service := newRESTMutationTestService(fake)
+		ctx := restMutationActorContext(61, "create")
+		prepared, err := service.Prepare(ctx, ResolvedRESTMutationTarget{ProjectID: 71})
+		if err != nil {
+			t.Fatalf("Prepare: %v", err)
+		}
+
+		got, err := prepared.Create(CreateCommand{Name: "  Review Queue  "})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if !reflect.DeepEqual(got, wantColumn) {
+			t.Fatalf("created column=%+v want=%+v", got, wantColumn)
+		}
+		if len(fake.mutationCalls) != 1 {
+			t.Fatalf("create calls=%d want=1", len(fake.mutationCalls))
+		}
+		call := fake.mutationCalls[0]
+		if call.operation != "create" || call.ctx != ctx || call.projectID != 71 || call.name != "  Review Queue  " {
+			t.Fatalf("create call=%+v", call)
+		}
+		if len(fake.refreshCalls) != 1 {
+			t.Fatalf("refresh calls=%d want=1", len(fake.refreshCalls))
+		}
+		refresh := fake.refreshCalls[0]
+		if refresh.ctx != ctx || refresh.projectID != 71 || refresh.reason != refreshReasonWorkflowColumnAdded {
+			t.Fatalf("refresh=%+v", refresh)
+		}
+		assertRESTMutationTrace(t, fake.trace, "role", "create", "refresh")
+	})
+
+	t.Run("store failure suppresses refresh", func(t *testing.T) {
+		fake := &restMutationFake{role: store.RoleMaintainer, createErr: storeFailure}
+		service := newRESTMutationTestService(fake)
+		prepared, err := service.Prepare(restMutationActorContext(62, "create failure"), ResolvedRESTMutationTarget{ProjectID: 72})
+		if err != nil {
+			t.Fatalf("Prepare: %v", err)
+		}
+
+		got, err := prepared.Create(CreateCommand{Name: "Review"})
+		if err != storeFailure {
+			t.Fatalf("Create error=%v want=%v", err, storeFailure)
+		}
+		if got != (store.WorkflowColumn{}) {
+			t.Fatalf("created column=%+v want zero", got)
+		}
+		if len(fake.mutationCalls) != 1 || len(fake.refreshCalls) != 0 {
+			t.Fatalf("calls: mutations=%d refreshes=%d", len(fake.mutationCalls), len(fake.refreshCalls))
+		}
+		assertRESTMutationTrace(t, fake.trace, "role", "create")
+	})
+
+	t.Run("nil publisher is a no-op", func(t *testing.T) {
+		fake := &restMutationFake{role: store.RoleMaintainer, createResult: wantColumn}
+		service := NewRESTMutationService(RESTMutationServiceDependencies{
+			Roles:     fake,
+			Mutations: fake,
+		})
+		prepared, err := service.Prepare(restMutationActorContext(63, "nil publisher"), ResolvedRESTMutationTarget{ProjectID: 73})
+		if err != nil {
+			t.Fatalf("Prepare: %v", err)
+		}
+
+		got, err := prepared.Create(CreateCommand{Name: "Review"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if !reflect.DeepEqual(got, wantColumn) || len(fake.mutationCalls) != 1 {
+			t.Fatalf("result=%+v mutations=%d", got, len(fake.mutationCalls))
+		}
+		assertRESTMutationTrace(t, fake.trace, "role", "create")
+	})
+}
+
+func TestPreparedRESTMutationUpdate(t *testing.T) {
+	storeFailure := errors.New("update failed")
+
+	t.Run("success persists before refresh", func(t *testing.T) {
+		fake := &restMutationFake{role: store.RoleMaintainer}
+		service := newRESTMutationTestService(fake)
+		ctx := restMutationActorContext(71, "update")
+		prepared, err := service.Prepare(ctx, ResolvedRESTMutationTarget{ProjectID: 81})
+		if err != nil {
+			t.Fatalf("Prepare: %v", err)
+		}
+
+		err = prepared.Update(UpdateCommand{
+			Key:   "  review_queue  ",
+			Name:  "  Ready for review  ",
+			Color: "  #A1B2C3  ",
+		})
+		if err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+		if len(fake.mutationCalls) != 1 {
+			t.Fatalf("update calls=%d want=1", len(fake.mutationCalls))
+		}
+		call := fake.mutationCalls[0]
+		if call.operation != "update" || call.ctx != ctx || call.projectID != 81 ||
+			call.key != "  review_queue  " || call.name != "  Ready for review  " || call.color != "  #A1B2C3  " {
+			t.Fatalf("update call=%+v", call)
+		}
+		if len(fake.refreshCalls) != 1 {
+			t.Fatalf("refresh calls=%d want=1", len(fake.refreshCalls))
+		}
+		refresh := fake.refreshCalls[0]
+		if refresh.ctx != ctx || refresh.projectID != 81 || refresh.reason != refreshReasonWorkflowColumnUpdated {
+			t.Fatalf("refresh=%+v", refresh)
+		}
+		assertRESTMutationTrace(t, fake.trace, "role", "update", "refresh")
+	})
+
+	t.Run("store failure suppresses refresh", func(t *testing.T) {
+		fake := &restMutationFake{role: store.RoleMaintainer, updateErr: storeFailure}
+		service := newRESTMutationTestService(fake)
+		prepared, err := service.Prepare(restMutationActorContext(72, "update failure"), ResolvedRESTMutationTarget{ProjectID: 82})
+		if err != nil {
+			t.Fatalf("Prepare: %v", err)
+		}
+
+		if err := prepared.Update(UpdateCommand{Key: "doing", Name: "Doing", Color: "#123456"}); err != storeFailure {
+			t.Fatalf("Update error=%v want=%v", err, storeFailure)
+		}
+		if len(fake.mutationCalls) != 1 || len(fake.refreshCalls) != 0 {
+			t.Fatalf("calls: mutations=%d refreshes=%d", len(fake.mutationCalls), len(fake.refreshCalls))
+		}
+		assertRESTMutationTrace(t, fake.trace, "role", "update")
+	})
+}
+
+func TestPreparedRESTMutationDeleteFailureSuppressesRefresh(t *testing.T) {
+	storeFailure := errors.New("delete failed")
+	fake := &restMutationFake{role: store.RoleMaintainer, deleteErr: storeFailure}
+	service := newRESTMutationTestService(fake)
+	prepared, err := service.Prepare(restMutationActorContext(81, "delete failure"), ResolvedRESTMutationTarget{ProjectID: 91})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	if err := prepared.Delete(DeleteCommand{Key: "review"}); err != storeFailure {
+		t.Fatalf("Delete error=%v want=%v", err, storeFailure)
+	}
+	if len(fake.mutationCalls) != 1 || len(fake.refreshCalls) != 0 {
+		t.Fatalf("calls: mutations=%d refreshes=%d", len(fake.mutationCalls), len(fake.refreshCalls))
+	}
+	assertRESTMutationTrace(t, fake.trace, "role", "delete")
+}
+
+func TestPreparedRESTMutationUsesCancelledBoundContext(t *testing.T) {
+	fake := &restMutationFake{role: store.RoleMaintainer, honorContextErr: true}
+	service := newRESTMutationTestService(fake)
+	ctx, cancel := context.WithCancel(restMutationActorContext(91, "cancelled"))
+	prepared, err := service.Prepare(ctx, ResolvedRESTMutationTarget{ProjectID: 111})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	cancel()
+
+	_, err = prepared.Create(CreateCommand{Name: "Review"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Create error=%v want=%v", err, context.Canceled)
+	}
+	if len(fake.mutationCalls) != 1 || fake.mutationCalls[0].ctx != ctx {
+		t.Fatalf("mutation calls=%+v", fake.mutationCalls)
+	}
+	if len(fake.refreshCalls) != 0 {
+		t.Fatalf("refresh calls=%+v want none", fake.refreshCalls)
+	}
+	assertRESTMutationTrace(t, fake.trace, "role", "create")
+}
+
+func TestBoardRefreshPublisherFuncNilIsNoop(t *testing.T) {
+	var publish BoardRefreshPublisherFunc
+	publish.PublishBoardRefresh(context.Background(), 1, "ignored")
+}

--- a/internal/httpapi/routing_board.go
+++ b/internal/httpapi/routing_board.go
@@ -10,8 +10,20 @@ import (
 	"time"
 
 	todoapp "scrumboy/internal/application/todo"
+	workflowapp "scrumboy/internal/application/workflow"
 	"scrumboy/internal/store"
 )
+
+func writeWorkflowMutationPrepareError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, workflowapp.ErrActorRequired):
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
+	case errors.Is(err, workflowapp.ErrMaintainerRequired):
+		writeError(w, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
+	default:
+		writeInternal(w, err)
+	}
+}
 
 func (s *Server) handleBoard(w http.ResponseWriter, r *http.Request, rest []string) {
 	if len(rest) == 0 {
@@ -156,14 +168,11 @@ func (s *Server) handleBoardWorkflowRoutes(w http.ResponseWriter, r *http.Reques
 	// POST /api/board/{slug}/workflow - add a new non-done lane before done.
 	if len(rest) == 2 && rest[1] == "workflow" && r.Method == http.MethodPost {
 		ctx := s.requestContext(r)
-		userID, ok := store.UserIDFromContext(ctx)
-		if !ok {
-			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
-			return true
-		}
-		role, err := s.store.GetProjectRole(ctx, project.ID, userID)
-		if err != nil || !role.HasMinimumRole(store.RoleMaintainer) {
-			writeError(w, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
+		prepared, err := s.workflowMutations.Prepare(ctx, workflowapp.ResolvedRESTMutationTarget{
+			ProjectID: project.ID,
+		})
+		if err != nil {
+			writeWorkflowMutationPrepareError(w, err)
 			return true
 		}
 
@@ -183,12 +192,11 @@ func (s *Server) handleBoardWorkflowRoutes(w http.ResponseWriter, r *http.Reques
 			return true
 		}
 
-		col, err := s.store.AddWorkflowColumn(ctx, project.ID, in.Name)
+		col, err := prepared.Create(workflowapp.CreateCommand{Name: in.Name})
 		if err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}
-		s.emitRefreshNeeded(s.requestContext(r), project.ID, "workflow_column_added")
 		writeJSON(w, http.StatusCreated, workflowColumnJSON{
 			Key:      col.Key,
 			Name:     col.Name,
@@ -202,14 +210,11 @@ func (s *Server) handleBoardWorkflowRoutes(w http.ResponseWriter, r *http.Reques
 	// PATCH /api/board/{slug}/workflow/{key} - update workflow lane label and color.
 	if len(rest) == 3 && rest[1] == "workflow" && r.Method == http.MethodPatch {
 		ctx := s.requestContext(r)
-		userID, ok := store.UserIDFromContext(ctx)
-		if !ok {
-			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
-			return true
-		}
-		role, err := s.store.GetProjectRole(ctx, project.ID, userID)
-		if err != nil || !role.HasMinimumRole(store.RoleMaintainer) {
-			writeError(w, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
+		prepared, err := s.workflowMutations.Prepare(ctx, workflowapp.ResolvedRESTMutationTarget{
+			ProjectID: project.ID,
+		})
+		if err != nil {
+			writeWorkflowMutationPrepareError(w, err)
 			return true
 		}
 		columnKey := strings.TrimSpace(rest[2])
@@ -243,11 +248,14 @@ func (s *Server) handleBoardWorkflowRoutes(w http.ResponseWriter, r *http.Reques
 			writeValidationError(w, "invalid workflow column color", "invalid_workflow_column_color", map[string]any{"field": "color"})
 			return true
 		}
-		if err := s.store.UpdateWorkflowColumn(ctx, project.ID, columnKey, in.Name, in.Color); err != nil {
+		if err := prepared.Update(workflowapp.UpdateCommand{
+			Key:   columnKey,
+			Name:  in.Name,
+			Color: in.Color,
+		}); err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}
-		s.emitRefreshNeeded(s.requestContext(r), project.ID, "workflow_column_updated")
 		w.WriteHeader(http.StatusNoContent)
 		return true
 	}
@@ -255,14 +263,11 @@ func (s *Server) handleBoardWorkflowRoutes(w http.ResponseWriter, r *http.Reques
 	// DELETE /api/board/{slug}/workflow/{key} - delete an empty non-done lane.
 	if len(rest) == 3 && rest[1] == "workflow" && r.Method == http.MethodDelete {
 		ctx := s.requestContext(r)
-		userID, ok := store.UserIDFromContext(ctx)
-		if !ok {
-			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
-			return true
-		}
-		role, err := s.store.GetProjectRole(ctx, project.ID, userID)
-		if err != nil || !role.HasMinimumRole(store.RoleMaintainer) {
-			writeError(w, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
+		prepared, err := s.workflowMutations.Prepare(ctx, workflowapp.ResolvedRESTMutationTarget{
+			ProjectID: project.ID,
+		})
+		if err != nil {
+			writeWorkflowMutationPrepareError(w, err)
 			return true
 		}
 		columnKey := strings.TrimSpace(rest[2])
@@ -270,11 +275,10 @@ func (s *Server) handleBoardWorkflowRoutes(w http.ResponseWriter, r *http.Reques
 			writeValidationError(w, "invalid workflow key", "invalid_workflow_key", map[string]any{"field": "key"})
 			return true
 		}
-		if err := s.store.DeleteWorkflowColumn(ctx, project.ID, columnKey); err != nil {
+		if err := prepared.Delete(workflowapp.DeleteCommand{Key: columnKey}); err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}
-		s.emitRefreshNeeded(s.requestContext(r), project.ID, "workflow_column_deleted")
 		w.WriteHeader(http.StatusNoContent)
 		return true
 	}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -13,6 +13,7 @@ import (
 
 	boardapp "scrumboy/internal/application/board"
 	todoapp "scrumboy/internal/application/todo"
+	workflowapp "scrumboy/internal/application/workflow"
 	"scrumboy/internal/config"
 	"scrumboy/internal/eventbus"
 	"scrumboy/internal/httpapi/ratelimit"
@@ -93,11 +94,12 @@ type Options struct {
 }
 
 type Server struct {
-	store       storeAPI
-	boardReads  *boardapp.ReadService
-	todoCreates *todoapp.CreateService
-	todoMoves   *todoapp.MoveService
-	todoUpdates *todoapp.UpdateService
+	store             storeAPI
+	boardReads        *boardapp.ReadService
+	todoCreates       *todoapp.CreateService
+	todoMoves         *todoapp.MoveService
+	todoUpdates       *todoapp.UpdateService
+	workflowMutations *workflowapp.RESTMutationService
 
 	logger                  *log.Logger
 	maxBody                 int64
@@ -220,9 +222,7 @@ type storeAPI interface {
 	UpdateProjectImage(ctx context.Context, projectID int64, userID int64, image *string, dominantColor string) error
 	UpdateProjectName(ctx context.Context, projectID int64, userID int64, name string) error
 	UpdateProjectDefaultSprintWeeks(ctx context.Context, projectID int64, userID int64, weeks int) error
-	AddWorkflowColumn(ctx context.Context, projectID int64, name string) (store.WorkflowColumn, error)
-	DeleteWorkflowColumn(ctx context.Context, projectID int64, key string) error
-	UpdateWorkflowColumn(ctx context.Context, projectID int64, key, name, color string) error
+	workflowapp.MutationStore
 	CountTodosByColumnKey(ctx context.Context, projectID int64) (map[string]int, error)
 	GetProjectRole(ctx context.Context, projectID int64, userID int64) (store.ProjectRole, error)
 	CheckProjectRole(ctx context.Context, projectID int64, userID int64, requiredRole store.ProjectRole) error
@@ -592,6 +592,13 @@ func NewServer(st storeAPI, opts Options) *Server {
 	server.todoUpdates = todoapp.NewUpdateService(todoapp.UpdateServiceDependencies{
 		Update:  st,
 		Refresh: boardRefreshPublisher,
+	})
+	server.workflowMutations = workflowapp.NewRESTMutationService(workflowapp.RESTMutationServiceDependencies{
+		Roles:     st,
+		Mutations: st,
+		Refresh: workflowapp.BoardRefreshPublisherFunc(func(ctx context.Context, projectID int64, reason string) {
+			server.emitRefreshNeeded(ctx, projectID, reason)
+		}),
 	})
 	return server
 }

--- a/internal/httpapi/workflow_mutation_transport_contract_test.go
+++ b/internal/httpapi/workflow_mutation_transport_contract_test.go
@@ -1,0 +1,256 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+type workflowRESTFixture struct {
+	ts      *httptest.Server
+	st      *store.Store
+	client  *http.Client
+	ownerID int64
+	ctx     context.Context
+	project store.Project
+}
+
+func newWorkflowRESTFixture(t *testing.T, name string) *workflowRESTFixture {
+	t.Helper()
+	ts, sqlDB, cleanup := newTestHTTPServer(t, "full")
+	t.Cleanup(cleanup)
+	client := newCookieClient(t)
+	owner := bootstrapUserClient(t, client, ts.URL, "Workflow Owner", name+"@example.com", "password123")
+	ownerID := int64(owner["id"].(float64))
+	ctx := store.WithUserID(context.Background(), ownerID)
+	st := store.New(sqlDB, nil)
+	project, err := st.CreateProject(ctx, name)
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	return &workflowRESTFixture{ts: ts, st: st, client: client, ownerID: ownerID, ctx: ctx, project: project}
+}
+
+func workflowColumnByKey(t *testing.T, columns []store.WorkflowColumn, key string) (store.WorkflowColumn, bool) {
+	t.Helper()
+	for _, column := range columns {
+		if column.Key == key {
+			return column, true
+		}
+	}
+	return store.WorkflowColumn{}, false
+}
+
+func assertWorkflowRESTRefresh(t *testing.T, events []todoUpdateWireEvent, projectID int64, reason string) {
+	t.Helper()
+	if len(events) != 1 {
+		t.Fatalf("workflow event count=%d want=1; events=%+v", len(events), events)
+	}
+	event := events[0]
+	if event.Type != "refresh_needed" || event.ProjectID != projectID || event.Reason != reason {
+		t.Fatalf("workflow refresh mismatch: want project=%d reason=%q; event=%+v", projectID, reason, event)
+	}
+}
+
+func TestWorkflowMutationRESTSuccessRefreshContracts(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		fx := newWorkflowRESTFixture(t, "workflow-rest-create")
+		stream := subscribeTodoUpdateEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+
+		var created workflowColumnJSON
+		resp, body := doJSON(t, fx.client, http.MethodPost, fx.ts.URL+"/api/board/"+fx.project.Slug+"/workflow", map[string]any{
+			"name": "  Code Review  ",
+		}, &created)
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("create status=%d body=%s", resp.StatusCode, body)
+		}
+		if created.Key != "code_review" || created.Name != "Code Review" || created.IsDone || created.Position != 4 {
+			t.Fatalf("created column=%+v", created)
+		}
+		columns, err := fx.st.GetProjectWorkflow(fx.ctx, fx.project.ID)
+		if err != nil {
+			t.Fatalf("get workflow: %v", err)
+		}
+		persisted, ok := workflowColumnByKey(t, columns, created.Key)
+		if !ok || persisted.Name != created.Name {
+			t.Fatalf("created column not persisted once: response=%+v columns=%+v", created, columns)
+		}
+		assertWorkflowRESTRefresh(t, collectTodoUpdateEvents(t, stream), fx.project.ID, "workflow_column_added")
+	})
+
+	t.Run("update", func(t *testing.T) {
+		fx := newWorkflowRESTFixture(t, "workflow-rest-update")
+		stream := subscribeTodoUpdateEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+
+		resp, body := doJSON(t, fx.client, http.MethodPatch, fx.ts.URL+"/api/board/"+fx.project.Slug+"/workflow/"+store.DefaultColumnDoing, map[string]any{
+			"name":  "  Building  ",
+			"color": "  #123456  ",
+		}, nil)
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("update status=%d body=%s", resp.StatusCode, body)
+		}
+		columns, err := fx.st.GetProjectWorkflow(fx.ctx, fx.project.ID)
+		if err != nil {
+			t.Fatalf("get workflow: %v", err)
+		}
+		persisted, ok := workflowColumnByKey(t, columns, store.DefaultColumnDoing)
+		if !ok || persisted.Name != "Building" || persisted.Color != "#123456" {
+			t.Fatalf("updated column=%+v found=%v", persisted, ok)
+		}
+		assertWorkflowRESTRefresh(t, collectTodoUpdateEvents(t, stream), fx.project.ID, "workflow_column_updated")
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		fx := newWorkflowRESTFixture(t, "workflow-rest-delete")
+		column, err := fx.st.AddWorkflowColumn(fx.ctx, fx.project.ID, "Disposable")
+		if err != nil {
+			t.Fatalf("add delete fixture: %v", err)
+		}
+		stream := subscribeTodoUpdateEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+
+		resp, body := doJSON(t, fx.client, http.MethodDelete, fx.ts.URL+"/api/board/"+fx.project.Slug+"/workflow/"+column.Key, nil, nil)
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("delete status=%d body=%s", resp.StatusCode, body)
+		}
+		columns, err := fx.st.GetProjectWorkflow(fx.ctx, fx.project.ID)
+		if err != nil {
+			t.Fatalf("get workflow: %v", err)
+		}
+		if _, ok := workflowColumnByKey(t, columns, column.Key); ok {
+			t.Fatalf("deleted column %q still present: %+v", column.Key, columns)
+		}
+		assertWorkflowRESTRefresh(t, collectTodoUpdateEvents(t, stream), fx.project.ID, "workflow_column_deleted")
+	})
+}
+
+func TestWorkflowMutationRESTFailureSilence(t *testing.T) {
+	t.Run("validation", func(t *testing.T) {
+		fx := newWorkflowRESTFixture(t, "workflow-rest-validation-silence")
+		stream := subscribeTodoUpdateEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+
+		resp, body := doJSON(t, fx.client, http.MethodPost, fx.ts.URL+"/api/board/"+fx.project.Slug+"/workflow", map[string]any{"name": "   "}, nil)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("validation status=%d body=%s", resp.StatusCode, body)
+		}
+		if events := collectTodoUpdateEvents(t, stream); len(events) != 0 {
+			t.Fatalf("validation emitted workflow events: %+v", events)
+		}
+	})
+
+	t.Run("authorization", func(t *testing.T) {
+		fx := newWorkflowRESTFixture(t, "workflow-rest-auth-silence")
+		contributor, err := fx.st.CreateUser(context.Background(), "workflow-rest-contributor@example.com", "password123", "Contributor")
+		if err != nil {
+			t.Fatalf("create contributor: %v", err)
+		}
+		if err := fx.st.AddProjectMember(fx.ctx, fx.ownerID, fx.project.ID, contributor.ID, store.RoleContributor); err != nil {
+			t.Fatalf("add contributor: %v", err)
+		}
+		contributorClient := newCookieClient(t)
+		loginUserClient(t, contributorClient, fx.ts.URL, contributor.Email, "password123")
+		stream := subscribeTodoUpdateEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+
+		resp, body := doJSON(t, contributorClient, http.MethodPatch, fx.ts.URL+"/api/board/"+fx.project.Slug+"/workflow/"+store.DefaultColumnDoing, map[string]any{
+			"name":  "Forbidden",
+			"color": "#123456",
+		}, nil)
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("authorization status=%d body=%s", resp.StatusCode, body)
+		}
+		if events := collectTodoUpdateEvents(t, stream); len(events) != 0 {
+			t.Fatalf("authorization failure emitted workflow events: %+v", events)
+		}
+	})
+
+	t.Run("store rejection", func(t *testing.T) {
+		fx := newWorkflowRESTFixture(t, "workflow-rest-store-silence")
+		column, err := fx.st.AddWorkflowColumn(fx.ctx, fx.project.ID, "Occupied")
+		if err != nil {
+			t.Fatalf("add occupied lane: %v", err)
+		}
+		if _, err := fx.st.CreateTodo(fx.ctx, fx.project.ID, store.CreateTodoInput{Title: "Blocks deletion", ColumnKey: column.Key}, store.ModeFull); err != nil {
+			t.Fatalf("create todo in occupied lane: %v", err)
+		}
+		stream := subscribeTodoUpdateEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+
+		resp, body := doJSON(t, fx.client, http.MethodDelete, fx.ts.URL+"/api/board/"+fx.project.Slug+"/workflow/"+column.Key, nil, nil)
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("store rejection status=%d body=%s", resp.StatusCode, body)
+		}
+		if events := collectTodoUpdateEvents(t, stream); len(events) != 0 {
+			t.Fatalf("store rejection emitted workflow events: %+v", events)
+		}
+	})
+}
+
+func TestWorkflowMutationRESTAccessRoleAndBodyPrecedence(t *testing.T) {
+	fx := newWorkflowRESTFixture(t, "workflow-rest-precedence")
+	contributor, err := fx.st.CreateUser(context.Background(), "workflow-rest-precedence-contributor@example.com", "password123", "Contributor")
+	if err != nil {
+		t.Fatalf("create contributor: %v", err)
+	}
+	if err := fx.st.AddProjectMember(fx.ctx, fx.ownerID, fx.project.ID, contributor.ID, store.RoleContributor); err != nil {
+		t.Fatalf("add contributor: %v", err)
+	}
+	contributorClient := newCookieClient(t)
+	loginUserClient(t, contributorClient, fx.ts.URL, contributor.Email, "password123")
+
+	tests := []struct {
+		name     string
+		client   *http.Client
+		slug     string
+		wantHTTP int
+		wantCode string
+	}{
+		{name: "inaccessible project wins before body", client: fx.client, slug: "missing-workflow-board", wantHTTP: http.StatusNotFound, wantCode: "NOT_FOUND"},
+		{name: "maintainer role wins before body", client: contributorClient, slug: fx.project.Slug, wantHTTP: http.StatusForbidden, wantCode: "FORBIDDEN"},
+		{name: "authorized actor reaches body validation", client: fx.client, slug: fx.project.Slug, wantHTTP: http.StatusBadRequest, wantCode: "VALIDATION_ERROR"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var envelope apiErrorEnvelope
+			resp, body := doJSON(t, tc.client, http.MethodPost, fx.ts.URL+"/api/board/"+tc.slug+"/workflow", "not-an-object", &envelope)
+			if resp.StatusCode != tc.wantHTTP || envelope.Error.Code != tc.wantCode {
+				t.Fatalf("status=%d code=%q want status=%d code=%q body=%s", resp.StatusCode, envelope.Error.Code, tc.wantHTTP, tc.wantCode, body)
+			}
+		})
+	}
+}
+
+func TestWorkflowMutationRESTBoardModeContracts(t *testing.T) {
+	t.Run("Temporary Board creator is forbidden because workflow requires durable membership", func(t *testing.T) {
+		ts, sqlDB, cleanup := newTestHTTPServer(t, "full")
+		t.Cleanup(cleanup)
+		client := newCookieClient(t)
+		owner := bootstrapUserClient(t, client, ts.URL, "Temporary Creator", "workflow-temp-creator@example.com", "password123")
+		ownerID := int64(owner["id"].(float64))
+		st := store.New(sqlDB, nil)
+		board, err := st.CreateAnonymousBoard(store.WithUserID(context.Background(), ownerID))
+		if err != nil {
+			t.Fatalf("create Temporary Board: %v", err)
+		}
+
+		resp, body := doJSON(t, client, http.MethodPost, ts.URL+"/api/board/"+board.Slug+"/workflow", map[string]any{"name": "Not Allowed"}, nil)
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("Temporary Board workflow status=%d want=403 body=%s", resp.StatusCode, body)
+		}
+	})
+
+	t.Run("Anonymous Board signed-out caller is unauthorized", func(t *testing.T) {
+		ts, sqlDB, cleanup := newTestHTTPServer(t, "full")
+		t.Cleanup(cleanup)
+		st := store.New(sqlDB, nil)
+		board, err := st.CreateAnonymousBoard(context.Background())
+		if err != nil {
+			t.Fatalf("create Anonymous Board: %v", err)
+		}
+
+		resp, body := doJSON(t, ts.Client(), http.MethodPost, ts.URL+"/api/board/"+board.Slug+"/workflow", map[string]any{"name": "Not Allowed"}, nil)
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("Anonymous Board workflow status=%d want=401 body=%s", resp.StatusCode, body)
+		}
+	})
+}

--- a/internal/httpapi/workflow_mutation_transport_contract_test.go
+++ b/internal/httpapi/workflow_mutation_transport_contract_test.go
@@ -76,7 +76,7 @@ func TestWorkflowMutationRESTSuccessRefreshContracts(t *testing.T) {
 		}
 		persisted, ok := workflowColumnByKey(t, columns, created.Key)
 		if !ok || persisted.Name != created.Name {
-			t.Fatalf("created column not persisted once: response=%+v columns=%+v", created, columns)
+			t.Fatalf("created column not persisted as expected: response=%+v columns=%+v", created, columns)
 		}
 		assertWorkflowRESTRefresh(t, collectTodoUpdateEvents(t, stream), fx.project.ID, "workflow_column_added")
 	})

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -13,6 +13,7 @@ import (
 
 	boardapp "scrumboy/internal/application/board"
 	todoapp "scrumboy/internal/application/todo"
+	workflowapp "scrumboy/internal/application/workflow"
 	"scrumboy/internal/publicorigin"
 	"scrumboy/internal/store"
 )
@@ -59,9 +60,7 @@ type storeAPI interface {
 	UpdateProjectMemberRole(ctx context.Context, requesterID, projectID, targetUserID int64, role store.ProjectRole) error
 	RemoveProjectMember(ctx context.Context, requesterID, projectID, targetUserID int64) error
 	GetProjectWorkflow(ctx context.Context, projectID int64) ([]store.WorkflowColumn, error)
-	AddWorkflowColumn(ctx context.Context, projectID int64, name string) (store.WorkflowColumn, error)
-	UpdateWorkflowColumn(ctx context.Context, projectID int64, key, name, color string) error
-	DeleteWorkflowColumn(ctx context.Context, projectID int64, key string) error
+	workflowapp.MutationStore
 	CountTodosForBoardLane(ctx context.Context, projectID int64, columnKey string, tagFilter string, searchFilter string, assigneeFilter store.AssigneeFilter, sprintFilter store.SprintFilter) (int, error)
 	UpdateBoardActivity(ctx context.Context, projectID int64) error
 	CreateProject(ctx context.Context, name string) (store.Project, error)
@@ -89,15 +88,16 @@ type Options struct {
 }
 
 type Adapter struct {
-	store        storeAPI
-	boardReads   *boardapp.MCPBoardReadService
-	todoCreates  *todoapp.MCPCreateService
-	todoMoves    *todoapp.MCPMoveService
-	todoUpdates  *todoapp.MCPUpdateService
-	mode         string
-	tools        toolRegistry
-	publicOrigin *publicorigin.Resolver
-	logger       *log.Logger
+	store             storeAPI
+	boardReads        *boardapp.MCPBoardReadService
+	todoCreates       *todoapp.MCPCreateService
+	todoMoves         *todoapp.MCPMoveService
+	todoUpdates       *todoapp.MCPUpdateService
+	workflowMutations *workflowapp.MCPMutationService
+	mode              string
+	tools             toolRegistry
+	publicOrigin      *publicorigin.Resolver
+	logger            *log.Logger
 }
 
 func New(st storeAPI, opts Options) *Adapter {
@@ -141,6 +141,11 @@ func New(st storeAPI, opts Options) *Adapter {
 			Access: st,
 			Lookup: st,
 			Update: st,
+		}),
+		workflowMutations: workflowapp.NewMCPMutationService(workflowapp.MCPMutationServiceDependencies{
+			Access:    st,
+			Mutations: st,
+			Workflow:  st,
 		}),
 		mode:         mode,
 		tools:        make(toolRegistry),

--- a/internal/mcp/workflow_mutation_transport_contract_test.go
+++ b/internal/mcp/workflow_mutation_transport_contract_test.go
@@ -1,0 +1,310 @@
+package mcp_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/db"
+	"scrumboy/internal/httpapi"
+	"scrumboy/internal/mcp"
+	"scrumboy/internal/migrate"
+	"scrumboy/internal/store"
+)
+
+func workflowMCPData(t *testing.T, transport string, response map[string]any) map[string]any {
+	t.Helper()
+	if transport == "legacy" {
+		if got, want := sortedMapKeys(response), []string{"data", "meta", "ok"}; !reflect.DeepEqual(got, want) || response["ok"] != true {
+			t.Fatalf("legacy success envelope=%+v keys=%v want=%v", response, got, want)
+		}
+		if meta := response["meta"].(map[string]any); len(meta) != 0 {
+			t.Fatalf("legacy metadata=%+v want empty", meta)
+		}
+		return response["data"].(map[string]any)
+	}
+
+	if got, want := sortedMapKeys(response), []string{"id", "jsonrpc", "result"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("JSON-RPC envelope=%+v keys=%v want=%v", response, got, want)
+	}
+	result := response["result"].(map[string]any)
+	if got, want := sortedMapKeys(result), []string{"content", "structuredContent"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("JSON-RPC result=%+v keys=%v want=%v", result, got, want)
+	}
+	data := result["structuredContent"].(map[string]any)
+	content := result["content"].([]any)
+	if len(content) != 1 || content[0].(map[string]any)["type"] != "text" {
+		t.Fatalf("JSON-RPC content=%+v", content)
+	}
+	var textData map[string]any
+	if err := json.Unmarshal([]byte(content[0].(map[string]any)["text"].(string)), &textData); err != nil {
+		t.Fatalf("decode JSON-RPC text content: %v", err)
+	}
+	if !reflect.DeepEqual(textData, data) {
+		t.Fatalf("JSON-RPC text/structured divergence: text=%+v structured=%+v", textData, data)
+	}
+	return data
+}
+
+func TestWorkflowMutationMCPTransportAndRealtimeContracts(t *testing.T) {
+	operations := []string{"create", "update", "delete"}
+	transports := []string{"legacy", "jsonrpc"}
+	for _, operation := range operations {
+		for _, transport := range transports {
+			t.Run(transport+"/"+operation, func(t *testing.T) {
+				ts, sqlDB, st, cleanup := newTodoUpdateMCPServer(t, "full")
+				t.Cleanup(cleanup)
+				client := newCookieClient(t, ts)
+				bootstrapUser(t, client, ts.URL)
+				ownerID := firstUserID(t, sqlDB)
+				ctx := store.WithUserID(context.Background(), ownerID)
+				project, err := st.CreateProject(ctx, "workflow MCP "+transport+" "+operation)
+				if err != nil {
+					t.Fatalf("create project: %v", err)
+				}
+
+				tool := "workflow_" + operation
+				args := map[string]any{"projectSlug": project.Slug}
+				var targetKey string
+				switch operation {
+				case "create":
+					args["name"] = "Code Review"
+					targetKey = "code_review"
+				case "update":
+					args["columnKey"] = store.DefaultColumnDoing
+					args["name"] = "Building"
+					args["color"] = "#123456"
+					targetKey = store.DefaultColumnDoing
+				case "delete":
+					column, err := st.AddWorkflowColumn(ctx, project.ID, "Disposable")
+					if err != nil {
+						t.Fatalf("add delete fixture: %v", err)
+					}
+					args["columnKey"] = column.Key
+					targetKey = column.Key
+				}
+
+				stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+				defer stream.close()
+				resp, out := callTodoUpdateMCP(t, client, ts.URL, transport, tool, args)
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("%s %s status=%d response=%+v", transport, tool, resp.StatusCode, out)
+				}
+				data := workflowMCPData(t, transport, out)
+
+				columns, err := st.GetProjectWorkflow(ctx, project.ID)
+				if err != nil {
+					t.Fatalf("get workflow: %v", err)
+				}
+				switch operation {
+				case "create":
+					column := data["column"].(map[string]any)
+					if column["key"] != targetKey || column["name"] != "Code Review" || column["isDone"] != false || column["system"] != false {
+						t.Fatalf("create projection=%+v", column)
+					}
+					persisted, ok := workflowColumnByKeyMCP(columns, targetKey)
+					if !ok || persisted.Name != "Code Review" {
+						t.Fatalf("create persistence=%+v", columns)
+					}
+				case "update":
+					column := data["column"].(map[string]any)
+					if column["key"] != targetKey || column["name"] != "Building" || column["color"] != "#123456" {
+						t.Fatalf("update projection=%+v", column)
+					}
+					persisted, ok := workflowColumnByKeyMCP(columns, targetKey)
+					if !ok || persisted.Name != "Building" || persisted.Color != "#123456" {
+						t.Fatalf("update persistence=%+v", columns)
+					}
+				case "delete":
+					deleted := data["deleted"].(map[string]any)
+					if deleted["projectSlug"] != project.Slug || deleted["columnKey"] != targetKey {
+						t.Fatalf("delete projection=%+v", deleted)
+					}
+					if _, ok := workflowColumnByKeyMCP(columns, targetKey); ok {
+						t.Fatalf("deleted column %q still present: %+v", targetKey, columns)
+					}
+				}
+				if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+					t.Fatalf("MCP workflow mutation emitted realtime events: %+v", events)
+				}
+			})
+		}
+	}
+}
+
+func workflowColumnByKeyMCP(columns []store.WorkflowColumn, key string) (store.WorkflowColumn, bool) {
+	for _, column := range columns {
+		if column.Key == key {
+			return column, true
+		}
+	}
+	return store.WorkflowColumn{}, false
+}
+
+func TestWorkflowMutationMCPSemanticValidationPrecedesAccess(t *testing.T) {
+	ts, _, _, cleanup := newTodoUpdateMCPServer(t, "full")
+	t.Cleanup(cleanup)
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+
+	t.Run("invalid name wins before missing project", func(t *testing.T) {
+		resp, out := callTodoUpdateMCP(t, client, ts.URL, "legacy", "workflow_create", map[string]any{
+			"projectSlug": "missing-workflow-board",
+			"name":        "   ",
+		})
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		errBody := out["error"].(map[string]any)
+		if errBody["code"] != "VALIDATION_ERROR" || errBody["message"] != "name required" {
+			t.Fatalf("validation error=%+v", errBody)
+		}
+	})
+
+	t.Run("valid semantics reach project access", func(t *testing.T) {
+		resp, out := callTodoUpdateMCP(t, client, ts.URL, "legacy", "workflow_create", map[string]any{
+			"projectSlug": "missing-workflow-board",
+			"name":        "Valid Name",
+		})
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		if code := out["error"].(map[string]any)["code"]; code != "NOT_FOUND" {
+			t.Fatalf("access error code=%v want NOT_FOUND", code)
+		}
+	})
+}
+
+func TestWorkflowMutationMCPBoardModeContracts(t *testing.T) {
+	t.Run("Temporary Board creator is forbidden because access context has no durable role", func(t *testing.T) {
+		ts, sqlDB, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		t.Cleanup(cleanup)
+		client := newCookieClient(t, ts)
+		bootstrapUser(t, client, ts.URL)
+		ownerID := firstUserID(t, sqlDB)
+		board, err := st.CreateAnonymousBoard(store.WithUserID(context.Background(), ownerID))
+		if err != nil {
+			t.Fatalf("create Temporary Board: %v", err)
+		}
+
+		resp, out := callTodoUpdateMCP(t, client, ts.URL, "legacy", "workflow_create", map[string]any{
+			"projectSlug": board.Slug,
+			"name":        "Not Allowed",
+		})
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("Temporary Board status=%d response=%+v", resp.StatusCode, out)
+		}
+		if code := out["error"].(map[string]any)["code"]; code != "FORBIDDEN" {
+			t.Fatalf("Temporary Board error=%+v", out)
+		}
+	})
+
+	t.Run("Anonymous Mode reports capability unavailable", func(t *testing.T) {
+		ts, _, st, cleanup := newTodoUpdateMCPServer(t, "anonymous")
+		t.Cleanup(cleanup)
+		board, err := st.CreateAnonymousBoard(context.Background())
+		if err != nil {
+			t.Fatalf("create Anonymous Board: %v", err)
+		}
+
+		resp, out := callTodoUpdateMCP(t, ts.Client(), ts.URL, "legacy", "workflow_create", map[string]any{
+			"projectSlug": board.Slug,
+			"name":        "Not Allowed",
+		})
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("Anonymous Mode status=%d response=%+v", resp.StatusCode, out)
+		}
+		errBody := out["error"].(map[string]any)
+		if errBody["code"] != "CAPABILITY_UNAVAILABLE" || errBody["message"] != "workflow_create is unavailable in anonymous mode" {
+			t.Fatalf("Anonymous Mode error=%+v", errBody)
+		}
+	})
+}
+
+type workflowPostReadFailureStore struct {
+	*store.Store
+	err       error
+	readCalls int
+}
+
+func (s *workflowPostReadFailureStore) GetProjectWorkflow(context.Context, int64) ([]store.WorkflowColumn, error) {
+	s.readCalls++
+	return nil, s.err
+}
+
+func newWorkflowPostReadFailureServer(t *testing.T, readErr error) (*httptest.Server, *sql.DB, *workflowPostReadFailureStore, func()) {
+	t.Helper()
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "app.db"), db.Options{
+		BusyTimeout: 5000,
+		JournalMode: "WAL",
+		Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := migrate.Apply(context.Background(), sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+	wrapped := &workflowPostReadFailureStore{Store: store.New(sqlDB, nil), err: readErr}
+	srv := httpapi.NewServer(wrapped, httpapi.Options{
+		MaxRequestBody: 1 << 20,
+		ScrumboyMode:   "full",
+		MCPHandler:     mcp.New(wrapped, mcp.Options{Mode: "full"}),
+	})
+	ts := httptest.NewServer(srv)
+	return ts, sqlDB, wrapped, func() {
+		ts.Close()
+		_ = sqlDB.Close()
+	}
+}
+
+func TestWorkflowMutationMCPUpdatePostReadFailureOccursAfterCommit(t *testing.T) {
+	readErr := errors.New("forced workflow post-read failure")
+	ts, sqlDB, wrapped, cleanup := newWorkflowPostReadFailureServer(t, readErr)
+	t.Cleanup(cleanup)
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	ownerID := firstUserID(t, sqlDB)
+	ctx := store.WithUserID(context.Background(), ownerID)
+	project, err := wrapped.Store.CreateProject(ctx, "workflow MCP post-read failure")
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+	defer stream.close()
+
+	resp, out := callTodoUpdateMCP(t, client, ts.URL, "legacy", "workflow_update", map[string]any{
+		"projectSlug": project.Slug,
+		"columnKey":   store.DefaultColumnDoing,
+		"name":        "Committed Before Read Failure",
+		"color":       "#654321",
+	})
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+	}
+	errBody := out["error"].(map[string]any)
+	if errBody["code"] != "INTERNAL" || errBody["message"] != "internal error" {
+		t.Fatalf("post-read error envelope=%+v", errBody)
+	}
+	if wrapped.readCalls != 1 {
+		t.Fatalf("post-read calls=%d want=1", wrapped.readCalls)
+	}
+	columns, err := wrapped.Store.GetProjectWorkflow(ctx, project.ID)
+	if err != nil {
+		t.Fatalf("read committed workflow: %v", err)
+	}
+	updated, ok := workflowColumnByKeyMCP(columns, store.DefaultColumnDoing)
+	if !ok || updated.Name != "Committed Before Read Failure" || updated.Color != "#654321" {
+		t.Fatalf("update did not commit before post-read failure: %+v", columns)
+	}
+	if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+		t.Fatalf("post-read failure emitted realtime events: %+v", events)
+	}
+}

--- a/internal/mcp/workflow_mutation_transport_contract_test.go
+++ b/internal/mcp/workflow_mutation_transport_contract_test.go
@@ -5,10 +5,12 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"scrumboy/internal/db"
@@ -227,18 +229,26 @@ func TestWorkflowMutationMCPBoardModeContracts(t *testing.T) {
 	})
 }
 
-type workflowPostReadFailureStore struct {
+type workflowPostReadStore struct {
 	*store.Store
 	err       error
+	workflow  []store.WorkflowColumn
 	readCalls int
 }
 
-func (s *workflowPostReadFailureStore) GetProjectWorkflow(context.Context, int64) ([]store.WorkflowColumn, error) {
+func (s *workflowPostReadStore) GetProjectWorkflow(context.Context, int64) ([]store.WorkflowColumn, error) {
 	s.readCalls++
-	return nil, s.err
+	if s.err != nil {
+		return nil, s.err
+	}
+	return append([]store.WorkflowColumn(nil), s.workflow...), nil
 }
 
-func newWorkflowPostReadFailureServer(t *testing.T, readErr error) (*httptest.Server, *sql.DB, *workflowPostReadFailureStore, func()) {
+func newWorkflowPostReadServer(
+	t *testing.T,
+	readErr error,
+	workflow []store.WorkflowColumn,
+) (*httptest.Server, *sql.DB, *workflowPostReadStore, func()) {
 	t.Helper()
 	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "app.db"), db.Options{
 		BusyTimeout: 5000,
@@ -252,7 +262,7 @@ func newWorkflowPostReadFailureServer(t *testing.T, readErr error) (*httptest.Se
 		_ = sqlDB.Close()
 		t.Fatalf("migrate: %v", err)
 	}
-	wrapped := &workflowPostReadFailureStore{Store: store.New(sqlDB, nil), err: readErr}
+	wrapped := &workflowPostReadStore{Store: store.New(sqlDB, nil), err: readErr, workflow: workflow}
 	srv := httpapi.NewServer(wrapped, httpapi.Options{
 		MaxRequestBody: 1 << 20,
 		ScrumboyMode:   "full",
@@ -266,45 +276,156 @@ func newWorkflowPostReadFailureServer(t *testing.T, readErr error) (*httptest.Se
 }
 
 func TestWorkflowMutationMCPUpdatePostReadFailureOccursAfterCommit(t *testing.T) {
-	readErr := errors.New("forced workflow post-read failure")
-	ts, sqlDB, wrapped, cleanup := newWorkflowPostReadFailureServer(t, readErr)
-	t.Cleanup(cleanup)
-	client := newCookieClient(t, ts)
-	bootstrapUser(t, client, ts.URL)
-	ownerID := firstUserID(t, sqlDB)
-	ctx := store.WithUserID(context.Background(), ownerID)
-	project, err := wrapped.Store.CreateProject(ctx, "workflow MCP post-read failure")
-	if err != nil {
-		t.Fatalf("create project: %v", err)
+	tests := []struct {
+		name             string
+		transport        string
+		readErr          error
+		workflow         []store.WorkflowColumn
+		wantLegacyStatus int
+		wantCode         string
+		wantMessage      string
+	}{
+		{
+			name:             "legacy generic read failure",
+			transport:        "legacy",
+			readErr:          errors.New("forced workflow post-read failure"),
+			wantLegacyStatus: http.StatusInternalServerError,
+			wantCode:         "INTERNAL",
+			wantMessage:      "internal error",
+		},
+		{
+			name:             "legacy wrapped not found",
+			transport:        "legacy",
+			readErr:          fmt.Errorf("wrapped workflow read failure: %w", store.ErrNotFound),
+			wantLegacyStatus: http.StatusNotFound,
+			wantCode:         "NOT_FOUND",
+			wantMessage:      "not found",
+		},
+		{
+			name:        "JSON-RPC wrapped not found",
+			transport:   "jsonrpc",
+			readErr:     fmt.Errorf("wrapped JSON-RPC workflow read failure: %w", store.ErrNotFound),
+			wantCode:    "NOT_FOUND",
+			wantMessage: "not found",
+		},
+		{
+			name:             "legacy missing updated column",
+			transport:        "legacy",
+			workflow:         []store.WorkflowColumn{{Key: "other"}},
+			wantLegacyStatus: http.StatusInternalServerError,
+			wantCode:         "INTERNAL",
+			wantMessage:      "internal error",
+		},
+		{
+			name:        "JSON-RPC missing updated column",
+			transport:   "jsonrpc",
+			workflow:    []store.WorkflowColumn{{Key: "other"}},
+			wantCode:    "INTERNAL",
+			wantMessage: "internal error",
+		},
 	}
-	stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
-	defer stream.close()
 
-	resp, out := callTodoUpdateMCP(t, client, ts.URL, "legacy", "workflow_update", map[string]any{
-		"projectSlug": project.Slug,
-		"columnKey":   store.DefaultColumnDoing,
-		"name":        "Committed Before Read Failure",
-		"color":       "#654321",
-	})
-	if resp.StatusCode != http.StatusInternalServerError {
-		t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, sqlDB, wrapped, cleanup := newWorkflowPostReadServer(t, tt.readErr, tt.workflow)
+			t.Cleanup(cleanup)
+			client := newCookieClient(t, ts)
+			bootstrapUser(t, client, ts.URL)
+			ownerID := firstUserID(t, sqlDB)
+			ctx := store.WithUserID(context.Background(), ownerID)
+			project, err := wrapped.Store.CreateProject(ctx, "workflow MCP "+tt.name)
+			if err != nil {
+				t.Fatalf("create project: %v", err)
+			}
+			stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+			defer stream.close()
+
+			resp, out := callTodoUpdateMCP(t, client, ts.URL, tt.transport, "workflow_update", map[string]any{
+				"projectSlug": project.Slug,
+				"columnKey":   store.DefaultColumnDoing,
+				"name":        "Committed Before Read Failure",
+				"color":       "#654321",
+			})
+			assertWorkflowPostReadMCPError(
+				t,
+				tt.transport,
+				resp,
+				out,
+				tt.readErr,
+				tt.wantLegacyStatus,
+				tt.wantCode,
+				tt.wantMessage,
+			)
+
+			if wrapped.readCalls != 1 {
+				t.Fatalf("post-read calls=%d want=1", wrapped.readCalls)
+			}
+			columns, err := wrapped.Store.GetProjectWorkflow(ctx, project.ID)
+			if err != nil {
+				t.Fatalf("read committed workflow: %v", err)
+			}
+			updated, ok := workflowColumnByKeyMCP(columns, store.DefaultColumnDoing)
+			if !ok || updated.Name != "Committed Before Read Failure" || updated.Color != "#654321" {
+				t.Fatalf("update did not commit before post-read failure: %+v", columns)
+			}
+			if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+				t.Fatalf("post-read failure emitted realtime events: %+v", events)
+			}
+		})
 	}
-	errBody := out["error"].(map[string]any)
-	if errBody["code"] != "INTERNAL" || errBody["message"] != "internal error" {
-		t.Fatalf("post-read error envelope=%+v", errBody)
+}
+
+func assertWorkflowPostReadMCPError(
+	t *testing.T,
+	transport string,
+	resp *http.Response,
+	out map[string]any,
+	readErr error,
+	wantLegacyStatus int,
+	wantCode string,
+	wantMessage string,
+) {
+	t.Helper()
+
+	var publicError map[string]any
+	if transport == "legacy" {
+		if resp.StatusCode != wantLegacyStatus {
+			t.Fatalf("status=%d want=%d response=%+v", resp.StatusCode, wantLegacyStatus, out)
+		}
+		publicError = out["error"].(map[string]any)
+	} else {
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("JSON-RPC status=%d response=%+v", resp.StatusCode, out)
+		}
+		result := out["result"].(map[string]any)
+		if result["isError"] != true {
+			t.Fatalf("JSON-RPC result=%+v want isError=true", result)
+		}
+		content := result["content"].([]any)
+		if len(content) != 1 || content[0].(map[string]any)["type"] != "text" || content[0].(map[string]any)["text"] != wantMessage {
+			t.Fatalf("JSON-RPC content=%+v", content)
+		}
+		publicError = result["structuredContent"].(map[string]any)
 	}
-	if wrapped.readCalls != 1 {
-		t.Fatalf("post-read calls=%d want=1", wrapped.readCalls)
+
+	if publicError["code"] != wantCode || publicError["message"] != wantMessage {
+		t.Fatalf("post-read error envelope=%+v", publicError)
 	}
-	columns, err := wrapped.Store.GetProjectWorkflow(ctx, project.ID)
+	details := publicError["details"].(map[string]any)
+	if len(details) != 0 {
+		t.Fatalf("post-read public details=%+v want empty", details)
+	}
+	encoded, err := json.Marshal(out)
 	if err != nil {
-		t.Fatalf("read committed workflow: %v", err)
+		t.Fatalf("marshal response: %v", err)
 	}
-	updated, ok := workflowColumnByKeyMCP(columns, store.DefaultColumnDoing)
-	if !ok || updated.Name != "Committed Before Read Failure" || updated.Color != "#654321" {
-		t.Fatalf("update did not commit before post-read failure: %+v", columns)
+	forbiddenValues := []string{store.DefaultColumnDoing}
+	if readErr != nil {
+		forbiddenValues = append(forbiddenValues, readErr.Error())
 	}
-	if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
-		t.Fatalf("post-read failure emitted realtime events: %+v", events)
+	for _, forbidden := range forbiddenValues {
+		if strings.Contains(string(encoded), forbidden) {
+			t.Fatalf("public response leaked %q: %s", forbidden, encoded)
+		}
 	}
 }

--- a/internal/mcp/workflow_tools.go
+++ b/internal/mcp/workflow_tools.go
@@ -2,9 +2,11 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 
+	workflowapp "scrumboy/internal/application/workflow"
 	"scrumboy/internal/store"
 )
 
@@ -40,15 +42,37 @@ func workflowColumnToItem(col store.WorkflowColumn) workflowColumnItem {
 	}
 }
 
-func (a *Adapter) requireMaintainerProjectContext(ctx context.Context, projectSlug string) (store.ProjectContext, *adapterError) {
-	pc, pcErr := a.store.GetProjectContextBySlug(ctx, projectSlug, a.storeMode())
-	if pcErr != nil {
-		return store.ProjectContext{}, mapStoreError(pcErr)
+func mapWorkflowMutationPrepareError(err error) *adapterError {
+	if errors.Is(err, workflowapp.ErrMaintainerRequired) {
+		return newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
 	}
-	if !pc.Role.HasMinimumRole(store.RoleMaintainer) {
-		return store.ProjectContext{}, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
+	return mapStoreError(err)
+}
+
+func mapWorkflowMutationUpdateError(err error) *adapterError {
+	switch {
+	case errors.Is(err, workflowapp.ErrWorkflowProjectionColumnMissing):
+		projectionErr := newAdapterError(
+			http.StatusInternalServerError,
+			CodeInternal,
+			"internal error",
+			map[string]any{"detail": "updated workflow column not found in post-read"},
+		)
+		projectionErr.Cause = err
+		return projectionErr
+	case errors.Is(err, workflowapp.ErrWorkflowProjectionFailed):
+		if cause := errors.Unwrap(err); cause != nil {
+			mapped := mapStoreError(cause)
+			mapped.Cause = err
+			return mapped
+		}
+
+		projectionErr := newAdapterError(http.StatusInternalServerError, CodeInternal, "internal error", nil)
+		projectionErr.Cause = err
+		return projectionErr
+	default:
+		return mapStoreError(err)
 	}
-	return pc, nil
 }
 
 func (a *Adapter) handleWorkflowList(ctx context.Context, input any) (any, map[string]any, *adapterError) {
@@ -124,12 +148,15 @@ func (a *Adapter) handleWorkflowCreate(ctx context.Context, input any) (any, map
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid workflow column name", map[string]any{"field": "name"})
 	}
 
-	pc, pcErr := a.requireMaintainerProjectContext(ctx, in.ProjectSlug)
-	if pcErr != nil {
-		return nil, nil, pcErr
+	prepared, prepareErr := a.workflowMutations.Prepare(ctx, workflowapp.MCPMutationTarget{
+		ProjectSlug: in.ProjectSlug,
+		Mode:        a.storeMode(),
+	})
+	if prepareErr != nil {
+		return nil, nil, mapWorkflowMutationPrepareError(prepareErr)
 	}
 
-	col, colErr := a.store.AddWorkflowColumn(ctx, pc.Project.ID, in.Name)
+	col, colErr := prepared.Create(workflowapp.CreateCommand{Name: in.Name})
 	if colErr != nil {
 		return nil, nil, mapStoreError(colErr)
 	}
@@ -180,31 +207,26 @@ func (a *Adapter) handleWorkflowUpdate(ctx context.Context, input any) (any, map
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid workflow column color", map[string]any{"field": "color"})
 	}
 
-	pc, pcErr := a.requireMaintainerProjectContext(ctx, in.ProjectSlug)
-	if pcErr != nil {
-		return nil, nil, pcErr
+	prepared, prepareErr := a.workflowMutations.Prepare(ctx, workflowapp.MCPMutationTarget{
+		ProjectSlug: in.ProjectSlug,
+		Mode:        a.storeMode(),
+	})
+	if prepareErr != nil {
+		return nil, nil, mapWorkflowMutationPrepareError(prepareErr)
 	}
 
-	if updateErr := a.store.UpdateWorkflowColumn(ctx, pc.Project.ID, in.ColumnKey, in.Name, in.Color); updateErr != nil {
-		return nil, nil, mapStoreError(updateErr)
+	col, updateErr := prepared.Update(workflowapp.UpdateCommand{
+		Key:   in.ColumnKey,
+		Name:  in.Name,
+		Color: in.Color,
+	})
+	if updateErr != nil {
+		return nil, nil, mapWorkflowMutationUpdateError(updateErr)
 	}
 
-	workflow, workflowErr := a.store.GetProjectWorkflow(ctx, pc.Project.ID)
-	if workflowErr != nil {
-		return nil, nil, mapStoreError(workflowErr)
-	}
-	for _, col := range workflow {
-		if col.Key == in.ColumnKey {
-			return map[string]any{
-				"column": workflowColumnToItem(col),
-			}, map[string]any{}, nil
-		}
-	}
-
-	// Existence was already verified by the store update above succeeding; if the
-	// column vanishes here, treat it as an internal inconsistency rather than
-	// weakening the contract with a not-found response.
-	return nil, nil, newAdapterError(http.StatusInternalServerError, CodeInternal, "internal error", map[string]any{"detail": "updated workflow column not found in post-read"})
+	return map[string]any{
+		"column": workflowColumnToItem(col),
+	}, map[string]any{}, nil
 }
 
 func (a *Adapter) handleWorkflowDelete(ctx context.Context, input any) (any, map[string]any, *adapterError) {
@@ -234,12 +256,15 @@ func (a *Adapter) handleWorkflowDelete(ctx context.Context, input any) (any, map
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "missing columnKey", map[string]any{"field": "columnKey"})
 	}
 
-	pc, pcErr := a.requireMaintainerProjectContext(ctx, in.ProjectSlug)
-	if pcErr != nil {
-		return nil, nil, pcErr
+	prepared, prepareErr := a.workflowMutations.Prepare(ctx, workflowapp.MCPMutationTarget{
+		ProjectSlug: in.ProjectSlug,
+		Mode:        a.storeMode(),
+	})
+	if prepareErr != nil {
+		return nil, nil, mapWorkflowMutationPrepareError(prepareErr)
 	}
 
-	if deleteErr := a.store.DeleteWorkflowColumn(ctx, pc.Project.ID, in.ColumnKey); deleteErr != nil {
+	if deleteErr := prepared.Delete(workflowapp.DeleteCommand{Key: in.ColumnKey}); deleteErr != nil {
 		return nil, nil, mapStoreError(deleteErr)
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.29.3"
+const Version = "3.29.4"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
REST and MCP workflow col create, update, and delete now share command boundaries instead of owning write logic in the transports. Part of an on-going refactor effort.