### PR TITLE
Refactor/project membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.29.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags), **3.29.0** (MCP JSON-RPC error/`board_get` identity) - see those releases.
 
+## [3.29.5] - 2026-08-03
+
+### Changed
+
+- **Project membership mutations move behind application services** - REST and
+  MCP member add, role update, and remove now share
+  `internal/application/membership` command boundaries instead of owning write
+  logic in the transports. HTTP and MCP adapters stay thin wrappers;
+  permissions, validation, response shapes, and REST membership-event side
+  effects are preserved. Contract tests lock the migrated mutation paths.
+
 ## [3.29.4] - 2026-08-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.29.4-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.29.5-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/internal/application/membership/mcp_mutation.go
+++ b/internal/application/membership/mcp_mutation.go
@@ -1,0 +1,160 @@
+package membership
+
+import (
+	"context"
+	"errors"
+
+	"scrumboy/internal/store"
+)
+
+var (
+	// ErrMaintainerRequired reports that the slug-resolved MCP project role does
+	// not satisfy the current membership-mutation precheck.
+	ErrMaintainerRequired = errors.New("membership mutation maintainer required")
+
+	// ErrAddedMemberMissing identifies a successful add and member-list read
+	// whose result does not contain the requested target.
+	ErrAddedMemberMissing = errors.New("added member missing from post-write projection")
+
+	// ErrUpdatedMemberMissing identifies a successful role update and member-list
+	// read whose result does not contain the requested target.
+	ErrUpdatedMemberMissing = errors.New("updated member missing from post-write projection")
+)
+
+// MCPMutationAccessStore resolves the project-slug access boundary used by MCP
+// membership mutations.
+type MCPMutationAccessStore interface {
+	GetProjectContextBySlug(
+		ctx context.Context,
+		slug string,
+		mode store.Mode,
+	) (store.ProjectContext, error)
+}
+
+// MCPMutationServiceDependencies names the access, persistence, and post-write
+// read capabilities used by canonical MCP membership mutations.
+type MCPMutationServiceDependencies struct {
+	Access    MCPMutationAccessStore
+	Mutations MutationStore
+	Members   MemberListStore
+}
+
+// MCPMutationService owns slug access, the current Maintainer precheck,
+// requester binding, persistence, and add/update target selection. It
+// deliberately has no refresh or event dependency.
+type MCPMutationService struct {
+	access    MCPMutationAccessStore
+	mutations MutationStore
+	members   MemberListStore
+}
+
+func NewMCPMutationService(deps MCPMutationServiceDependencies) *MCPMutationService {
+	return &MCPMutationService{
+		access:    deps.Access,
+		mutations: deps.Mutations,
+		members:   deps.Members,
+	}
+}
+
+// MCPMutationTarget contains only the slug and mode needed for access. Neither
+// value is retained after preparation.
+type MCPMutationTarget struct {
+	ProjectSlug string
+	Mode        store.Mode
+}
+
+// PreparedMCPMutation binds the exact access context, requester identity, and
+// resolved project identity to subsequent membership mutations.
+type PreparedMCPMutation struct {
+	ctx         context.Context
+	service     *MCPMutationService
+	requesterID int64
+	projectID   int64
+}
+
+// Prepare preserves the current MCP ordering: slug access, resolved-role
+// precheck, then requester extraction from the same context. Semantic input
+// validation remains adapter-owned and must precede this call.
+func (s *MCPMutationService) Prepare(
+	ctx context.Context,
+	target MCPMutationTarget,
+) (*PreparedMCPMutation, error) {
+	projectContext, err := s.access.GetProjectContextBySlug(ctx, target.ProjectSlug, target.Mode)
+	if err != nil {
+		return nil, err
+	}
+	if !projectContext.Role.HasMinimumRole(store.RoleMaintainer) {
+		return nil, ErrMaintainerRequired
+	}
+	requesterID, ok := store.UserIDFromContext(ctx)
+	if !ok {
+		return nil, ErrActorRequired
+	}
+	return &PreparedMCPMutation{
+		ctx:         ctx,
+		service:     s,
+		requesterID: requesterID,
+		projectID:   projectContext.Project.ID,
+	}, nil
+}
+
+// Add persists one adapter-prepared command, then returns the requested member
+// from the authorization-sensitive post-write list.
+func (p *PreparedMCPMutation) Add(command AddCommand) (store.ProjectMember, error) {
+	if err := p.service.mutations.AddProjectMember(
+		p.ctx,
+		p.requesterID,
+		p.projectID,
+		command.TargetUserID,
+		command.Role,
+	); err != nil {
+		return store.ProjectMember{}, err
+	}
+
+	members, err := p.service.members.ListProjectMembers(p.ctx, p.projectID, p.requesterID)
+	if err != nil {
+		return store.ProjectMember{}, err
+	}
+	for _, member := range members {
+		if member.UserID == command.TargetUserID {
+			return member, nil
+		}
+	}
+	return store.ProjectMember{}, ErrAddedMemberMissing
+}
+
+// UpdateRole deliberately performs no semantic comparison. Every successful
+// mutation proceeds to the current target-selecting post-write read.
+func (p *PreparedMCPMutation) UpdateRole(command UpdateRoleCommand) (store.ProjectMember, error) {
+	if err := p.service.mutations.UpdateProjectMemberRole(
+		p.ctx,
+		p.requesterID,
+		p.projectID,
+		command.TargetUserID,
+		command.Role,
+	); err != nil {
+		return store.ProjectMember{}, err
+	}
+
+	members, err := p.service.members.ListProjectMembers(p.ctx, p.projectID, p.requesterID)
+	if err != nil {
+		return store.ProjectMember{}, err
+	}
+	for _, member := range members {
+		if member.UserID == command.TargetUserID {
+			return member, nil
+		}
+	}
+	return store.ProjectMember{}, ErrUpdatedMemberMissing
+}
+
+// Remove preserves the current MCP mutation-only path. Requested-slug and
+// target-user response projection remain adapter-owned.
+func (p *PreparedMCPMutation) Remove(command RemoveCommand) error {
+	return p.service.mutations.RemoveProjectMember(
+		p.ctx,
+		p.requesterID,
+		p.projectID,
+		command.TargetUserID,
+	)
+}

--- a/internal/application/membership/mcp_mutation_test.go
+++ b/internal/application/membership/mcp_mutation_test.go
@@ -1,0 +1,535 @@
+package membership
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+var _ MCPMutationAccessStore = (*store.Store)(nil)
+
+type mcpMutationContextKey struct{}
+
+type mcpMembershipAccessCall struct {
+	ctx  context.Context
+	slug string
+	mode store.Mode
+}
+
+type mcpMembershipMutationCall struct {
+	operation   string
+	ctx         context.Context
+	requesterID int64
+	projectID   int64
+	targetID    int64
+	role        store.ProjectRole
+}
+
+type mcpMembershipListCall struct {
+	ctx         context.Context
+	projectID   int64
+	requesterID int64
+}
+
+type mcpMutationFake struct {
+	trace []string
+
+	projectContext store.ProjectContext
+	accessErr      error
+	addErr         error
+	updateErr      error
+	removeErr      error
+	listErr        error
+	members        []store.ProjectMember
+	honorContext   bool
+	afterMutation  func()
+
+	accessCalls   []mcpMembershipAccessCall
+	mutationCalls []mcpMembershipMutationCall
+	listCalls     []mcpMembershipListCall
+}
+
+func (f *mcpMutationFake) GetProjectContextBySlug(
+	ctx context.Context,
+	slug string,
+	mode store.Mode,
+) (store.ProjectContext, error) {
+	f.trace = append(f.trace, "access")
+	f.accessCalls = append(f.accessCalls, mcpMembershipAccessCall{ctx: ctx, slug: slug, mode: mode})
+	if f.honorContext && ctx.Err() != nil {
+		return store.ProjectContext{}, ctx.Err()
+	}
+	if f.accessErr != nil {
+		return store.ProjectContext{}, f.accessErr
+	}
+	return f.projectContext, nil
+}
+
+func (f *mcpMutationFake) AddProjectMember(
+	ctx context.Context,
+	requesterID int64,
+	projectID int64,
+	targetUserID int64,
+	role store.ProjectRole,
+) error {
+	f.trace = append(f.trace, "add")
+	f.mutationCalls = append(f.mutationCalls, mcpMembershipMutationCall{
+		operation: "add", ctx: ctx, requesterID: requesterID, projectID: projectID,
+		targetID: targetUserID, role: role,
+	})
+	if f.honorContext && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if f.addErr != nil {
+		return f.addErr
+	}
+	if f.afterMutation != nil {
+		f.afterMutation()
+	}
+	return nil
+}
+
+func (f *mcpMutationFake) UpdateProjectMemberRole(
+	ctx context.Context,
+	requesterID int64,
+	projectID int64,
+	targetUserID int64,
+	role store.ProjectRole,
+) error {
+	f.trace = append(f.trace, "update_role")
+	f.mutationCalls = append(f.mutationCalls, mcpMembershipMutationCall{
+		operation: "update_role", ctx: ctx, requesterID: requesterID, projectID: projectID,
+		targetID: targetUserID, role: role,
+	})
+	if f.honorContext && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	if f.afterMutation != nil {
+		f.afterMutation()
+	}
+	return nil
+}
+
+func (f *mcpMutationFake) RemoveProjectMember(
+	ctx context.Context,
+	requesterID int64,
+	projectID int64,
+	targetUserID int64,
+) error {
+	f.trace = append(f.trace, "remove")
+	f.mutationCalls = append(f.mutationCalls, mcpMembershipMutationCall{
+		operation: "remove", ctx: ctx, requesterID: requesterID, projectID: projectID,
+		targetID: targetUserID,
+	})
+	if f.honorContext && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if f.removeErr != nil {
+		return f.removeErr
+	}
+	if f.afterMutation != nil {
+		f.afterMutation()
+	}
+	return nil
+}
+
+func (f *mcpMutationFake) ListProjectMembers(
+	ctx context.Context,
+	projectID int64,
+	requesterID int64,
+) ([]store.ProjectMember, error) {
+	f.trace = append(f.trace, "list")
+	f.listCalls = append(f.listCalls, mcpMembershipListCall{
+		ctx: ctx, projectID: projectID, requesterID: requesterID,
+	})
+	if f.honorContext && ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.members, nil
+}
+
+func newMCPMutationTestService(fake *mcpMutationFake) *MCPMutationService {
+	return NewMCPMutationService(MCPMutationServiceDependencies{
+		Access:    fake,
+		Mutations: fake,
+		Members:   fake,
+	})
+}
+
+func mcpMutationActorContext(userID int64, marker string) context.Context {
+	ctx := context.WithValue(context.Background(), mcpMutationContextKey{}, marker)
+	return store.WithUserID(ctx, userID)
+}
+
+func assertMCPMutationTrace(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("call trace=%v want=%v", got, want)
+	}
+}
+
+func preparedMCPMutationForTest(
+	t *testing.T,
+	fake *mcpMutationFake,
+	ctx context.Context,
+) *PreparedMCPMutation {
+	t.Helper()
+	prepared, err := newMCPMutationTestService(fake).Prepare(ctx, MCPMutationTarget{
+		ProjectSlug: "bound-project",
+		Mode:        store.ModeFull,
+	})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	return prepared
+}
+
+func TestMCPMutationPrepareOrderingAndBinding(t *testing.T) {
+	t.Run("access failure", func(t *testing.T) {
+		accessErr := errors.New("access failed")
+		fake := &mcpMutationFake{accessErr: accessErr}
+		prepared, err := newMCPMutationTestService(fake).Prepare(
+			mcpMutationActorContext(41, "access failure"),
+			MCPMutationTarget{ProjectSlug: "missing-project", Mode: store.ModeAnonymous},
+		)
+		if prepared != nil || err != accessErr {
+			t.Fatalf("Prepare=(%v, %v), want nil and exact %v", prepared, err, accessErr)
+		}
+		if len(fake.accessCalls) != 1 || len(fake.mutationCalls) != 0 || len(fake.listCalls) != 0 {
+			t.Fatalf("calls: access=%+v mutations=%+v lists=%+v", fake.accessCalls, fake.mutationCalls, fake.listCalls)
+		}
+		call := fake.accessCalls[0]
+		if call.slug != "missing-project" || call.mode != store.ModeAnonymous {
+			t.Fatalf("access call=%+v", call)
+		}
+		assertMCPMutationTrace(t, fake.trace, "access")
+	})
+
+	for _, role := range []store.ProjectRole{"", store.RoleViewer, store.RoleContributor} {
+		t.Run("insufficient role "+string(role), func(t *testing.T) {
+			fake := &mcpMutationFake{projectContext: store.ProjectContext{
+				Project: store.Project{ID: 51}, Role: role,
+			}}
+			prepared, err := newMCPMutationTestService(fake).Prepare(
+				context.Background(),
+				MCPMutationTarget{ProjectSlug: "role-project", Mode: store.ModeFull},
+			)
+			if prepared != nil || !errors.Is(err, ErrMaintainerRequired) || errors.Is(err, ErrActorRequired) {
+				t.Fatalf("Prepare=(%v, %v), want nil and only %v", prepared, err, ErrMaintainerRequired)
+			}
+			assertMCPMutationTrace(t, fake.trace, "access")
+		})
+	}
+
+	t.Run("actor required after authorized access", func(t *testing.T) {
+		fake := &mcpMutationFake{projectContext: store.ProjectContext{
+			Project: store.Project{ID: 52}, Role: store.RoleMaintainer,
+		}}
+		prepared, err := newMCPMutationTestService(fake).Prepare(
+			context.Background(),
+			MCPMutationTarget{ProjectSlug: "actor-project", Mode: store.ModeFull},
+		)
+		if prepared != nil || !errors.Is(err, ErrActorRequired) || errors.Is(err, ErrMaintainerRequired) {
+			t.Fatalf("Prepare=(%v, %v), want nil and only %v", prepared, err, ErrActorRequired)
+		}
+		assertMCPMutationTrace(t, fake.trace, "access")
+	})
+
+	for _, role := range []store.ProjectRole{store.RoleMaintainer, store.RoleOwner} {
+		t.Run("authorized role "+string(role), func(t *testing.T) {
+			ctx := mcpMutationActorContext(61, "bound")
+			fake := &mcpMutationFake{projectContext: store.ProjectContext{
+				Project: store.Project{ID: 71}, Role: role,
+			}}
+			target := MCPMutationTarget{ProjectSlug: "bound-project", Mode: store.ModeFull}
+			service := newMCPMutationTestService(fake)
+			prepared, err := service.Prepare(ctx, target)
+			if err != nil {
+				t.Fatalf("Prepare: %v", err)
+			}
+			target.ProjectSlug = "replacement-project"
+			target.Mode = store.ModeAnonymous
+			fake.projectContext.Project.ID = 99
+			if prepared.ctx != ctx || prepared.service != service || prepared.requesterID != 61 || prepared.projectID != 71 {
+				t.Fatalf("prepared binding: ctxSame=%v serviceSame=%v requester=%d project=%d", prepared.ctx == ctx, prepared.service == service, prepared.requesterID, prepared.projectID)
+			}
+			if got := prepared.ctx.Value(mcpMutationContextKey{}); got != "bound" {
+				t.Fatalf("context marker=%v want=bound", got)
+			}
+			if len(fake.accessCalls) != 1 || fake.accessCalls[0].ctx != ctx ||
+				fake.accessCalls[0].slug != "bound-project" || fake.accessCalls[0].mode != store.ModeFull {
+				t.Fatalf("access calls=%+v", fake.accessCalls)
+			}
+			if len(fake.mutationCalls) != 0 || len(fake.listCalls) != 0 {
+				t.Fatalf("preparation performed operation: mutations=%+v lists=%+v", fake.mutationCalls, fake.listCalls)
+			}
+			assertMCPMutationTrace(t, fake.trace, "access")
+		})
+	}
+}
+
+func TestPreparedMCPMutationSuccessfulSequences(t *testing.T) {
+	ctx := mcpMutationActorContext(81, "successful sequence")
+	wantTarget := store.ProjectMember{
+		UserID: 91, Email: "target@example.com", Name: "Target", Role: store.RoleViewer,
+	}
+	wantMembers := []store.ProjectMember{
+		{UserID: 81, Name: "Requester", Role: store.RoleMaintainer},
+		wantTarget,
+		{UserID: 92, Name: "Other", Role: store.RoleContributor},
+	}
+
+	t.Run("add", func(t *testing.T) {
+		fake := &mcpMutationFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 101}, Role: store.RoleMaintainer},
+			members:        wantMembers,
+		}
+		prepared := preparedMCPMutationForTest(t, fake, ctx)
+		got, err := prepared.Add(AddCommand{TargetUserID: 91, Role: store.RoleViewer})
+		if err != nil || !reflect.DeepEqual(got, wantTarget) {
+			t.Fatalf("Add=(%+v, %v), want %+v", got, err, wantTarget)
+		}
+		assertMCPMutationCallAndList(t, fake, ctx, "add", 81, 101, 91, store.RoleViewer)
+		assertMCPMutationTrace(t, fake.trace, "access", "add", "list")
+	})
+
+	t.Run("update semantic no-op still persists and lists", func(t *testing.T) {
+		fake := &mcpMutationFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 101}, Role: store.RoleMaintainer},
+			members:        wantMembers,
+		}
+		prepared := preparedMCPMutationForTest(t, fake, ctx)
+		got, err := prepared.UpdateRole(UpdateRoleCommand{TargetUserID: 91, Role: store.RoleViewer})
+		if err != nil || !reflect.DeepEqual(got, wantTarget) {
+			t.Fatalf("UpdateRole=(%+v, %v), want %+v", got, err, wantTarget)
+		}
+		assertMCPMutationCallAndList(t, fake, ctx, "update_role", 81, 101, 91, store.RoleViewer)
+		assertMCPMutationTrace(t, fake.trace, "access", "update_role", "list")
+	})
+
+	t.Run("remove including self-removal performs no list", func(t *testing.T) {
+		fake := &mcpMutationFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 101}, Role: store.RoleMaintainer},
+			listErr:        errors.New("remove must not list"),
+		}
+		prepared := preparedMCPMutationForTest(t, fake, ctx)
+		if err := prepared.Remove(RemoveCommand{TargetUserID: 81}); err != nil {
+			t.Fatalf("Remove: %v", err)
+		}
+		if len(fake.mutationCalls) != 1 || len(fake.listCalls) != 0 {
+			t.Fatalf("calls: mutations=%+v lists=%+v", fake.mutationCalls, fake.listCalls)
+		}
+		call := fake.mutationCalls[0]
+		if call.operation != "remove" || call.ctx != ctx || call.requesterID != 81 ||
+			call.projectID != 101 || call.targetID != 81 || call.role != "" {
+			t.Fatalf("remove call=%+v", call)
+		}
+		assertMCPMutationTrace(t, fake.trace, "access", "remove")
+	})
+}
+
+func assertMCPMutationCallAndList(
+	t *testing.T,
+	fake *mcpMutationFake,
+	ctx context.Context,
+	operation string,
+	requesterID int64,
+	projectID int64,
+	targetID int64,
+	role store.ProjectRole,
+) {
+	t.Helper()
+	if len(fake.mutationCalls) != 1 || len(fake.listCalls) != 1 {
+		t.Fatalf("call cardinality: mutations=%d lists=%d", len(fake.mutationCalls), len(fake.listCalls))
+	}
+	mutation := fake.mutationCalls[0]
+	if mutation.operation != operation || mutation.ctx != ctx || mutation.requesterID != requesterID ||
+		mutation.projectID != projectID || mutation.targetID != targetID || mutation.role != role {
+		t.Fatalf("mutation call=%+v", mutation)
+	}
+	list := fake.listCalls[0]
+	if list.ctx != ctx || list.projectID != projectID || list.requesterID != requesterID {
+		t.Fatalf("list call=%+v", list)
+	}
+}
+
+type mcpMutationOperation struct {
+	name      string
+	traceName string
+	setError  func(*mcpMutationFake, error)
+	execute   func(*PreparedMCPMutation) (store.ProjectMember, error)
+}
+
+func mcpMutationOperations() []mcpMutationOperation {
+	return []mcpMutationOperation{
+		{
+			name: "add", traceName: "add",
+			setError: func(f *mcpMutationFake, err error) { f.addErr = err },
+			execute: func(p *PreparedMCPMutation) (store.ProjectMember, error) {
+				return p.Add(AddCommand{TargetUserID: 111, Role: store.RoleContributor})
+			},
+		},
+		{
+			name: "update role", traceName: "update_role",
+			setError: func(f *mcpMutationFake, err error) { f.updateErr = err },
+			execute: func(p *PreparedMCPMutation) (store.ProjectMember, error) {
+				return p.UpdateRole(UpdateRoleCommand{TargetUserID: 111, Role: store.RoleViewer})
+			},
+		},
+		{
+			name: "remove", traceName: "remove",
+			setError: func(f *mcpMutationFake, err error) { f.removeErr = err },
+			execute: func(p *PreparedMCPMutation) (store.ProjectMember, error) {
+				return store.ProjectMember{}, p.Remove(RemoveCommand{TargetUserID: 111})
+			},
+		},
+	}
+}
+
+func TestPreparedMCPMutationFailuresPreserveOrderAndIdentity(t *testing.T) {
+	for _, operation := range mcpMutationOperations() {
+		t.Run(operation.name+" mutation failure", func(t *testing.T) {
+			mutationErr := errors.New(operation.traceName + " failed")
+			fake := &mcpMutationFake{
+				projectContext: store.ProjectContext{Project: store.Project{ID: 121}, Role: store.RoleMaintainer},
+			}
+			operation.setError(fake, mutationErr)
+			prepared := preparedMCPMutationForTest(t, fake, mcpMutationActorContext(122, operation.traceName))
+			got, err := operation.execute(prepared)
+			if err != mutationErr || got != (store.ProjectMember{}) {
+				t.Fatalf("execute=(%+v, %v), want zero member and exact %v", got, err, mutationErr)
+			}
+			if len(fake.mutationCalls) != 1 || len(fake.listCalls) != 0 {
+				t.Fatalf("calls: mutations=%+v lists=%+v", fake.mutationCalls, fake.listCalls)
+			}
+			assertMCPMutationTrace(t, fake.trace, "access", operation.traceName)
+		})
+	}
+
+	readErrors := []struct {
+		name string
+		err  error
+	}{
+		{name: "generic", err: errors.New("list failed")},
+		{name: "wrapped sentinel", err: fmt.Errorf("wrapped list failure: %w", store.ErrNotFound)},
+	}
+	for _, operation := range mcpMutationOperations()[:2] {
+		for _, readError := range readErrors {
+			t.Run(operation.name+" "+readError.name+" post-read failure", func(t *testing.T) {
+				fake := &mcpMutationFake{
+					projectContext: store.ProjectContext{Project: store.Project{ID: 131}, Role: store.RoleMaintainer},
+					listErr:        readError.err,
+				}
+				prepared := preparedMCPMutationForTest(t, fake, mcpMutationActorContext(132, operation.traceName+" list"))
+				got, err := operation.execute(prepared)
+				if err != readError.err || got != (store.ProjectMember{}) {
+					t.Fatalf("execute=(%+v, %v), want zero member and exact %v", got, err, readError.err)
+				}
+				if len(fake.mutationCalls) != 1 || len(fake.listCalls) != 1 {
+					t.Fatalf("calls: mutations=%+v lists=%+v", fake.mutationCalls, fake.listCalls)
+				}
+				assertMCPMutationTrace(t, fake.trace, "access", operation.traceName, "list")
+			})
+		}
+	}
+}
+
+func TestPreparedMCPMutationMissingTargetSentinelsAreDistinct(t *testing.T) {
+	tests := []struct {
+		name      string
+		traceName string
+		want      error
+		notWant   error
+		execute   func(*PreparedMCPMutation) (store.ProjectMember, error)
+		forbidden []string
+	}{
+		{
+			name: "add", traceName: "add", want: ErrAddedMemberMissing, notWant: ErrUpdatedMemberMissing,
+			execute: func(p *PreparedMCPMutation) (store.ProjectMember, error) {
+				return p.Add(AddCommand{TargetUserID: 141, Role: store.RoleViewer})
+			},
+			forbidden: []string{"bound-project", "141", "MCP", "INTERNAL"},
+		},
+		{
+			name: "update", traceName: "update_role", want: ErrUpdatedMemberMissing, notWant: ErrAddedMemberMissing,
+			execute: func(p *PreparedMCPMutation) (store.ProjectMember, error) {
+				return p.UpdateRole(UpdateRoleCommand{TargetUserID: 142, Role: store.RoleContributor})
+			},
+			forbidden: []string{"bound-project", "142", "MCP", "NOT_FOUND"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &mcpMutationFake{
+				projectContext: store.ProjectContext{Project: store.Project{ID: 143}, Role: store.RoleMaintainer},
+				members:        []store.ProjectMember{{UserID: 999, Role: store.RoleViewer}},
+			}
+			prepared := preparedMCPMutationForTest(t, fake, mcpMutationActorContext(144, tt.name+" missing"))
+			got, err := tt.execute(prepared)
+			if got != (store.ProjectMember{}) || !errors.Is(err, tt.want) || errors.Is(err, tt.notWant) {
+				t.Fatalf("execute=(%+v, %v), want zero member, %v, and not %v", got, err, tt.want, tt.notWant)
+			}
+			for _, forbidden := range tt.forbidden {
+				if strings.Contains(err.Error(), forbidden) {
+					t.Fatalf("stable sentinel leaked %q: %q", forbidden, err.Error())
+				}
+			}
+			if len(fake.mutationCalls) != 1 || len(fake.listCalls) != 1 {
+				t.Fatalf("calls: mutations=%+v lists=%+v", fake.mutationCalls, fake.listCalls)
+			}
+			assertMCPMutationTrace(t, fake.trace, "access", tt.traceName, "list")
+		})
+	}
+}
+
+func TestPreparedMCPMutationUsesCancelledBoundContext(t *testing.T) {
+	for _, operation := range mcpMutationOperations() {
+		t.Run(operation.name, func(t *testing.T) {
+			fake := &mcpMutationFake{
+				projectContext: store.ProjectContext{Project: store.Project{ID: 151}, Role: store.RoleMaintainer},
+				honorContext:   true,
+			}
+			ctx, cancel := context.WithCancel(mcpMutationActorContext(152, operation.traceName+" cancelled"))
+			prepared := preparedMCPMutationForTest(t, fake, ctx)
+			cancel()
+			got, err := operation.execute(prepared)
+			if got != (store.ProjectMember{}) || !errors.Is(err, context.Canceled) {
+				t.Fatalf("execute=(%+v, %v), want zero member and %v", got, err, context.Canceled)
+			}
+			if len(fake.mutationCalls) != 1 || fake.mutationCalls[0].ctx != ctx || len(fake.listCalls) != 0 {
+				t.Fatalf("calls: mutations=%+v lists=%+v", fake.mutationCalls, fake.listCalls)
+			}
+			assertMCPMutationTrace(t, fake.trace, "access", operation.traceName)
+		})
+	}
+}
+
+func TestPreparedMCPMutationCancellationAfterMutationReachesList(t *testing.T) {
+	ctx, cancel := context.WithCancel(mcpMutationActorContext(161, "cancel before list"))
+	fake := &mcpMutationFake{
+		projectContext: store.ProjectContext{Project: store.Project{ID: 162}, Role: store.RoleMaintainer},
+		honorContext:   true,
+		afterMutation:  cancel,
+	}
+	prepared := preparedMCPMutationForTest(t, fake, ctx)
+	got, err := prepared.Add(AddCommand{TargetUserID: 163, Role: store.RoleViewer})
+	if got != (store.ProjectMember{}) || !errors.Is(err, context.Canceled) {
+		t.Fatalf("Add=(%+v, %v), want zero member and %v", got, err, context.Canceled)
+	}
+	if len(fake.mutationCalls) != 1 || len(fake.listCalls) != 1 || fake.listCalls[0].ctx != ctx {
+		t.Fatalf("calls: mutations=%+v lists=%+v", fake.mutationCalls, fake.listCalls)
+	}
+	assertMCPMutationTrace(t, fake.trace, "access", "add", "list")
+}

--- a/internal/application/membership/mutation.go
+++ b/internal/application/membership/mutation.go
@@ -1,0 +1,66 @@
+package membership
+
+import (
+	"context"
+
+	"scrumboy/internal/store"
+)
+
+// AddCommand contains the adapter-prepared target and canonical role for adding
+// a project member. Requester identity is bound separately from request context
+// by the future prepared service.
+type AddCommand struct {
+	TargetUserID int64
+	Role         store.ProjectRole
+}
+
+// UpdateRoleCommand contains the adapter-prepared target and canonical role for
+// changing an existing project membership.
+type UpdateRoleCommand struct {
+	TargetUserID int64
+	Role         store.ProjectRole
+}
+
+// RemoveCommand identifies the project member to remove.
+type RemoveCommand struct {
+	TargetUserID int64
+}
+
+// MutationStore is the persistence capability shared by future REST and MCP
+// membership-mutation services. Transport parsing and public validation remain
+// adapter-owned; the store remains authoritative for membership authorization,
+// invariants, audits, assignment cleanup, persistence, and transactions.
+type MutationStore interface {
+	AddProjectMember(
+		ctx context.Context,
+		requesterID int64,
+		projectID int64,
+		targetUserID int64,
+		role store.ProjectRole,
+	) error
+	UpdateProjectMemberRole(
+		ctx context.Context,
+		requesterID int64,
+		projectID int64,
+		targetUserID int64,
+		role store.ProjectRole,
+	) error
+	RemoveProjectMember(
+		ctx context.Context,
+		requesterID int64,
+		projectID int64,
+		targetUserID int64,
+	) error
+}
+
+// MemberListStore is separate from MutationStore because the transports use
+// the authorization-sensitive post-write read differently: REST returns the
+// complete list, MCP add and update select the target, and MCP remove does not
+// read the list.
+type MemberListStore interface {
+	ListProjectMembers(
+		ctx context.Context,
+		projectID int64,
+		requesterID int64,
+	) ([]store.ProjectMember, error)
+}

--- a/internal/application/membership/mutation_test.go
+++ b/internal/application/membership/mutation_test.go
@@ -1,0 +1,6 @@
+package membership
+
+import "scrumboy/internal/store"
+
+var _ MutationStore = (*store.Store)(nil)
+var _ MemberListStore = (*store.Store)(nil)

--- a/internal/application/membership/rest_mutation.go
+++ b/internal/application/membership/rest_mutation.go
@@ -1,0 +1,174 @@
+package membership
+
+import (
+	"context"
+	"errors"
+
+	"scrumboy/internal/store"
+)
+
+// MembershipAction identifies the established structured membership event
+// action emitted after a successful canonical REST mutation.
+type MembershipAction string
+
+const (
+	MembershipActionAdded       MembershipAction = "added"
+	MembershipActionRoleChanged MembershipAction = "role_changed"
+	MembershipActionRemoved     MembershipAction = "removed"
+)
+
+// ErrActorRequired reports that the exact context supplied to Prepare does not
+// contain an authenticated requester.
+var ErrActorRequired = errors.New("membership mutation actor required")
+
+// RESTMutationPublisher exposes the two distinct best-effort publications made
+// after a REST membership mutation and its authorization-sensitive post-read
+// both succeed.
+type RESTMutationPublisher interface {
+	PublishMembersUpdated(ctx context.Context, projectID int64)
+	PublishMembershipChanged(
+		ctx context.Context,
+		projectID int64,
+		actorUserID int64,
+		targetUserID int64,
+		action MembershipAction,
+	)
+}
+
+type nopRESTMutationPublisher struct{}
+
+func (nopRESTMutationPublisher) PublishMembersUpdated(context.Context, int64) {}
+
+func (nopRESTMutationPublisher) PublishMembershipChanged(
+	context.Context,
+	int64,
+	int64,
+	int64,
+	MembershipAction,
+) {
+}
+
+// RESTMutationServiceDependencies names the persistence, post-write read, and
+// publication capabilities used by canonical REST membership mutations.
+type RESTMutationServiceDependencies struct {
+	Mutations MutationStore
+	Members   MemberListStore
+	Publisher RESTMutationPublisher
+}
+
+// RESTMutationService owns requester binding and the mutation, member-list read,
+// and ordered publication sequence. Store authorization remains authoritative.
+type RESTMutationService struct {
+	mutations MutationStore
+	members   MemberListStore
+	publisher RESTMutationPublisher
+}
+
+func NewRESTMutationService(deps RESTMutationServiceDependencies) *RESTMutationService {
+	publisher := deps.Publisher
+	if publisher == nil {
+		publisher = nopRESTMutationPublisher{}
+	}
+	return &RESTMutationService{
+		mutations: deps.Mutations,
+		members:   deps.Members,
+		publisher: publisher,
+	}
+}
+
+// ResolvedRESTMutationTarget carries only the numeric project identity already
+// parsed by the REST adapter. The store mutation remains the access boundary.
+type ResolvedRESTMutationTarget struct {
+	ProjectID int64
+}
+
+// PreparedRESTMutation binds the exact request context, requester identity, and
+// project identity to subsequent membership mutations.
+type PreparedRESTMutation struct {
+	ctx         context.Context
+	service     *RESTMutationService
+	requesterID int64
+	projectID   int64
+}
+
+// Prepare derives requester identity only after the adapter has completed its
+// current path, body, and role validation. It performs no persistence, access
+// lookup, member-list read, or publication.
+func (s *RESTMutationService) Prepare(
+	ctx context.Context,
+	target ResolvedRESTMutationTarget,
+) (*PreparedRESTMutation, error) {
+	requesterID, ok := store.UserIDFromContext(ctx)
+	if !ok {
+		return nil, ErrActorRequired
+	}
+	return &PreparedRESTMutation{
+		ctx:         ctx,
+		service:     s,
+		requesterID: requesterID,
+		projectID:   target.ProjectID,
+	}, nil
+}
+
+// Add performs one adapter-prepared add, then the established post-write read
+// and ordered REST publications.
+func (p *PreparedRESTMutation) Add(command AddCommand) ([]store.ProjectMember, error) {
+	if err := p.service.mutations.AddProjectMember(
+		p.ctx,
+		p.requesterID,
+		p.projectID,
+		command.TargetUserID,
+		command.Role,
+	); err != nil {
+		return nil, err
+	}
+	return p.complete(command.TargetUserID, MembershipActionAdded)
+}
+
+// UpdateRole deliberately performs no semantic comparison. A successful store
+// call always proceeds through the current read and publication sequence.
+func (p *PreparedRESTMutation) UpdateRole(command UpdateRoleCommand) ([]store.ProjectMember, error) {
+	if err := p.service.mutations.UpdateProjectMemberRole(
+		p.ctx,
+		p.requesterID,
+		p.projectID,
+		command.TargetUserID,
+		command.Role,
+	); err != nil {
+		return nil, err
+	}
+	return p.complete(command.TargetUserID, MembershipActionRoleChanged)
+}
+
+// Remove preserves the current self-removal behavior: a successful mutation may
+// still be followed by an authorization-sensitive member-list failure.
+func (p *PreparedRESTMutation) Remove(command RemoveCommand) ([]store.ProjectMember, error) {
+	if err := p.service.mutations.RemoveProjectMember(
+		p.ctx,
+		p.requesterID,
+		p.projectID,
+		command.TargetUserID,
+	); err != nil {
+		return nil, err
+	}
+	return p.complete(command.TargetUserID, MembershipActionRemoved)
+}
+
+func (p *PreparedRESTMutation) complete(
+	targetUserID int64,
+	action MembershipAction,
+) ([]store.ProjectMember, error) {
+	members, err := p.service.members.ListProjectMembers(p.ctx, p.projectID, p.requesterID)
+	if err != nil {
+		return nil, err
+	}
+	p.service.publisher.PublishMembersUpdated(p.ctx, p.projectID)
+	p.service.publisher.PublishMembershipChanged(
+		p.ctx,
+		p.projectID,
+		p.requesterID,
+		targetUserID,
+		action,
+	)
+	return members, nil
+}

--- a/internal/application/membership/rest_mutation_test.go
+++ b/internal/application/membership/rest_mutation_test.go
@@ -1,0 +1,392 @@
+package membership
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+type restMutationContextKey struct{}
+
+type restMembershipMutationCall struct {
+	operation   string
+	ctx         context.Context
+	requesterID int64
+	projectID   int64
+	targetID    int64
+	role        store.ProjectRole
+}
+
+type restMembershipListCall struct {
+	ctx         context.Context
+	projectID   int64
+	requesterID int64
+}
+
+type restMembersUpdatedCall struct {
+	ctx       context.Context
+	projectID int64
+}
+
+type restMembershipChangedCall struct {
+	ctx       context.Context
+	projectID int64
+	actorID   int64
+	targetID  int64
+	action    MembershipAction
+}
+
+type restMutationFake struct {
+	trace []string
+
+	mutationCalls []restMembershipMutationCall
+	listCalls     []restMembershipListCall
+	members       []store.ProjectMember
+	addErr        error
+	updateErr     error
+	removeErr     error
+	listErr       error
+	honorContext  bool
+
+	membersUpdatedCalls    []restMembersUpdatedCall
+	membershipChangedCalls []restMembershipChangedCall
+}
+
+func (f *restMutationFake) AddProjectMember(
+	ctx context.Context,
+	requesterID int64,
+	projectID int64,
+	targetUserID int64,
+	role store.ProjectRole,
+) error {
+	f.trace = append(f.trace, "add")
+	f.mutationCalls = append(f.mutationCalls, restMembershipMutationCall{
+		operation: "add", ctx: ctx, requesterID: requesterID, projectID: projectID,
+		targetID: targetUserID, role: role,
+	})
+	if f.honorContext && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return f.addErr
+}
+
+func (f *restMutationFake) UpdateProjectMemberRole(
+	ctx context.Context,
+	requesterID int64,
+	projectID int64,
+	targetUserID int64,
+	role store.ProjectRole,
+) error {
+	f.trace = append(f.trace, "update_role")
+	f.mutationCalls = append(f.mutationCalls, restMembershipMutationCall{
+		operation: "update_role", ctx: ctx, requesterID: requesterID, projectID: projectID,
+		targetID: targetUserID, role: role,
+	})
+	if f.honorContext && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return f.updateErr
+}
+
+func (f *restMutationFake) RemoveProjectMember(
+	ctx context.Context,
+	requesterID int64,
+	projectID int64,
+	targetUserID int64,
+) error {
+	f.trace = append(f.trace, "remove")
+	f.mutationCalls = append(f.mutationCalls, restMembershipMutationCall{
+		operation: "remove", ctx: ctx, requesterID: requesterID, projectID: projectID,
+		targetID: targetUserID,
+	})
+	if f.honorContext && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return f.removeErr
+}
+
+func (f *restMutationFake) ListProjectMembers(
+	ctx context.Context,
+	projectID int64,
+	requesterID int64,
+) ([]store.ProjectMember, error) {
+	f.trace = append(f.trace, "list")
+	f.listCalls = append(f.listCalls, restMembershipListCall{
+		ctx: ctx, projectID: projectID, requesterID: requesterID,
+	})
+	if f.honorContext && ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.members, nil
+}
+
+func (f *restMutationFake) PublishMembersUpdated(ctx context.Context, projectID int64) {
+	f.trace = append(f.trace, "publish_members_updated")
+	f.membersUpdatedCalls = append(f.membersUpdatedCalls, restMembersUpdatedCall{
+		ctx: ctx, projectID: projectID,
+	})
+}
+
+func (f *restMutationFake) PublishMembershipChanged(
+	ctx context.Context,
+	projectID int64,
+	actorUserID int64,
+	targetUserID int64,
+	action MembershipAction,
+) {
+	f.trace = append(f.trace, "publish_membership_changed")
+	f.membershipChangedCalls = append(f.membershipChangedCalls, restMembershipChangedCall{
+		ctx: ctx, projectID: projectID, actorID: actorUserID,
+		targetID: targetUserID, action: action,
+	})
+}
+
+func newRESTMutationTestService(fake *restMutationFake) *RESTMutationService {
+	return NewRESTMutationService(RESTMutationServiceDependencies{
+		Mutations: fake,
+		Members:   fake,
+		Publisher: fake,
+	})
+}
+
+func restMutationActorContext(userID int64, marker string) context.Context {
+	ctx := context.WithValue(context.Background(), restMutationContextKey{}, marker)
+	return store.WithUserID(ctx, userID)
+}
+
+func assertRESTMutationTrace(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("call trace=%v want=%v", got, want)
+	}
+}
+
+type restMutationOperation struct {
+	name       string
+	traceName  string
+	targetID   int64
+	role       store.ProjectRole
+	wantAction MembershipAction
+	execute    func(*PreparedRESTMutation) ([]store.ProjectMember, error)
+	setError   func(*restMutationFake, error)
+}
+
+func restMutationOperations() []restMutationOperation {
+	return []restMutationOperation{
+		{
+			name: "add", traceName: "add", targetID: 301, role: store.RoleContributor,
+			wantAction: MembershipAction("added"),
+			execute: func(p *PreparedRESTMutation) ([]store.ProjectMember, error) {
+				return p.Add(AddCommand{TargetUserID: 301, Role: store.RoleContributor})
+			},
+			setError: func(f *restMutationFake, err error) { f.addErr = err },
+		},
+		{
+			name: "update role including semantic no-op", traceName: "update_role",
+			targetID: 302, role: store.RoleViewer,
+			wantAction: MembershipAction("role_changed"),
+			execute: func(p *PreparedRESTMutation) ([]store.ProjectMember, error) {
+				return p.UpdateRole(UpdateRoleCommand{TargetUserID: 302, Role: store.RoleViewer})
+			},
+			setError: func(f *restMutationFake, err error) { f.updateErr = err },
+		},
+		{
+			name: "remove", traceName: "remove", targetID: 303,
+			wantAction: MembershipAction("removed"),
+			execute: func(p *PreparedRESTMutation) ([]store.ProjectMember, error) {
+				return p.Remove(RemoveCommand{TargetUserID: 303})
+			},
+			setError: func(f *restMutationFake, err error) { f.removeErr = err },
+		},
+	}
+}
+
+func TestRESTMutationPrepareBindsActorContextAndProject(t *testing.T) {
+	fake := &restMutationFake{}
+	service := newRESTMutationTestService(fake)
+
+	prepared, err := service.Prepare(context.Background(), ResolvedRESTMutationTarget{ProjectID: 51})
+	if !errors.Is(err, ErrActorRequired) || prepared != nil {
+		t.Fatalf("missing-actor Prepare=(%v, %v), want nil and %v", prepared, err, ErrActorRequired)
+	}
+	assertRESTMutationTrace(t, fake.trace)
+
+	ctx := restMutationActorContext(41, "bound")
+	target := ResolvedRESTMutationTarget{ProjectID: 61}
+	prepared, err = service.Prepare(ctx, target)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	target.ProjectID = 99
+	if prepared.ctx != ctx || prepared.requesterID != 41 || prepared.projectID != 61 || prepared.service != service {
+		t.Fatalf("prepared binding: ctxSame=%v requester=%d project=%d serviceSame=%v", prepared.ctx == ctx, prepared.requesterID, prepared.projectID, prepared.service == service)
+	}
+	if got := prepared.ctx.Value(restMutationContextKey{}); got != "bound" {
+		t.Fatalf("bound context marker=%v want=bound", got)
+	}
+	assertRESTMutationTrace(t, fake.trace)
+}
+
+func TestPreparedRESTMutationSuccessfulSequences(t *testing.T) {
+	wantMembers := []store.ProjectMember{
+		{UserID: 41, Name: "Requester", Role: store.RoleMaintainer},
+		{UserID: 302, Name: "Target", Role: store.RoleViewer},
+	}
+
+	for _, operation := range restMutationOperations() {
+		t.Run(operation.name, func(t *testing.T) {
+			fake := &restMutationFake{members: wantMembers}
+			service := newRESTMutationTestService(fake)
+			ctx := restMutationActorContext(41, operation.traceName)
+			prepared, err := service.Prepare(ctx, ResolvedRESTMutationTarget{ProjectID: 71})
+			if err != nil {
+				t.Fatalf("Prepare: %v", err)
+			}
+
+			got, err := operation.execute(prepared)
+			if err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if !reflect.DeepEqual(got, wantMembers) {
+				t.Fatalf("members=%+v want=%+v", got, wantMembers)
+			}
+			if len(fake.mutationCalls) != 1 || len(fake.listCalls) != 1 ||
+				len(fake.membersUpdatedCalls) != 1 || len(fake.membershipChangedCalls) != 1 {
+				t.Fatalf("call cardinality: mutations=%d lists=%d membersUpdated=%d membershipChanged=%d", len(fake.mutationCalls), len(fake.listCalls), len(fake.membersUpdatedCalls), len(fake.membershipChangedCalls))
+			}
+			mutation := fake.mutationCalls[0]
+			if mutation.operation != operation.traceName || mutation.ctx != ctx ||
+				mutation.requesterID != 41 || mutation.projectID != 71 ||
+				mutation.targetID != operation.targetID || mutation.role != operation.role {
+				t.Fatalf("mutation call=%+v", mutation)
+			}
+			list := fake.listCalls[0]
+			if list.ctx != ctx || list.projectID != 71 || list.requesterID != 41 {
+				t.Fatalf("list call=%+v", list)
+			}
+			membersUpdated := fake.membersUpdatedCalls[0]
+			if membersUpdated.ctx != ctx || membersUpdated.projectID != 71 {
+				t.Fatalf("members-updated publication=%+v", membersUpdated)
+			}
+			membershipChanged := fake.membershipChangedCalls[0]
+			if membershipChanged.ctx != ctx || membershipChanged.projectID != 71 ||
+				membershipChanged.actorID != 41 || membershipChanged.targetID != operation.targetID ||
+				membershipChanged.action != operation.wantAction {
+				t.Fatalf("membership-changed publication=%+v", membershipChanged)
+			}
+			if got := mutation.ctx.Value(restMutationContextKey{}); got != operation.traceName {
+				t.Fatalf("mutation context marker=%v want=%s", got, operation.traceName)
+			}
+			assertRESTMutationTrace(t, fake.trace,
+				operation.traceName,
+				"list",
+				"publish_members_updated",
+				"publish_membership_changed",
+			)
+		})
+	}
+}
+
+func TestPreparedRESTMutationFailuresShortCircuit(t *testing.T) {
+	for _, operation := range restMutationOperations() {
+		t.Run(operation.name+" mutation failure", func(t *testing.T) {
+			mutationErr := errors.New(operation.traceName + " failed")
+			fake := &restMutationFake{}
+			operation.setError(fake, mutationErr)
+			prepared, err := newRESTMutationTestService(fake).Prepare(
+				restMutationActorContext(51, operation.traceName+" failure"),
+				ResolvedRESTMutationTarget{ProjectID: 81},
+			)
+			if err != nil {
+				t.Fatalf("Prepare: %v", err)
+			}
+
+			got, err := operation.execute(prepared)
+			if err != mutationErr || got != nil {
+				t.Fatalf("execute=(%+v, %v), want nil and exact %v", got, err, mutationErr)
+			}
+			if len(fake.mutationCalls) != 1 || len(fake.listCalls) != 0 ||
+				len(fake.membersUpdatedCalls) != 0 || len(fake.membershipChangedCalls) != 0 {
+				t.Fatalf("call cardinality: mutations=%d lists=%d membersUpdated=%d membershipChanged=%d", len(fake.mutationCalls), len(fake.listCalls), len(fake.membersUpdatedCalls), len(fake.membershipChangedCalls))
+			}
+			assertRESTMutationTrace(t, fake.trace, operation.traceName)
+		})
+
+		t.Run(operation.name+" post-read failure", func(t *testing.T) {
+			readErr := errors.New(operation.traceName + " list failed")
+			if operation.traceName == "remove" {
+				readErr = store.ErrNotFound
+			}
+			fake := &restMutationFake{listErr: readErr}
+			prepared, err := newRESTMutationTestService(fake).Prepare(
+				restMutationActorContext(52, operation.traceName+" read failure"),
+				ResolvedRESTMutationTarget{ProjectID: 82},
+			)
+			if err != nil {
+				t.Fatalf("Prepare: %v", err)
+			}
+
+			got, err := operation.execute(prepared)
+			if err != readErr || got != nil {
+				t.Fatalf("execute=(%+v, %v), want nil and exact %v", got, err, readErr)
+			}
+			if len(fake.mutationCalls) != 1 || len(fake.listCalls) != 1 ||
+				len(fake.membersUpdatedCalls) != 0 || len(fake.membershipChangedCalls) != 0 {
+				t.Fatalf("call cardinality: mutations=%d lists=%d membersUpdated=%d membershipChanged=%d", len(fake.mutationCalls), len(fake.listCalls), len(fake.membersUpdatedCalls), len(fake.membershipChangedCalls))
+			}
+			assertRESTMutationTrace(t, fake.trace, operation.traceName, "list")
+		})
+	}
+}
+
+func TestPreparedRESTMutationUsesCancelledBoundContext(t *testing.T) {
+	fake := &restMutationFake{honorContext: true}
+	service := newRESTMutationTestService(fake)
+	ctx, cancel := context.WithCancel(restMutationActorContext(61, "cancelled"))
+	prepared, err := service.Prepare(ctx, ResolvedRESTMutationTarget{ProjectID: 91})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	cancel()
+
+	got, err := prepared.Add(AddCommand{TargetUserID: 401, Role: store.RoleViewer})
+	if !errors.Is(err, context.Canceled) || got != nil {
+		t.Fatalf("Add=(%+v, %v), want nil and %v", got, err, context.Canceled)
+	}
+	if len(fake.mutationCalls) != 1 || fake.mutationCalls[0].ctx != ctx || len(fake.listCalls) != 0 ||
+		len(fake.membersUpdatedCalls) != 0 || len(fake.membershipChangedCalls) != 0 {
+		t.Fatalf("cancelled calls: mutations=%+v lists=%+v membersUpdated=%+v membershipChanged=%+v", fake.mutationCalls, fake.listCalls, fake.membersUpdatedCalls, fake.membershipChangedCalls)
+	}
+	assertRESTMutationTrace(t, fake.trace, "add")
+}
+
+func TestRESTMutationServiceNilPublisherIsNoop(t *testing.T) {
+	wantMembers := []store.ProjectMember{{UserID: 501, Role: store.RoleContributor}}
+	fake := &restMutationFake{members: wantMembers}
+	service := NewRESTMutationService(RESTMutationServiceDependencies{
+		Mutations: fake,
+		Members:   fake,
+	})
+	prepared, err := service.Prepare(
+		restMutationActorContext(71, "nil publisher"),
+		ResolvedRESTMutationTarget{ProjectID: 101},
+	)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	got, err := prepared.Add(AddCommand{TargetUserID: 501, Role: store.RoleContributor})
+	if err != nil || !reflect.DeepEqual(got, wantMembers) {
+		t.Fatalf("Add=(%+v, %v), want %+v", got, err, wantMembers)
+	}
+	if len(fake.mutationCalls) != 1 || len(fake.listCalls) != 1 {
+		t.Fatalf("call cardinality: mutations=%d lists=%d", len(fake.mutationCalls), len(fake.listCalls))
+	}
+	assertRESTMutationTrace(t, fake.trace, "add", "list")
+}

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -4,9 +4,30 @@ import (
 	"context"
 	"encoding/json"
 
+	membershipapp "scrumboy/internal/application/membership"
 	"scrumboy/internal/eventbus"
 	"scrumboy/internal/store"
 )
+
+type membershipMutationPublisher struct {
+	server *Server
+}
+
+var _ membershipapp.RESTMutationPublisher = membershipMutationPublisher{}
+
+func (p membershipMutationPublisher) PublishMembersUpdated(ctx context.Context, projectID int64) {
+	p.server.emitMembersUpdated(ctx, projectID)
+}
+
+func (p membershipMutationPublisher) PublishMembershipChanged(
+	ctx context.Context,
+	projectID int64,
+	actorUserID int64,
+	targetUserID int64,
+	action membershipapp.MembershipAction,
+) {
+	p.server.emitMembership(ctx, projectID, actorUserID, targetUserID, string(action))
+}
 
 type refreshNeededEvent struct {
 	ID        string `json:"id,omitempty"`
@@ -81,11 +102,13 @@ func (s *Server) emitMembersUpdated(ctx context.Context, projectID int64) {
 // emitMembership publishes a per-user membership change, distinct from the
 // board-wide "board.members_updated" SSE invalidation signal, so consumers
 // like the email notifier can target the one affected user.
-func (s *Server) emitMembership(ctx context.Context, projectID, affectedUserID int64, action string) {
-	var actorUserID int64
-	if uid, ok := store.UserIDFromContext(ctx); ok {
-		actorUserID = uid
-	}
+func (s *Server) emitMembership(
+	ctx context.Context,
+	projectID int64,
+	actorUserID int64,
+	affectedUserID int64,
+	action string,
+) {
 	payload, _ := json.Marshal(eventbus.MembershipPayload{
 		ProjectID:      projectID,
 		AffectedUserID: affectedUserID,

--- a/internal/httpapi/project_membership_transport_contract_test.go
+++ b/internal/httpapi/project_membership_transport_contract_test.go
@@ -334,6 +334,8 @@ type membershipListFailureStore struct {
 	listCalls int
 }
 
+const membershipPostReadFailureMessage = "forced membership post-read failure"
+
 func (s *membershipListFailureStore) ListProjectMembers(context.Context, int64, int64) ([]store.ProjectMember, error) {
 	s.listCalls++
 	return nil, s.err
@@ -351,7 +353,7 @@ func newMembershipListFailureRESTServer(t *testing.T) (*httptest.Server, *sql.DB
 		_ = sqlDB.Close()
 		t.Fatalf("migrate: %v", err)
 	}
-	wrapper := &membershipListFailureStore{Store: store.New(sqlDB, nil), err: errors.New("forced membership post-read failure")}
+	wrapper := &membershipListFailureStore{Store: store.New(sqlDB, nil), err: errors.New(membershipPostReadFailureMessage)}
 	srv := NewServer(wrapper, Options{MaxRequestBody: 1 << 20, ScrumboyMode: "full"})
 	collector := &membershipEventCollector{}
 	srv.fanout = eventbus.NewFanout(newSSEBridge(srv.hub), collector)
@@ -400,9 +402,13 @@ func TestProjectMembershipRESTPostReadFailureOccursAfterCommit(t *testing.T) {
 			}
 			stream := subscribeTodoUpdateEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
 
-			resp, responseBody := doJSON(t, client, method, url, body, nil)
-			if resp.StatusCode != http.StatusInternalServerError {
-				t.Fatalf("post-read status=%d want=500 body=%s", resp.StatusCode, responseBody)
+			var envelope apiErrorEnvelope
+			resp, responseBody := doJSON(t, client, method, url, body, &envelope)
+			if resp.StatusCode != http.StatusInternalServerError || envelope.Error.Code != "INTERNAL" || envelope.Error.Message != "internal error" {
+				t.Fatalf("post-read status=%d error=%+v body=%s", resp.StatusCode, envelope, responseBody)
+			}
+			if len(envelope.Error.Details) != 1 || envelope.Error.Details["detail"] != membershipPostReadFailureMessage {
+				t.Fatalf("post-read details=%+v want exact current detail", envelope.Error.Details)
 			}
 			if wrapped.listCalls != 1 {
 				t.Fatalf("post-read calls=%d want=1", wrapped.listCalls)
@@ -470,6 +476,26 @@ func TestProjectMembershipRESTValidationRoleAndModeContracts(t *testing.T) {
 		}
 		if role, err := fx.st.GetProjectRole(fx.ctx, fx.project.ID, target.ID); err != nil || role != store.RoleMaintainer {
 			t.Fatalf("legacy owner stored role=%q err=%v", role, err)
+		}
+	})
+
+	t.Run("add rejects non-exact legacy owner variants", func(t *testing.T) {
+		fx := newMembershipRESTFixture(t, "membership-rest-owner-variants")
+		for i, role := range []string{"Owner", " owner", "owner "} {
+			t.Run(fmt.Sprintf("variant_%d", i), func(t *testing.T) {
+				target := createMembershipUser(t, fx.st, fmt.Sprintf("membership-rest-owner-variant-%d", i))
+				var envelope apiErrorEnvelope
+				resp, body := doJSON(t, fx.client, http.MethodPost, fx.membersURL(), map[string]any{"user_id": target.ID, "role": role}, &envelope)
+				if resp.StatusCode != http.StatusBadRequest || envelope.Error.Code != "VALIDATION_ERROR" || envelope.Error.Message != "invalid role" {
+					t.Fatalf("role %q status=%d error=%+v body=%s", role, resp.StatusCode, envelope, body)
+				}
+				if envelope.Error.Details["field"] != "role" || envelope.Error.Details["reason"] != "invalid_role" {
+					t.Fatalf("role %q details=%+v", role, envelope.Error.Details)
+				}
+				if gotRole, err := fx.st.GetProjectRole(fx.ctx, fx.project.ID, target.ID); err != nil || gotRole != "" {
+					t.Fatalf("role %q unexpectedly mutated membership: stored=%q err=%v", role, gotRole, err)
+				}
+			})
 		}
 	})
 

--- a/internal/httpapi/project_membership_transport_contract_test.go
+++ b/internal/httpapi/project_membership_transport_contract_test.go
@@ -1,0 +1,569 @@
+package httpapi
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"scrumboy/internal/db"
+	"scrumboy/internal/eventbus"
+	"scrumboy/internal/mcp"
+	"scrumboy/internal/migrate"
+	"scrumboy/internal/store"
+)
+
+type membershipEventCollector struct {
+	mu     sync.Mutex
+	events []eventbus.Event
+}
+
+func (c *membershipEventCollector) OnEvent(_ context.Context, event eventbus.Event) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, event)
+}
+
+func (c *membershipEventCollector) snapshot() []eventbus.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]eventbus.Event(nil), c.events...)
+}
+
+type membershipRESTFixture struct {
+	ts        *httptest.Server
+	db        *sql.DB
+	st        *store.Store
+	client    *http.Client
+	ctx       context.Context
+	ownerID   int64
+	project   store.Project
+	collector *membershipEventCollector
+}
+
+func newMembershipRESTFixture(t *testing.T, name string) *membershipRESTFixture {
+	t.Helper()
+	ts, sqlDB, cleanup := newTestHTTPServer(t, "full")
+	t.Cleanup(cleanup)
+	client := newCookieClient(t)
+	owner := bootstrapUserClient(t, client, ts.URL, "Membership Owner", name+"-owner@example.com", "password123")
+	ownerID := int64(owner["id"].(float64))
+	ctx := store.WithUserID(context.Background(), ownerID)
+	st := store.New(sqlDB, nil)
+	project, err := st.CreateProject(ctx, name)
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	srv, ok := ts.Config.Handler.(*Server)
+	if !ok {
+		t.Fatalf("test handler type=%T, want *Server", ts.Config.Handler)
+	}
+	collector := &membershipEventCollector{}
+	// Keep the production fanout and SSE translation in the route contract while
+	// adding an in-process observer for the structured membership event.
+	srv.fanout = eventbus.NewFanout(newSSEBridge(srv.hub), collector)
+
+	return &membershipRESTFixture{
+		ts: ts, db: sqlDB, st: st, client: client, ctx: ctx,
+		ownerID: ownerID, project: project, collector: collector,
+	}
+}
+
+func (fx *membershipRESTFixture) membersURL() string {
+	return fmt.Sprintf("%s/api/projects/%d/members", fx.ts.URL, fx.project.ID)
+}
+
+func createMembershipUser(t *testing.T, st *store.Store, key string) store.User {
+	t.Helper()
+	user, err := st.CreateUser(context.Background(), key+"@example.com", "password123", key)
+	if err != nil {
+		t.Fatalf("create user %q: %v", key, err)
+	}
+	return user
+}
+
+func membershipAuditCount(t *testing.T, sqlDB *sql.DB, projectID, targetUserID int64, action string) int {
+	t.Helper()
+	var count int
+	if err := sqlDB.QueryRow(`
+		SELECT COUNT(*)
+		FROM audit_events
+		WHERE project_id = ? AND target_type = 'member' AND target_id = ? AND action = ?
+	`, projectID, targetUserID, action).Scan(&count); err != nil {
+		t.Fatalf("count %s audits: %v", action, err)
+	}
+	return count
+}
+
+func membershipLedgerCount(t *testing.T, sqlDB *sql.DB, todoID int64) int {
+	t.Helper()
+	var count int
+	if err := sqlDB.QueryRow(`
+		SELECT COUNT(*)
+		FROM todo_assignee_events
+		WHERE todo_id = ? AND reason = 'member_removed'
+	`, todoID).Scan(&count); err != nil {
+		t.Fatalf("count member_removed assignment events: %v", err)
+	}
+	return count
+}
+
+func findMembershipRESTMember(members []projectMemberJSON, userID int64) (projectMemberJSON, bool) {
+	for _, member := range members {
+		if member.UserID == userID {
+			return member, true
+		}
+	}
+	return projectMemberJSON{}, false
+}
+
+func assertMembershipRESTPublications(
+	t *testing.T,
+	fx *membershipRESTFixture,
+	stream *todoUpdateEventStream,
+	targetUserID int64,
+	action string,
+) {
+	t.Helper()
+	events := fx.collector.snapshot()
+	if len(events) != 2 {
+		t.Fatalf("fanout events=%+v, want exactly board.members_updated then project.membership", events)
+	}
+	if events[0].Type != "board.members_updated" || events[0].ProjectID != fx.project.ID {
+		t.Fatalf("first fanout event=%+v, want board.members_updated for project %d", events[0], fx.project.ID)
+	}
+	if events[1].Type != "project.membership" || events[1].ProjectID != fx.project.ID {
+		t.Fatalf("second fanout event=%+v, want project.membership for project %d", events[1], fx.project.ID)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(events[1].Payload, &payload); err != nil {
+		t.Fatalf("decode membership payload: %v", err)
+	}
+	assertExactJSONKeys(t, payload, "projectId", "affectedUserId", "action", "actorUserId")
+	if int64(payload["projectId"].(float64)) != fx.project.ID ||
+		int64(payload["affectedUserId"].(float64)) != targetUserID ||
+		payload["action"] != action ||
+		int64(payload["actorUserId"].(float64)) != fx.ownerID {
+		t.Fatalf("membership payload=%+v", payload)
+	}
+
+	sseEvents := collectTodoUpdateEvents(t, stream)
+	if len(sseEvents) != 1 || sseEvents[0].Type != "members_updated" || sseEvents[0].ProjectID != fx.project.ID {
+		t.Fatalf("board SSE events=%+v, want exactly one members_updated for project %d", sseEvents, fx.project.ID)
+	}
+}
+
+func assertMembershipRESTSilence(t *testing.T, collector *membershipEventCollector, stream *todoUpdateEventStream) {
+	t.Helper()
+	if events := collector.snapshot(); len(events) != 0 {
+		t.Fatalf("membership failure emitted fanout events: %+v", events)
+	}
+	if events := collectTodoUpdateEvents(t, stream); len(events) != 0 {
+		t.Fatalf("membership failure emitted SSE events: %+v", events)
+	}
+}
+
+func TestProjectMembershipRESTMutationContracts(t *testing.T) {
+	t.Run("add publishes ordered membership events", func(t *testing.T) {
+		fx := newMembershipRESTFixture(t, "membership-rest-add")
+		target := createMembershipUser(t, fx.st, "membership-rest-add-target")
+		stream := subscribeTodoUpdateEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+
+		var members []projectMemberJSON
+		resp, body := doJSON(t, fx.client, http.MethodPost, fx.membersURL(), map[string]any{
+			"user_id": target.ID,
+			"role":    "contributor",
+		}, &members)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("add status=%d body=%s", resp.StatusCode, body)
+		}
+		member, ok := findMembershipRESTMember(members, target.ID)
+		if !ok || member.Role != "contributor" || len(members) != 2 {
+			t.Fatalf("add response members=%+v", members)
+		}
+		if role, err := fx.st.GetProjectRole(fx.ctx, fx.project.ID, target.ID); err != nil || role != store.RoleContributor {
+			t.Fatalf("persisted role=%q err=%v", role, err)
+		}
+		if got := membershipAuditCount(t, fx.db, fx.project.ID, target.ID, "member_added"); got != 1 {
+			t.Fatalf("member_added audit count=%d want=1", got)
+		}
+		assertMembershipRESTPublications(t, fx, stream, target.ID, "added")
+	})
+
+	t.Run("update publishes ordered membership events", func(t *testing.T) {
+		fx := newMembershipRESTFixture(t, "membership-rest-update")
+		target := createMembershipUser(t, fx.st, "membership-rest-update-target")
+		if err := fx.st.AddProjectMember(fx.ctx, fx.ownerID, fx.project.ID, target.ID, store.RoleContributor); err != nil {
+			t.Fatalf("seed member: %v", err)
+		}
+		stream := subscribeTodoUpdateEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+
+		var members []projectMemberJSON
+		resp, body := doJSON(t, fx.client, http.MethodPatch, fx.membersURL()+fmt.Sprintf("/%d", target.ID), map[string]any{
+			"role": "viewer",
+		}, &members)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("update status=%d body=%s", resp.StatusCode, body)
+		}
+		member, ok := findMembershipRESTMember(members, target.ID)
+		if !ok || member.Role != "viewer" || len(members) != 2 {
+			t.Fatalf("update response members=%+v", members)
+		}
+		if got := membershipAuditCount(t, fx.db, fx.project.ID, target.ID, "member_role_changed"); got != 1 {
+			t.Fatalf("member_role_changed audit count=%d want=1", got)
+		}
+		assertMembershipRESTPublications(t, fx, stream, target.ID, "role_changed")
+	})
+
+	t.Run("remove clears assignment and publishes no todo event", func(t *testing.T) {
+		fx := newMembershipRESTFixture(t, "membership-rest-remove")
+		target := createMembershipUser(t, fx.st, "membership-rest-remove-target")
+		if err := fx.st.AddProjectMember(fx.ctx, fx.ownerID, fx.project.ID, target.ID, store.RoleContributor); err != nil {
+			t.Fatalf("seed member: %v", err)
+		}
+		assigneeID := target.ID
+		todo, err := fx.st.CreateTodo(fx.ctx, fx.project.ID, store.CreateTodoInput{
+			Title: "Unassign on member removal", AssigneeUserID: &assigneeID,
+		}, store.ModeFull)
+		if err != nil {
+			t.Fatalf("create assigned todo: %v", err)
+		}
+		stream := subscribeTodoUpdateEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+
+		var members []projectMemberJSON
+		resp, body := doJSON(t, fx.client, http.MethodDelete, fx.membersURL()+fmt.Sprintf("/%d", target.ID), nil, &members)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("remove status=%d body=%s", resp.StatusCode, body)
+		}
+		if _, ok := findMembershipRESTMember(members, target.ID); ok || len(members) != 1 {
+			t.Fatalf("remove response members=%+v", members)
+		}
+		persisted, err := fx.st.GetTodoByLocalID(fx.ctx, fx.project.ID, todo.LocalID, store.ModeFull)
+		if err != nil || persisted.AssigneeUserID != nil {
+			t.Fatalf("removed member assignment persisted=%+v err=%v", persisted, err)
+		}
+		if got := membershipLedgerCount(t, fx.db, todo.ID); got != 1 {
+			t.Fatalf("member_removed assignment ledger count=%d want=1", got)
+		}
+		if got := membershipAuditCount(t, fx.db, fx.project.ID, target.ID, "member_removed"); got != 1 {
+			t.Fatalf("member_removed audit count=%d want=1", got)
+		}
+		assertMembershipRESTPublications(t, fx, stream, target.ID, "removed")
+	})
+}
+
+func TestProjectMembershipRESTSemanticNoOpStillPublishes(t *testing.T) {
+	fx := newMembershipRESTFixture(t, "membership-rest-noop")
+	target := createMembershipUser(t, fx.st, "membership-rest-noop-target")
+	if err := fx.st.AddProjectMember(fx.ctx, fx.ownerID, fx.project.ID, target.ID, store.RoleViewer); err != nil {
+		t.Fatalf("seed member: %v", err)
+	}
+	stream := subscribeTodoUpdateEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+
+	var members []projectMemberJSON
+	resp, body := doJSON(t, fx.client, http.MethodPatch, fx.membersURL()+fmt.Sprintf("/%d", target.ID), map[string]any{
+		"role": " viewer ",
+	}, &members)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("semantic no-op status=%d body=%s", resp.StatusCode, body)
+	}
+	if member, ok := findMembershipRESTMember(members, target.ID); !ok || member.Role != "viewer" {
+		t.Fatalf("semantic no-op response=%+v", members)
+	}
+	if got := membershipAuditCount(t, fx.db, fx.project.ID, target.ID, "member_role_changed"); got != 0 {
+		t.Fatalf("semantic no-op audit count=%d want=0", got)
+	}
+	assertMembershipRESTPublications(t, fx, stream, target.ID, "role_changed")
+}
+
+func TestProjectMembershipRESTFailureSilence(t *testing.T) {
+	t.Run("validation", func(t *testing.T) {
+		fx := newMembershipRESTFixture(t, "membership-rest-validation")
+		target := createMembershipUser(t, fx.st, "membership-rest-validation-target")
+		stream := subscribeTodoUpdateEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+		resp, body := doJSON(t, fx.client, http.MethodPost, fx.membersURL(), map[string]any{"user_id": target.ID, "role": "invalid"}, nil)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("validation status=%d body=%s", resp.StatusCode, body)
+		}
+		assertMembershipRESTSilence(t, fx.collector, stream)
+	})
+
+	t.Run("authorization", func(t *testing.T) {
+		fx := newMembershipRESTFixture(t, "membership-rest-auth")
+		contributor := createMembershipUser(t, fx.st, "membership-rest-auth-contributor")
+		target := createMembershipUser(t, fx.st, "membership-rest-auth-target")
+		if err := fx.st.AddProjectMember(fx.ctx, fx.ownerID, fx.project.ID, contributor.ID, store.RoleContributor); err != nil {
+			t.Fatalf("seed contributor: %v", err)
+		}
+		client := newCookieClient(t)
+		loginUserClient(t, client, fx.ts.URL, contributor.Email, "password123")
+		stream := subscribeTodoUpdateEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+		resp, body := doJSON(t, client, http.MethodPost, fx.membersURL(), map[string]any{"user_id": target.ID, "role": "viewer"}, nil)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("authorization status=%d want concealed 404 body=%s", resp.StatusCode, body)
+		}
+		assertMembershipRESTSilence(t, fx.collector, stream)
+	})
+
+	t.Run("store rejection", func(t *testing.T) {
+		fx := newMembershipRESTFixture(t, "membership-rest-store-rejection")
+		target := createMembershipUser(t, fx.st, "membership-rest-store-rejection-target")
+		if err := fx.st.AddProjectMember(fx.ctx, fx.ownerID, fx.project.ID, target.ID, store.RoleViewer); err != nil {
+			t.Fatalf("seed member: %v", err)
+		}
+		stream := subscribeTodoUpdateEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+		resp, body := doJSON(t, fx.client, http.MethodPost, fx.membersURL(), map[string]any{"user_id": target.ID, "role": "viewer"}, nil)
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("store rejection status=%d body=%s", resp.StatusCode, body)
+		}
+		assertMembershipRESTSilence(t, fx.collector, stream)
+	})
+}
+
+type membershipListFailureStore struct {
+	*store.Store
+	err       error
+	listCalls int
+}
+
+func (s *membershipListFailureStore) ListProjectMembers(context.Context, int64, int64) ([]store.ProjectMember, error) {
+	s.listCalls++
+	return nil, s.err
+}
+
+func newMembershipListFailureRESTServer(t *testing.T) (*httptest.Server, *sql.DB, *membershipListFailureStore, *membershipEventCollector) {
+	t.Helper()
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "app.db"), db.Options{
+		BusyTimeout: 5000, JournalMode: "WAL", Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := migrate.Apply(context.Background(), sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+	wrapper := &membershipListFailureStore{Store: store.New(sqlDB, nil), err: errors.New("forced membership post-read failure")}
+	srv := NewServer(wrapper, Options{MaxRequestBody: 1 << 20, ScrumboyMode: "full"})
+	collector := &membershipEventCollector{}
+	srv.fanout = eventbus.NewFanout(newSSEBridge(srv.hub), collector)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(func() {
+		ts.Close()
+		_ = sqlDB.Close()
+	})
+	return ts, sqlDB, wrapper, collector
+}
+
+func TestProjectMembershipRESTPostReadFailureOccursAfterCommit(t *testing.T) {
+	for _, operation := range []string{"add", "update", "remove"} {
+		t.Run(operation, func(t *testing.T) {
+			ts, sqlDB, wrapped, collector := newMembershipListFailureRESTServer(t)
+			client := newCookieClient(t)
+			owner := bootstrapUserClient(t, client, ts.URL, "Membership Owner", "membership-postread-owner@example.com", "password123")
+			ownerID := int64(owner["id"].(float64))
+			ctx := store.WithUserID(context.Background(), ownerID)
+			project, err := wrapped.Store.CreateProject(ctx, "membership-rest-postread")
+			if err != nil {
+				t.Fatalf("create project: %v", err)
+			}
+			target := createMembershipUser(t, wrapped.Store, "membership-rest-postread-target")
+			method := http.MethodPost
+			url := fmt.Sprintf("%s/api/projects/%d/members", ts.URL, project.ID)
+			body := any(map[string]any{"user_id": target.ID, "role": "viewer"})
+			wantRole := store.RoleViewer
+			wantAudit := "member_added"
+			if operation != "add" {
+				if err := wrapped.Store.AddProjectMember(ctx, ownerID, project.ID, target.ID, store.RoleContributor); err != nil {
+					t.Fatalf("seed member: %v", err)
+				}
+				url += fmt.Sprintf("/%d", target.ID)
+			}
+			switch operation {
+			case "update":
+				method = http.MethodPatch
+				body = map[string]any{"role": "viewer"}
+				wantAudit = "member_role_changed"
+			case "remove":
+				method = http.MethodDelete
+				body = nil
+				wantRole = ""
+				wantAudit = "member_removed"
+			}
+			stream := subscribeTodoUpdateEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+
+			resp, responseBody := doJSON(t, client, method, url, body, nil)
+			if resp.StatusCode != http.StatusInternalServerError {
+				t.Fatalf("post-read status=%d want=500 body=%s", resp.StatusCode, responseBody)
+			}
+			if wrapped.listCalls != 1 {
+				t.Fatalf("post-read calls=%d want=1", wrapped.listCalls)
+			}
+			if role, err := wrapped.Store.GetProjectRole(ctx, project.ID, target.ID); err != nil || role != wantRole {
+				t.Fatalf("mutation did not commit before read failure: role=%q want=%q err=%v", role, wantRole, err)
+			}
+			if got := membershipAuditCount(t, sqlDB, project.ID, target.ID, wantAudit); got != 1 {
+				t.Fatalf("post-read %s audit count=%d want=1", wantAudit, got)
+			}
+			assertMembershipRESTSilence(t, collector, stream)
+		})
+	}
+}
+
+func TestProjectMembershipRESTSelfRemovalCommitsThenPostReadFails(t *testing.T) {
+	fx := newMembershipRESTFixture(t, "membership-rest-self-remove")
+	secondMaintainer := createMembershipUser(t, fx.st, "membership-rest-second-maintainer")
+	if err := fx.st.AddProjectMember(fx.ctx, fx.ownerID, fx.project.ID, secondMaintainer.ID, store.RoleMaintainer); err != nil {
+		t.Fatalf("seed second maintainer: %v", err)
+	}
+	stream := subscribeTodoUpdateEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+
+	var envelope apiErrorEnvelope
+	resp, body := doJSON(t, fx.client, http.MethodDelete, fx.membersURL()+fmt.Sprintf("/%d", fx.ownerID), nil, &envelope)
+	if resp.StatusCode != http.StatusNotFound || envelope.Error.Code != "NOT_FOUND" || envelope.Error.Message != "not found" {
+		t.Fatalf("self-removal status=%d error=%+v body=%s", resp.StatusCode, envelope, body)
+	}
+	if role, err := fx.st.GetProjectRole(fx.ctx, fx.project.ID, fx.ownerID); err != nil || role != "" {
+		t.Fatalf("self-removal did not commit: role=%q err=%v", role, err)
+	}
+	if got := membershipAuditCount(t, fx.db, fx.project.ID, fx.ownerID, "member_removed"); got != 1 {
+		t.Fatalf("self-removal audit count=%d want=1", got)
+	}
+	assertMembershipRESTSilence(t, fx.collector, stream)
+}
+
+func TestProjectMembershipRESTValidationRoleAndModeContracts(t *testing.T) {
+	t.Run("body and role validation precede actor extraction", func(t *testing.T) {
+		fx := newMembershipRESTFixture(t, "membership-rest-precedence")
+		target := createMembershipUser(t, fx.st, "membership-rest-precedence-target")
+		stateless := &http.Client{Transport: fx.ts.Client().Transport}
+		var envelope apiErrorEnvelope
+		resp, body := doJSON(t, stateless, http.MethodPost, fx.ts.URL+"/api/projects/not-an-id/members", "not-an-object", &envelope)
+		if resp.StatusCode != http.StatusBadRequest || envelope.Error.Code != "VALIDATION_ERROR" || envelope.Error.Details["field"] != "projectId" {
+			t.Fatalf("path precedence status=%d error=%+v body=%s", resp.StatusCode, envelope, body)
+		}
+		envelope = apiErrorEnvelope{}
+		resp, body = doJSON(t, stateless, http.MethodPost, fx.membersURL(), map[string]any{"user_id": target.ID, "role": "invalid"}, &envelope)
+		if resp.StatusCode != http.StatusBadRequest || envelope.Error.Code != "VALIDATION_ERROR" {
+			t.Fatalf("invalid role precedence status=%d error=%+v body=%s", resp.StatusCode, envelope, body)
+		}
+		resp, body = doJSON(t, stateless, http.MethodPost, fx.membersURL(), map[string]any{"user_id": target.ID, "role": "viewer"}, &envelope)
+		if resp.StatusCode != http.StatusUnauthorized || envelope.Error.Code != "UNAUTHORIZED" {
+			t.Fatalf("actor precedence status=%d error=%+v body=%s", resp.StatusCode, envelope, body)
+		}
+	})
+
+	t.Run("add accepts exact legacy owner and stores maintainer", func(t *testing.T) {
+		fx := newMembershipRESTFixture(t, "membership-rest-owner-compat")
+		target := createMembershipUser(t, fx.st, "membership-rest-owner-compat-target")
+		resp, body := doJSON(t, fx.client, http.MethodPost, fx.membersURL(), map[string]any{"user_id": target.ID, "role": "owner"}, nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("legacy owner status=%d body=%s", resp.StatusCode, body)
+		}
+		if role, err := fx.st.GetProjectRole(fx.ctx, fx.project.ID, target.ID); err != nil || role != store.RoleMaintainer {
+			t.Fatalf("legacy owner stored role=%q err=%v", role, err)
+		}
+	})
+
+	t.Run("Temporary Board creator is forbidden", func(t *testing.T) {
+		ts, sqlDB, cleanup := newTestHTTPServer(t, "full")
+		t.Cleanup(cleanup)
+		client := newCookieClient(t)
+		owner := bootstrapUserClient(t, client, ts.URL, "Temporary Creator", "membership-temp@example.com", "password123")
+		ownerID := int64(owner["id"].(float64))
+		st := store.New(sqlDB, nil)
+		board, err := st.CreateAnonymousBoard(store.WithUserID(context.Background(), ownerID))
+		if err != nil {
+			t.Fatalf("create Temporary Board: %v", err)
+		}
+		target := createMembershipUser(t, st, "membership-temp-target")
+		resp, body := doJSON(t, client, http.MethodPost, fmt.Sprintf("%s/api/projects/%d/members", ts.URL, board.ID), map[string]any{"user_id": target.ID, "role": "viewer"}, nil)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("Temporary Board status=%d want concealed 404 body=%s", resp.StatusCode, body)
+		}
+	})
+
+	t.Run("Anonymous Mode hides numeric membership route", func(t *testing.T) {
+		ts, sqlDB, cleanup := newTestHTTPServer(t, "anonymous")
+		t.Cleanup(cleanup)
+		st := store.New(sqlDB, nil)
+		board, err := st.CreateAnonymousBoard(context.Background())
+		if err != nil {
+			t.Fatalf("create Anonymous Board: %v", err)
+		}
+		resp, body := doJSON(t, ts.Client(), http.MethodPost, fmt.Sprintf("%s/api/projects/%d/members", ts.URL, board.ID), map[string]any{"user_id": 1, "role": "viewer"}, nil)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("Anonymous Mode status=%d want=404 body=%s", resp.StatusCode, body)
+		}
+	})
+}
+
+func TestProjectMembershipMCPMutationsAreStructurallyEventSilent(t *testing.T) {
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "app.db"), db.Options{
+		BusyTimeout: 5000, JournalMode: "WAL", Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := migrate.Apply(context.Background(), sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+	st := store.New(sqlDB, nil)
+	srv := NewServer(st, Options{
+		MaxRequestBody: 1 << 20,
+		ScrumboyMode:   "full",
+		MCPHandler:     mcp.New(st, mcp.Options{Mode: "full"}),
+	})
+	st.SetTodoAssignedPublisher(srv.PublishTodoAssigned)
+	collector := &membershipEventCollector{}
+	srv.fanout = eventbus.NewFanout(newSSEBridge(srv.hub), collector)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(func() {
+		ts.Close()
+		_ = sqlDB.Close()
+	})
+
+	client := newCookieClient(t)
+	owner := bootstrapUserClient(t, client, ts.URL, "Membership MCP Owner", "membership-mcp-fanout-owner@example.com", "password123")
+	ownerID := int64(owner["id"].(float64))
+	ctx := store.WithUserID(context.Background(), ownerID)
+	project, err := st.CreateProject(ctx, "membership MCP structural silence")
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	target := createMembershipUser(t, st, "membership-mcp-fanout-target")
+	stream := subscribeTodoUpdateEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+
+	operations := []struct {
+		tool  string
+		input map[string]any
+	}{
+		{tool: "members_add", input: map[string]any{"projectSlug": project.Slug, "userId": target.ID, "role": "contributor"}},
+		{tool: "members_updateRole", input: map[string]any{"projectSlug": project.Slug, "userId": target.ID, "role": "viewer"}},
+		{tool: "members_remove", input: map[string]any{"projectSlug": project.Slug, "userId": target.ID}},
+	}
+	for _, operation := range operations {
+		var output map[string]any
+		resp, body := doJSON(t, client, http.MethodPost, ts.URL+"/mcp", map[string]any{
+			"tool": operation.tool, "input": operation.input,
+		}, &output)
+		if resp.StatusCode != http.StatusOK || output["ok"] != true {
+			t.Fatalf("%s status=%d response=%+v body=%s", operation.tool, resp.StatusCode, output, body)
+		}
+		if events := collector.snapshot(); len(events) != 0 {
+			t.Fatalf("%s emitted fanout events: %+v", operation.tool, events)
+		}
+	}
+	if events := collectTodoUpdateEvents(t, stream); len(events) != 0 {
+		t.Fatalf("MCP membership mutations emitted SSE events: %+v", events)
+	}
+}

--- a/internal/httpapi/routing_projects.go
+++ b/internal/httpapi/routing_projects.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	boardapp "scrumboy/internal/application/board"
+	membershipapp "scrumboy/internal/application/membership"
 	"scrumboy/internal/projectcolor"
 	"scrumboy/internal/store"
 )
@@ -328,24 +329,27 @@ func (s *Server) handleProjectsProjectMembers(w http.ResponseWriter, r *http.Req
 			return true
 		}
 
-		userID, ok := store.UserIDFromContext(s.requestContext(r))
-		if !ok {
+		ctx := s.requestContext(r)
+		prepared, err := s.membershipMutations.Prepare(ctx, membershipapp.ResolvedRESTMutationTarget{
+			ProjectID: projectID,
+		})
+		if errors.Is(err, membershipapp.ErrActorRequired) {
 			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
 			return true
 		}
-
-		if err := s.store.AddProjectMember(s.requestContext(r), userID, projectID, in.UserID, role); err != nil {
-			writeStoreErr(w, err, true)
+		if err != nil {
+			writeInternal(w, err)
 			return true
 		}
 
-		members, err := s.store.ListProjectMembers(s.requestContext(r), projectID, userID)
+		members, err := prepared.Add(membershipapp.AddCommand{
+			TargetUserID: in.UserID,
+			Role:         role,
+		})
 		if err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}
-		s.emitMembersUpdated(r.Context(), projectID)
-		s.emitMembership(s.requestContext(r), projectID, in.UserID, "added")
 		writeJSON(w, http.StatusOK, projectMembersToJSON(members))
 		return true
 	}
@@ -357,24 +361,24 @@ func (s *Server) handleProjectsProjectMembers(w http.ResponseWriter, r *http.Req
 			return true
 		}
 
-		requesterID, ok := store.UserIDFromContext(s.requestContext(r))
-		if !ok {
+		ctx := s.requestContext(r)
+		prepared, err := s.membershipMutations.Prepare(ctx, membershipapp.ResolvedRESTMutationTarget{
+			ProjectID: projectID,
+		})
+		if errors.Is(err, membershipapp.ErrActorRequired) {
 			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
 			return true
 		}
-
-		if err := s.store.RemoveProjectMember(s.requestContext(r), requesterID, projectID, targetUserID); err != nil {
-			writeStoreErr(w, err, true)
+		if err != nil {
+			writeInternal(w, err)
 			return true
 		}
 
-		members, err := s.store.ListProjectMembers(s.requestContext(r), projectID, requesterID)
+		members, err := prepared.Remove(membershipapp.RemoveCommand{TargetUserID: targetUserID})
 		if err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}
-		s.emitMembersUpdated(r.Context(), projectID)
-		s.emitMembership(s.requestContext(r), projectID, targetUserID, "removed")
 		writeJSON(w, http.StatusOK, projectMembersToJSON(members))
 		return true
 	}
@@ -396,12 +400,23 @@ func (s *Server) handleProjectsProjectMembers(w http.ResponseWriter, r *http.Req
 			writeValidationError(w, "invalid role", "invalid_role", map[string]any{"field": "role"})
 			return true
 		}
-		requesterID, ok := store.UserIDFromContext(s.requestContext(r))
-		if !ok {
+		ctx := s.requestContext(r)
+		prepared, err := s.membershipMutations.Prepare(ctx, membershipapp.ResolvedRESTMutationTarget{
+			ProjectID: projectID,
+		})
+		if errors.Is(err, membershipapp.ErrActorRequired) {
 			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
 			return true
 		}
-		if err := s.store.UpdateProjectMemberRole(s.requestContext(r), requesterID, projectID, targetUserID, role); err != nil {
+		if err != nil {
+			writeInternal(w, err)
+			return true
+		}
+		members, err := prepared.UpdateRole(membershipapp.UpdateRoleCommand{
+			TargetUserID: targetUserID,
+			Role:         role,
+		})
+		if err != nil {
 			switch {
 			case errors.Is(err, store.ErrNotFound):
 				writeError(w, http.StatusNotFound, "NOT_FOUND", "not found", nil)
@@ -416,13 +431,6 @@ func (s *Server) handleProjectsProjectMembers(w http.ResponseWriter, r *http.Req
 			}
 			return true
 		}
-		members, err := s.store.ListProjectMembers(s.requestContext(r), projectID, requesterID)
-		if err != nil {
-			writeStoreErr(w, err, true)
-			return true
-		}
-		s.emitMembersUpdated(r.Context(), projectID)
-		s.emitMembership(s.requestContext(r), projectID, targetUserID, "role_changed")
 		writeJSON(w, http.StatusOK, projectMembersToJSON(members))
 		return true
 	}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	boardapp "scrumboy/internal/application/board"
+	membershipapp "scrumboy/internal/application/membership"
 	todoapp "scrumboy/internal/application/todo"
 	workflowapp "scrumboy/internal/application/workflow"
 	"scrumboy/internal/config"
@@ -94,12 +95,13 @@ type Options struct {
 }
 
 type Server struct {
-	store             storeAPI
-	boardReads        *boardapp.ReadService
-	todoCreates       *todoapp.CreateService
-	todoMoves         *todoapp.MoveService
-	todoUpdates       *todoapp.UpdateService
-	workflowMutations *workflowapp.RESTMutationService
+	store               storeAPI
+	boardReads          *boardapp.ReadService
+	todoCreates         *todoapp.CreateService
+	todoMoves           *todoapp.MoveService
+	todoUpdates         *todoapp.UpdateService
+	workflowMutations   *workflowapp.RESTMutationService
+	membershipMutations *membershipapp.RESTMutationService
 
 	logger                  *log.Logger
 	maxBody                 int64
@@ -223,13 +225,11 @@ type storeAPI interface {
 	UpdateProjectName(ctx context.Context, projectID int64, userID int64, name string) error
 	UpdateProjectDefaultSprintWeeks(ctx context.Context, projectID int64, userID int64, weeks int) error
 	workflowapp.MutationStore
+	membershipapp.MutationStore
 	CountTodosByColumnKey(ctx context.Context, projectID int64) (map[string]int, error)
 	GetProjectRole(ctx context.Context, projectID int64, userID int64) (store.ProjectRole, error)
 	CheckProjectRole(ctx context.Context, projectID int64, userID int64, requiredRole store.ProjectRole) error
 	ListProjectMembers(ctx context.Context, projectID int64, userID int64) ([]store.ProjectMember, error)
-	AddProjectMember(ctx context.Context, requesterID, projectID, targetUserID int64, role store.ProjectRole) error
-	RemoveProjectMember(ctx context.Context, requesterID, projectID, targetUserID int64) error
-	UpdateProjectMemberRole(ctx context.Context, requesterID, projectID, targetUserID int64, role store.ProjectRole) error
 	ListAvailableUsersForProject(ctx context.Context, requesterID, projectID int64) ([]store.User, error)
 
 	boardapp.ReadStore
@@ -599,6 +599,11 @@ func NewServer(st storeAPI, opts Options) *Server {
 		Refresh: workflowapp.BoardRefreshPublisherFunc(func(ctx context.Context, projectID int64, reason string) {
 			server.emitRefreshNeeded(ctx, projectID, reason)
 		}),
+	})
+	server.membershipMutations = membershipapp.NewRESTMutationService(membershipapp.RESTMutationServiceDependencies{
+		Mutations: st,
+		Members:   st,
+		Publisher: membershipMutationPublisher{server: server},
 	})
 	return server
 }

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	boardapp "scrumboy/internal/application/board"
+	membershipapp "scrumboy/internal/application/membership"
 	todoapp "scrumboy/internal/application/todo"
 	workflowapp "scrumboy/internal/application/workflow"
 	"scrumboy/internal/publicorigin"
@@ -56,9 +57,7 @@ type storeAPI interface {
 	GetProjectScopedTagByID(ctx context.Context, projectID, tagID int64) (store.TagWithColor, error)
 	ListProjectMembers(ctx context.Context, projectID int64, userID int64) ([]store.ProjectMember, error)
 	ListAvailableUsersForProject(ctx context.Context, requesterID, projectID int64) ([]store.User, error)
-	AddProjectMember(ctx context.Context, requesterID, projectID, targetUserID int64, role store.ProjectRole) error
-	UpdateProjectMemberRole(ctx context.Context, requesterID, projectID, targetUserID int64, role store.ProjectRole) error
-	RemoveProjectMember(ctx context.Context, requesterID, projectID, targetUserID int64) error
+	membershipapp.MutationStore
 	GetProjectWorkflow(ctx context.Context, projectID int64) ([]store.WorkflowColumn, error)
 	workflowapp.MutationStore
 	CountTodosForBoardLane(ctx context.Context, projectID int64, columnKey string, tagFilter string, searchFilter string, assigneeFilter store.AssigneeFilter, sprintFilter store.SprintFilter) (int, error)
@@ -88,16 +87,17 @@ type Options struct {
 }
 
 type Adapter struct {
-	store             storeAPI
-	boardReads        *boardapp.MCPBoardReadService
-	todoCreates       *todoapp.MCPCreateService
-	todoMoves         *todoapp.MCPMoveService
-	todoUpdates       *todoapp.MCPUpdateService
-	workflowMutations *workflowapp.MCPMutationService
-	mode              string
-	tools             toolRegistry
-	publicOrigin      *publicorigin.Resolver
-	logger            *log.Logger
+	store               storeAPI
+	boardReads          *boardapp.MCPBoardReadService
+	todoCreates         *todoapp.MCPCreateService
+	todoMoves           *todoapp.MCPMoveService
+	todoUpdates         *todoapp.MCPUpdateService
+	workflowMutations   *workflowapp.MCPMutationService
+	membershipMutations *membershipapp.MCPMutationService
+	mode                string
+	tools               toolRegistry
+	publicOrigin        *publicorigin.Resolver
+	logger              *log.Logger
 }
 
 func New(st storeAPI, opts Options) *Adapter {
@@ -146,6 +146,11 @@ func New(st storeAPI, opts Options) *Adapter {
 			Access:    st,
 			Mutations: st,
 			Workflow:  st,
+		}),
+		membershipMutations: membershipapp.NewMCPMutationService(membershipapp.MCPMutationServiceDependencies{
+			Access:    st,
+			Mutations: st,
+			Members:   st,
 		}),
 		mode:         mode,
 		tools:        make(toolRegistry),

--- a/internal/mcp/members_tools.go
+++ b/internal/mcp/members_tools.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	membershipapp "scrumboy/internal/application/membership"
 	"scrumboy/internal/store"
 )
 
@@ -19,6 +20,58 @@ func normalizeProjectMemberRoleForMCP(role string) string {
 		return "contributor"
 	default:
 		return s
+	}
+}
+
+func mapMembershipMutationPrepareError(err error) *adapterError {
+	switch {
+	case errors.Is(err, membershipapp.ErrMaintainerRequired):
+		return newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
+	case errors.Is(err, membershipapp.ErrActorRequired):
+		return newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
+	default:
+		return mapStoreError(err)
+	}
+}
+
+func mapMembershipAddError(err error) *adapterError {
+	switch {
+	case errors.Is(err, membershipapp.ErrAddedMemberMissing):
+		return newAdapterError(http.StatusInternalServerError, CodeInternal, "member not found after add", nil)
+	case errors.Is(err, store.ErrUnauthorized):
+		return newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
+	default:
+		return mapStoreError(err)
+	}
+}
+
+func mapMembershipUpdateRoleError(err error) *adapterError {
+	switch {
+	case errors.Is(err, membershipapp.ErrUpdatedMemberMissing):
+		return newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
+	case errors.Is(err, store.ErrUnauthorized):
+		return newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
+	case errors.Is(err, store.ErrConflict):
+		return newAdapterError(http.StatusConflict, CodeConflict, err.Error(), nil)
+	case errors.Is(err, store.ErrNotFound):
+		return newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
+	case errors.Is(err, store.ErrValidation):
+		return newAdapterError(http.StatusBadRequest, CodeValidationError, err.Error(), map[string]any{"field": "role"})
+	default:
+		return mapStoreError(err)
+	}
+}
+
+func mapMembershipRemoveError(err error) *adapterError {
+	switch {
+	case errors.Is(err, store.ErrUnauthorized):
+		return newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
+	case errors.Is(err, store.ErrNotFound):
+		return newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
+	case errors.Is(err, store.ErrValidation):
+		return newAdapterError(http.StatusBadRequest, CodeValidationError, err.Error(), nil)
+	default:
+		return mapStoreError(err)
 	}
 }
 
@@ -170,50 +223,30 @@ func (a *Adapter) handleMembersAdd(ctx context.Context, input any) (any, map[str
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "unsupported role", map[string]any{"field": "role"})
 	}
 
-	pc, pcErr := a.store.GetProjectContextBySlug(ctx, in.ProjectSlug, a.storeMode())
-	if pcErr != nil {
-		return nil, nil, mapStoreError(pcErr)
+	prepared, prepareErr := a.membershipMutations.Prepare(ctx, membershipapp.MCPMutationTarget{
+		ProjectSlug: in.ProjectSlug,
+		Mode:        a.storeMode(),
+	})
+	if prepareErr != nil {
+		return nil, nil, mapMembershipMutationPrepareError(prepareErr)
 	}
 
-	if !pc.Role.HasMinimumRole(store.RoleMaintainer) {
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
-	}
-
-	requesterID, ok := store.UserIDFromContext(ctx)
-	if !ok {
-		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
-	}
-
-	if err := a.store.AddProjectMember(ctx, requesterID, pc.Project.ID, in.UserID, pr); err != nil {
-		if errors.Is(err, store.ErrUnauthorized) {
-			return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
-		}
-		return nil, nil, mapStoreError(err)
-	}
-
-	members, mErr := a.store.ListProjectMembers(ctx, pc.Project.ID, requesterID)
-	if mErr != nil {
-		return nil, nil, mapStoreError(mErr)
-	}
-	var found *store.ProjectMember
-	for i := range members {
-		if members[i].UserID == in.UserID {
-			found = &members[i]
-			break
-		}
-	}
-	if found == nil {
-		return nil, nil, newAdapterError(http.StatusInternalServerError, CodeInternal, "member not found after add", nil)
+	member, addErr := prepared.Add(membershipapp.AddCommand{
+		TargetUserID: in.UserID,
+		Role:         pr,
+	})
+	if addErr != nil {
+		return nil, nil, mapMembershipAddError(addErr)
 	}
 
 	item := projectMemberItem{
 		ProjectSlug: in.ProjectSlug,
-		UserID:      found.UserID,
-		Email:       found.Email,
-		Name:        found.Name,
-		Image:       found.Image,
-		Role:        normalizeProjectMemberRoleForMCP(string(found.Role)),
-		CreatedAt:   found.CreatedAt,
+		UserID:      member.UserID,
+		Email:       member.Email,
+		Name:        member.Name,
+		Image:       member.Image,
+		Role:        normalizeProjectMemberRoleForMCP(string(member.Role)),
+		CreatedAt:   member.CreatedAt,
 	}
 
 	return map[string]any{
@@ -255,58 +288,30 @@ func (a *Adapter) handleMembersUpdateRole(ctx context.Context, input any) (any, 
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "unsupported role", map[string]any{"field": "role"})
 	}
 
-	pc, pcErr := a.store.GetProjectContextBySlug(ctx, in.ProjectSlug, a.storeMode())
-	if pcErr != nil {
-		return nil, nil, mapStoreError(pcErr)
+	prepared, prepareErr := a.membershipMutations.Prepare(ctx, membershipapp.MCPMutationTarget{
+		ProjectSlug: in.ProjectSlug,
+		Mode:        a.storeMode(),
+	})
+	if prepareErr != nil {
+		return nil, nil, mapMembershipMutationPrepareError(prepareErr)
 	}
 
-	if !pc.Role.HasMinimumRole(store.RoleMaintainer) {
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
-	}
-
-	requesterID, ok := store.UserIDFromContext(ctx)
-	if !ok {
-		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
-	}
-
-	if err := a.store.UpdateProjectMemberRole(ctx, requesterID, pc.Project.ID, in.UserID, pr); err != nil {
-		switch {
-		case errors.Is(err, store.ErrUnauthorized):
-			return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
-		case errors.Is(err, store.ErrConflict):
-			return nil, nil, newAdapterError(http.StatusConflict, CodeConflict, err.Error(), nil)
-		case errors.Is(err, store.ErrNotFound):
-			return nil, nil, newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
-		case errors.Is(err, store.ErrValidation):
-			return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, err.Error(), map[string]any{"field": "role"})
-		default:
-			return nil, nil, mapStoreError(err)
-		}
-	}
-
-	members, mErr := a.store.ListProjectMembers(ctx, pc.Project.ID, requesterID)
-	if mErr != nil {
-		return nil, nil, mapStoreError(mErr)
-	}
-	var found *store.ProjectMember
-	for i := range members {
-		if members[i].UserID == in.UserID {
-			found = &members[i]
-			break
-		}
-	}
-	if found == nil {
-		return nil, nil, newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
+	member, updateErr := prepared.UpdateRole(membershipapp.UpdateRoleCommand{
+		TargetUserID: in.UserID,
+		Role:         pr,
+	})
+	if updateErr != nil {
+		return nil, nil, mapMembershipUpdateRoleError(updateErr)
 	}
 
 	item := projectMemberItem{
 		ProjectSlug: in.ProjectSlug,
-		UserID:      found.UserID,
-		Email:       found.Email,
-		Name:        found.Name,
-		Image:       found.Image,
-		Role:        normalizeProjectMemberRoleForMCP(string(found.Role)),
-		CreatedAt:   found.CreatedAt,
+		UserID:      member.UserID,
+		Email:       member.Email,
+		Name:        member.Name,
+		Image:       member.Image,
+		Role:        normalizeProjectMemberRoleForMCP(string(member.Role)),
+		CreatedAt:   member.CreatedAt,
 	}
 
 	return map[string]any{
@@ -340,31 +345,17 @@ func (a *Adapter) handleMembersRemove(ctx context.Context, input any) (any, map[
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid userId", map[string]any{"field": "userId"})
 	}
 
-	pc, pcErr := a.store.GetProjectContextBySlug(ctx, in.ProjectSlug, a.storeMode())
-	if pcErr != nil {
-		return nil, nil, mapStoreError(pcErr)
+	prepared, prepareErr := a.membershipMutations.Prepare(ctx, membershipapp.MCPMutationTarget{
+		ProjectSlug: in.ProjectSlug,
+		Mode:        a.storeMode(),
+	})
+	if prepareErr != nil {
+		return nil, nil, mapMembershipMutationPrepareError(prepareErr)
 	}
 
-	if !pc.Role.HasMinimumRole(store.RoleMaintainer) {
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
-	}
-
-	requesterID, ok := store.UserIDFromContext(ctx)
-	if !ok {
-		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
-	}
-
-	if err := a.store.RemoveProjectMember(ctx, requesterID, pc.Project.ID, in.UserID); err != nil {
-		switch {
-		case errors.Is(err, store.ErrUnauthorized):
-			return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
-		case errors.Is(err, store.ErrNotFound):
-			return nil, nil, newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
-		case errors.Is(err, store.ErrValidation):
-			return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, err.Error(), nil)
-		default:
-			return nil, nil, mapStoreError(err)
-		}
+	removeErr := prepared.Remove(membershipapp.RemoveCommand{TargetUserID: in.UserID})
+	if removeErr != nil {
+		return nil, nil, mapMembershipRemoveError(removeErr)
 	}
 
 	return map[string]any{

--- a/internal/mcp/members_tools_test.go
+++ b/internal/mcp/members_tools_test.go
@@ -1,6 +1,14 @@
 package mcp
 
-import "testing"
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	membershipapp "scrumboy/internal/application/membership"
+	"scrumboy/internal/store"
+)
 
 func TestNormalizeProjectMemberRoleForMCP(t *testing.T) {
 	t.Parallel()
@@ -18,5 +26,149 @@ func TestNormalizeProjectMemberRoleForMCP(t *testing.T) {
 		if got := normalizeProjectMemberRoleForMCP(tc.in); got != tc.want {
 			t.Fatalf("normalizeProjectMemberRoleForMCP(%q) = %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+func assertMembershipAdapterError(
+	t *testing.T,
+	got *adapterError,
+	wantStatus int,
+	wantCode string,
+	wantMessage string,
+	wantDetails any,
+) {
+	t.Helper()
+	if got == nil {
+		t.Fatalf("adapter error=nil, want status=%d code=%q message=%q details=%#v", wantStatus, wantCode, wantMessage, wantDetails)
+	}
+	if got.Status != wantStatus || got.Code != wantCode || got.Message != wantMessage ||
+		!reflect.DeepEqual(got.Details, wantDetails) {
+		t.Fatalf("adapter error=%+v details=%#v, want status=%d code=%q message=%q details=%#v", got, got.Details, wantStatus, wantCode, wantMessage, wantDetails)
+	}
+}
+
+func TestMapMembershipMutationPrepareError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantStatus  int
+		wantCode    string
+		wantMessage string
+	}{
+		{
+			name: "maintainer required", err: fmt.Errorf("prepare: %w", membershipapp.ErrMaintainerRequired),
+			wantStatus: http.StatusForbidden, wantCode: CodeForbidden, wantMessage: "maintainer or higher required",
+		},
+		{
+			name: "actor required", err: fmt.Errorf("prepare: %w", membershipapp.ErrActorRequired),
+			wantStatus: http.StatusUnauthorized, wantCode: CodeAuthRequired, wantMessage: "Sign-in required for this tool",
+		},
+		{
+			name: "access not found", err: fmt.Errorf("access: %w", store.ErrNotFound),
+			wantStatus: http.StatusNotFound, wantCode: CodeNotFound, wantMessage: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertMembershipAdapterError(t, mapMembershipMutationPrepareError(tt.err), tt.wantStatus, tt.wantCode, tt.wantMessage, nil)
+		})
+	}
+}
+
+func TestMapMembershipAddError(t *testing.T) {
+	t.Run("missing target remains internal and client sanitized", func(t *testing.T) {
+		mapped := mapMembershipAddError(fmt.Errorf("projection: %w", membershipapp.ErrAddedMemberMissing))
+		assertMembershipAdapterError(t, mapped, http.StatusInternalServerError, CodeInternal, "member not found after add", nil)
+
+		client := clientErrorResponseBody(mapped)
+		details, ok := client.Details.(map[string]any)
+		if client.Code != CodeInternal || client.Message != "internal error" || !ok || len(details) != 0 {
+			t.Fatalf("client error=%+v, want generic INTERNAL with empty details", client)
+		}
+	})
+
+	t.Run("mutation unauthorized remains forbidden", func(t *testing.T) {
+		assertMembershipAdapterError(
+			t,
+			mapMembershipAddError(store.ErrUnauthorized),
+			http.StatusForbidden,
+			CodeForbidden,
+			"maintainer or higher required",
+			nil,
+		)
+	})
+
+	t.Run("other store errors retain generic mapping", func(t *testing.T) {
+		err := fmt.Errorf("%w: already a member", store.ErrConflict)
+		assertMembershipAdapterError(t, mapMembershipAddError(err), http.StatusConflict, CodeConflict, err.Error(), nil)
+	})
+}
+
+func TestMapMembershipUpdateRoleError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantStatus  int
+		wantCode    string
+		wantMessage string
+		wantDetails any
+	}{
+		{
+			name: "missing projected target", err: fmt.Errorf("projection: %w", membershipapp.ErrUpdatedMemberMissing),
+			wantStatus: http.StatusNotFound, wantCode: CodeNotFound, wantMessage: "not found",
+		},
+		{
+			name: "unauthorized", err: store.ErrUnauthorized,
+			wantStatus: http.StatusForbidden, wantCode: CodeForbidden, wantMessage: "maintainer or higher required",
+		},
+		{
+			name: "not found", err: store.ErrNotFound,
+			wantStatus: http.StatusNotFound, wantCode: CodeNotFound, wantMessage: "not found",
+		},
+		{
+			name: "conflict", err: fmt.Errorf("%w: cannot demote yourself", store.ErrConflict),
+			wantStatus: http.StatusConflict, wantCode: CodeConflict, wantMessage: "conflict: cannot demote yourself",
+		},
+		{
+			name: "validation", err: fmt.Errorf("%w: invalid role", store.ErrValidation),
+			wantStatus: http.StatusBadRequest, wantCode: CodeValidationError, wantMessage: "validation: invalid role",
+			wantDetails: map[string]any{"field": "role"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertMembershipAdapterError(t, mapMembershipUpdateRoleError(tt.err), tt.wantStatus, tt.wantCode, tt.wantMessage, tt.wantDetails)
+		})
+	}
+}
+
+func TestMapMembershipRemoveError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantStatus  int
+		wantCode    string
+		wantMessage string
+	}{
+		{
+			name: "unauthorized", err: store.ErrUnauthorized,
+			wantStatus: http.StatusForbidden, wantCode: CodeForbidden, wantMessage: "maintainer or higher required",
+		},
+		{
+			name: "not found", err: store.ErrNotFound,
+			wantStatus: http.StatusNotFound, wantCode: CodeNotFound, wantMessage: "not found",
+		},
+		{
+			name: "validation", err: fmt.Errorf("%w: cannot remove last maintainer", store.ErrValidation),
+			wantStatus: http.StatusBadRequest, wantCode: CodeValidationError, wantMessage: "validation: cannot remove last maintainer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertMembershipAdapterError(t, mapMembershipRemoveError(tt.err), tt.wantStatus, tt.wantCode, tt.wantMessage, nil)
+		})
 	}
 }

--- a/internal/mcp/project_membership_transport_contract_test.go
+++ b/internal/mcp/project_membership_transport_contract_test.go
@@ -1,0 +1,509 @@
+package mcp_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/db"
+	"scrumboy/internal/httpapi"
+	"scrumboy/internal/mcp"
+	"scrumboy/internal/migrate"
+	"scrumboy/internal/store"
+)
+
+func membershipMCPData(t *testing.T, transport string, response map[string]any) map[string]any {
+	t.Helper()
+	if transport == "legacy" {
+		if got, want := sortedMapKeys(response), []string{"data", "meta", "ok"}; !reflect.DeepEqual(got, want) || response["ok"] != true {
+			t.Fatalf("legacy success envelope=%+v keys=%v want=%v", response, got, want)
+		}
+		meta, ok := response["meta"].(map[string]any)
+		if !ok || len(meta) != 0 {
+			t.Fatalf("legacy metadata=%+v want empty object", response["meta"])
+		}
+		data, ok := response["data"].(map[string]any)
+		if !ok {
+			t.Fatalf("legacy data=%+v want object", response["data"])
+		}
+		return data
+	}
+
+	if got, want := sortedMapKeys(response), []string{"id", "jsonrpc", "result"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("JSON-RPC envelope=%+v keys=%v want=%v", response, got, want)
+	}
+	if response["jsonrpc"] != "2.0" || response["id"] != float64(14) {
+		t.Fatalf("JSON-RPC identity=%+v", response)
+	}
+	result, ok := response["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("JSON-RPC result=%+v want object", response["result"])
+	}
+	if got, want := sortedMapKeys(result), []string{"content", "structuredContent"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("JSON-RPC result=%+v keys=%v want=%v", result, got, want)
+	}
+	data, ok := result["structuredContent"].(map[string]any)
+	if !ok {
+		t.Fatalf("JSON-RPC structuredContent=%+v want object", result["structuredContent"])
+	}
+	content, ok := result["content"].([]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("JSON-RPC content=%+v", result["content"])
+	}
+	textBlock, ok := content[0].(map[string]any)
+	if !ok || textBlock["type"] != "text" {
+		t.Fatalf("JSON-RPC content block=%+v", content[0])
+	}
+	text, ok := textBlock["text"].(string)
+	if !ok {
+		t.Fatalf("JSON-RPC text=%+v", textBlock["text"])
+	}
+	var textData map[string]any
+	if err := json.Unmarshal([]byte(text), &textData); err != nil {
+		t.Fatalf("decode JSON-RPC text content: %v", err)
+	}
+	if !reflect.DeepEqual(textData, data) {
+		t.Fatalf("JSON-RPC text/structured divergence: text=%+v structured=%+v", textData, data)
+	}
+	return data
+}
+
+func membershipMCPAuditCount(t *testing.T, sqlDB *sql.DB, projectID, targetUserID int64, action string) int {
+	t.Helper()
+	var count int
+	if err := sqlDB.QueryRow(`
+		SELECT COUNT(*)
+		FROM audit_events
+		WHERE project_id = ? AND target_type = 'member' AND target_id = ? AND action = ?
+	`, projectID, targetUserID, action).Scan(&count); err != nil {
+		t.Fatalf("count %s audits: %v", action, err)
+	}
+	return count
+}
+
+func TestProjectMembershipMCPTransportAliasAndRealtimeMatrix(t *testing.T) {
+	operations := []struct {
+		name      string
+		canonical string
+		alias     string
+	}{
+		{name: "add", canonical: "members_add", alias: "members.add"},
+		{name: "update", canonical: "members_updateRole", alias: "members.updateRole"},
+		{name: "remove", canonical: "members_remove", alias: "members.remove"},
+	}
+	transports := []string{"legacy", "jsonrpc"}
+
+	for _, operation := range operations {
+		for _, tool := range []string{operation.canonical, operation.alias} {
+			for _, transport := range transports {
+				t.Run(operation.name+"/"+tool+"/"+transport, func(t *testing.T) {
+					ts, sqlDB, st, cleanup := newTodoUpdateMCPServer(t, "full")
+					t.Cleanup(cleanup)
+					client := newCookieClient(t, ts)
+					bootstrapUser(t, client, ts.URL)
+					ownerID := firstUserID(t, sqlDB)
+					ctx := store.WithUserID(context.Background(), ownerID)
+					project, err := st.CreateProject(ctx, "membership MCP matrix")
+					if err != nil {
+						t.Fatalf("create project: %v", err)
+					}
+					target, err := st.CreateUser(context.Background(), "membership-matrix-target@example.com", "password123", "Matrix Target")
+					if err != nil {
+						t.Fatalf("create target: %v", err)
+					}
+
+					args := map[string]any{"projectSlug": project.Slug, "userId": target.ID}
+					wantRole := store.RoleContributor
+					wantAudit := "member_added"
+					switch operation.name {
+					case "add":
+						args["role"] = "contributor"
+					case "update":
+						if err := st.AddProjectMember(ctx, ownerID, project.ID, target.ID, store.RoleContributor); err != nil {
+							t.Fatalf("seed update member: %v", err)
+						}
+						args["role"] = "viewer"
+						wantRole = store.RoleViewer
+						wantAudit = "member_role_changed"
+					case "remove":
+						if err := st.AddProjectMember(ctx, ownerID, project.ID, target.ID, store.RoleContributor); err != nil {
+							t.Fatalf("seed remove member: %v", err)
+						}
+						wantRole = ""
+						wantAudit = "member_removed"
+					}
+
+					stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+					defer stream.close()
+					resp, out := callTodoUpdateMCP(t, client, ts.URL, transport, tool, args)
+					if resp.StatusCode != http.StatusOK {
+						t.Fatalf("%s %s status=%d response=%+v", transport, tool, resp.StatusCode, out)
+					}
+					data := membershipMCPData(t, transport, out)
+
+					role, err := st.GetProjectRole(ctx, project.ID, target.ID)
+					if err != nil || role != wantRole {
+						t.Fatalf("persisted role=%q want=%q err=%v", role, wantRole, err)
+					}
+					if got := membershipMCPAuditCount(t, sqlDB, project.ID, target.ID, wantAudit); got != 1 {
+						t.Fatalf("%s audit count=%d want=1", wantAudit, got)
+					}
+
+					if operation.name == "remove" {
+						if got, want := sortedMapKeys(data), []string{"removed"}; !reflect.DeepEqual(got, want) {
+							t.Fatalf("remove data keys=%v want=%v data=%+v", got, want, data)
+						}
+						removed := data["removed"].(map[string]any)
+						if removed["projectSlug"] != project.Slug || int64(removed["userId"].(float64)) != target.ID {
+							t.Fatalf("remove projection=%+v", removed)
+						}
+					} else {
+						if got, want := sortedMapKeys(data), []string{"member"}; !reflect.DeepEqual(got, want) {
+							t.Fatalf("member data keys=%v want=%v data=%+v", got, want, data)
+						}
+						member := data["member"].(map[string]any)
+						if member["projectSlug"] != project.Slug || int64(member["userId"].(float64)) != target.ID || member["role"] != string(wantRole) {
+							t.Fatalf("member projection=%+v", member)
+						}
+					}
+					if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+						t.Fatalf("MCP membership mutation emitted realtime events: %+v", events)
+					}
+				})
+			}
+		}
+	}
+}
+
+func assertMembershipMCPError(t *testing.T, transport string, resp *http.Response, out map[string]any, wantStatus int, wantCode, wantMessage string) {
+	t.Helper()
+	if transport == "legacy" {
+		if resp.StatusCode != wantStatus {
+			t.Fatalf("legacy error status=%d want=%d response=%+v", resp.StatusCode, wantStatus, out)
+		}
+		errBody, ok := out["error"].(map[string]any)
+		if !ok || errBody["code"] != wantCode || errBody["message"] != wantMessage {
+			t.Fatalf("legacy error=%+v", out)
+		}
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("JSON-RPC status=%d response=%+v", resp.StatusCode, out)
+	}
+	result, ok := out["result"].(map[string]any)
+	if !ok || result["isError"] != true {
+		t.Fatalf("JSON-RPC result=%+v want tool error", out["result"])
+	}
+	structured, ok := result["structuredContent"].(map[string]any)
+	if !ok || structured["code"] != wantCode || structured["message"] != wantMessage {
+		t.Fatalf("JSON-RPC structured error=%+v", result["structuredContent"])
+	}
+	content, ok := result["content"].([]any)
+	if !ok || len(content) != 1 || content[0].(map[string]any)["text"] != wantMessage {
+		t.Fatalf("JSON-RPC content=%+v", result["content"])
+	}
+}
+
+func TestProjectMembershipMCPSemanticValidationPrecedesAccess(t *testing.T) {
+	ts, _, _, cleanup := newTodoUpdateMCPServer(t, "full")
+	t.Cleanup(cleanup)
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+
+	tests := []struct {
+		name      string
+		transport string
+		tool      string
+		role      string
+		wantHTTP  int
+		wantCode  string
+		wantMsg   string
+	}{
+		{name: "legacy invalid role", transport: "legacy", tool: "members_add", role: "owner", wantHTTP: http.StatusBadRequest, wantCode: "VALIDATION_ERROR", wantMsg: "unsupported role"},
+		{name: "JSON-RPC alias invalid role", transport: "jsonrpc", tool: "members.add", role: "owner", wantHTTP: http.StatusBadRequest, wantCode: "VALIDATION_ERROR", wantMsg: "unsupported role"},
+		{name: "valid semantics reach access", transport: "legacy", tool: "members_add", role: "viewer", wantHTTP: http.StatusNotFound, wantCode: "NOT_FOUND", wantMsg: "not found"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, out := callTodoUpdateMCP(t, client, ts.URL, tt.transport, tt.tool, map[string]any{
+				"projectSlug": "missing-membership-project",
+				"userId":      9876,
+				"role":        tt.role,
+			})
+			assertMembershipMCPError(t, tt.transport, resp, out, tt.wantHTTP, tt.wantCode, tt.wantMsg)
+		})
+	}
+}
+
+func TestProjectMembershipMCPNoOpAndSelfRemovalContracts(t *testing.T) {
+	t.Run("semantic no-op persists no audit and remains realtime silent", func(t *testing.T) {
+		ts, sqlDB, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		t.Cleanup(cleanup)
+		client := newCookieClient(t, ts)
+		bootstrapUser(t, client, ts.URL)
+		ownerID := firstUserID(t, sqlDB)
+		ctx := store.WithUserID(context.Background(), ownerID)
+		project, err := st.CreateProject(ctx, "membership MCP no-op")
+		if err != nil {
+			t.Fatalf("create project: %v", err)
+		}
+		target, err := st.CreateUser(context.Background(), "membership-noop-target@example.com", "password123", "No-op Target")
+		if err != nil {
+			t.Fatalf("create target: %v", err)
+		}
+		if err := st.AddProjectMember(ctx, ownerID, project.ID, target.ID, store.RoleViewer); err != nil {
+			t.Fatalf("seed member: %v", err)
+		}
+		stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+		defer stream.close()
+		resp, out := callTodoUpdateMCP(t, client, ts.URL, "legacy", "members_updateRole", map[string]any{
+			"projectSlug": project.Slug, "userId": target.ID, "role": " viewer ",
+		})
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("no-op status=%d response=%+v", resp.StatusCode, out)
+		}
+		member := membershipMCPData(t, "legacy", out)["member"].(map[string]any)
+		if member["role"] != "viewer" {
+			t.Fatalf("no-op projection=%+v", member)
+		}
+		if got := membershipMCPAuditCount(t, sqlDB, project.ID, target.ID, "member_role_changed"); got != 0 {
+			t.Fatalf("no-op audit count=%d want=0", got)
+		}
+		if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+			t.Fatalf("no-op emitted realtime events: %+v", events)
+		}
+	})
+
+	t.Run("self-removal succeeds without a post-read", func(t *testing.T) {
+		ts, sqlDB, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		t.Cleanup(cleanup)
+		client := newCookieClient(t, ts)
+		bootstrapUser(t, client, ts.URL)
+		ownerID := firstUserID(t, sqlDB)
+		ctx := store.WithUserID(context.Background(), ownerID)
+		project, err := st.CreateProject(ctx, "membership MCP self-removal")
+		if err != nil {
+			t.Fatalf("create project: %v", err)
+		}
+		second, err := st.CreateUser(context.Background(), "membership-mcp-second@example.com", "password123", "Second Maintainer")
+		if err != nil {
+			t.Fatalf("create second maintainer: %v", err)
+		}
+		if err := st.AddProjectMember(ctx, ownerID, project.ID, second.ID, store.RoleMaintainer); err != nil {
+			t.Fatalf("seed second maintainer: %v", err)
+		}
+		stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+		defer stream.close()
+		resp, out := callTodoUpdateMCP(t, client, ts.URL, "jsonrpc", "members.remove", map[string]any{
+			"projectSlug": project.Slug, "userId": ownerID,
+		})
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("self-removal status=%d response=%+v", resp.StatusCode, out)
+		}
+		removed := membershipMCPData(t, "jsonrpc", out)["removed"].(map[string]any)
+		if removed["projectSlug"] != project.Slug || int64(removed["userId"].(float64)) != ownerID {
+			t.Fatalf("self-removal projection=%+v", removed)
+		}
+		if role, err := st.GetProjectRole(ctx, project.ID, ownerID); err != nil || role != "" {
+			t.Fatalf("self-removal persistence role=%q err=%v", role, err)
+		}
+		if got := membershipMCPAuditCount(t, sqlDB, project.ID, ownerID, "member_removed"); got != 1 {
+			t.Fatalf("self-removal audit count=%d want=1", got)
+		}
+		if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+			t.Fatalf("self-removal emitted realtime events: %+v", events)
+		}
+	})
+}
+
+func TestProjectMembershipMCPBoardModeContracts(t *testing.T) {
+	t.Run("Temporary Board creator lacks a durable maintainer role", func(t *testing.T) {
+		ts, sqlDB, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		t.Cleanup(cleanup)
+		client := newCookieClient(t, ts)
+		bootstrapUser(t, client, ts.URL)
+		ownerID := firstUserID(t, sqlDB)
+		board, err := st.CreateAnonymousBoard(store.WithUserID(context.Background(), ownerID))
+		if err != nil {
+			t.Fatalf("create Temporary Board: %v", err)
+		}
+		target, err := st.CreateUser(context.Background(), "membership-mcp-temp-target@example.com", "password123", "Temp Target")
+		if err != nil {
+			t.Fatalf("create target: %v", err)
+		}
+		resp, out := callTodoUpdateMCP(t, client, ts.URL, "legacy", "members_add", map[string]any{
+			"projectSlug": board.Slug, "userId": target.ID, "role": "viewer",
+		})
+		assertMembershipMCPError(t, "legacy", resp, out, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required")
+	})
+
+	t.Run("Anonymous Mode reports capability unavailable", func(t *testing.T) {
+		ts, _, st, cleanup := newTodoUpdateMCPServer(t, "anonymous")
+		t.Cleanup(cleanup)
+		board, err := st.CreateAnonymousBoard(context.Background())
+		if err != nil {
+			t.Fatalf("create Anonymous Board: %v", err)
+		}
+		resp, out := callTodoUpdateMCP(t, ts.Client(), ts.URL, "legacy", "members_add", map[string]any{
+			"projectSlug": board.Slug, "userId": 1, "role": "viewer",
+		})
+		assertMembershipMCPError(t, "legacy", resp, out, http.StatusForbidden, "CAPABILITY_UNAVAILABLE", "members_add is unavailable in anonymous mode")
+	})
+}
+
+type membershipPostReadStore struct {
+	*store.Store
+	err       error
+	members   []store.ProjectMember
+	readCalls int
+}
+
+func (s *membershipPostReadStore) ListProjectMembers(context.Context, int64, int64) ([]store.ProjectMember, error) {
+	s.readCalls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	return append([]store.ProjectMember(nil), s.members...), nil
+}
+
+func newMembershipPostReadMCPServer(t *testing.T, readErr error, members []store.ProjectMember) (*httptest.Server, *sql.DB, *membershipPostReadStore) {
+	t.Helper()
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "app.db"), db.Options{
+		BusyTimeout: 5000, JournalMode: "WAL", Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := migrate.Apply(context.Background(), sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+	wrapper := &membershipPostReadStore{Store: store.New(sqlDB, nil), err: readErr, members: members}
+	srv := httpapi.NewServer(wrapper, httpapi.Options{
+		MaxRequestBody: 1 << 20,
+		ScrumboyMode:   "full",
+		MCPHandler:     mcp.New(wrapper, mcp.Options{Mode: "full"}),
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(func() {
+		ts.Close()
+		_ = sqlDB.Close()
+	})
+	return ts, sqlDB, wrapper
+}
+
+func TestProjectMembershipMCPPostReadContracts(t *testing.T) {
+	tests := []struct {
+		name       string
+		operation  string
+		transport  string
+		readErr    error
+		members    []store.ProjectMember
+		wantStatus int
+		wantCode   string
+		wantMsg    string
+	}{
+		{name: "add generic read failure", operation: "add", transport: "legacy", readErr: errors.New("forced membership post-read failure"), wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL", wantMsg: "internal error"},
+		{name: "add wrapped not found", operation: "add", transport: "legacy", readErr: fmt.Errorf("wrapped membership read: %w", store.ErrNotFound), wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND", wantMsg: "not found"},
+		{name: "add target missing", operation: "add", transport: "legacy", members: []store.ProjectMember{}, wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL", wantMsg: "internal error"},
+		{name: "update generic read failure JSON-RPC", operation: "update", transport: "jsonrpc", readErr: errors.New("forced JSON-RPC membership post-read failure"), wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL", wantMsg: "internal error"},
+		{name: "update target missing", operation: "update", transport: "legacy", members: []store.ProjectMember{}, wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND", wantMsg: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, sqlDB, wrapped := newMembershipPostReadMCPServer(t, tt.readErr, tt.members)
+			client := newCookieClient(t, ts)
+			bootstrapUser(t, client, ts.URL)
+			ownerID := firstUserID(t, sqlDB)
+			ctx := store.WithUserID(context.Background(), ownerID)
+			project, err := wrapped.Store.CreateProject(ctx, "membership MCP post-read")
+			if err != nil {
+				t.Fatalf("create project: %v", err)
+			}
+			target, err := wrapped.Store.CreateUser(context.Background(), "membership-postread-target@example.com", "password123", "Post-read Target")
+			if err != nil {
+				t.Fatalf("create target: %v", err)
+			}
+			tool := "members_add"
+			args := map[string]any{"projectSlug": project.Slug, "userId": target.ID, "role": "viewer"}
+			wantAction := "member_added"
+			if tt.operation == "update" {
+				if err := wrapped.Store.AddProjectMember(ctx, ownerID, project.ID, target.ID, store.RoleContributor); err != nil {
+					t.Fatalf("seed member: %v", err)
+				}
+				tool = "members_updateRole"
+				wantAction = "member_role_changed"
+			}
+
+			stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+			defer stream.close()
+			resp, out := callTodoUpdateMCP(t, client, ts.URL, tt.transport, tool, args)
+			assertMembershipMCPError(t, tt.transport, resp, out, tt.wantStatus, tt.wantCode, tt.wantMsg)
+			if wrapped.readCalls != 1 {
+				t.Fatalf("post-read calls=%d want=1", wrapped.readCalls)
+			}
+			if role, err := wrapped.Store.GetProjectRole(ctx, project.ID, target.ID); err != nil || role != store.RoleViewer {
+				t.Fatalf("mutation did not commit before post-read outcome: role=%q err=%v", role, err)
+			}
+			if got := membershipMCPAuditCount(t, sqlDB, project.ID, target.ID, wantAction); got != 1 {
+				t.Fatalf("%s audit count=%d want=1", wantAction, got)
+			}
+			if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+				t.Fatalf("post-read outcome emitted realtime events: %+v", events)
+			}
+		})
+	}
+}
+
+func TestProjectMembershipMCPRemoveSkipsPostRead(t *testing.T) {
+	ts, sqlDB, wrapped := newMembershipPostReadMCPServer(t, errors.New("remove must not read members"), nil)
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	ownerID := firstUserID(t, sqlDB)
+	ctx := store.WithUserID(context.Background(), ownerID)
+	project, err := wrapped.Store.CreateProject(ctx, "membership MCP remove no read")
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	target, err := wrapped.Store.CreateUser(context.Background(), "membership-remove-no-read@example.com", "password123", "Remove Target")
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	if err := wrapped.Store.AddProjectMember(ctx, ownerID, project.ID, target.ID, store.RoleViewer); err != nil {
+		t.Fatalf("seed member: %v", err)
+	}
+	stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+	defer stream.close()
+
+	resp, out := callTodoUpdateMCP(t, client, ts.URL, "jsonrpc", "members.remove", map[string]any{
+		"projectSlug": project.Slug,
+		"userId":      target.ID,
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("remove status=%d response=%+v", resp.StatusCode, out)
+	}
+	removed := membershipMCPData(t, "jsonrpc", out)["removed"].(map[string]any)
+	if removed["projectSlug"] != project.Slug || int64(removed["userId"].(float64)) != target.ID {
+		t.Fatalf("remove projection=%+v", removed)
+	}
+	if wrapped.readCalls != 0 {
+		t.Fatalf("remove post-read calls=%d want=0", wrapped.readCalls)
+	}
+	if role, err := wrapped.Store.GetProjectRole(ctx, project.ID, target.ID); err != nil || role != "" {
+		t.Fatalf("remove persistence role=%q err=%v", role, err)
+	}
+	if got := membershipMCPAuditCount(t, sqlDB, project.ID, target.ID, "member_removed"); got != 1 {
+		t.Fatalf("remove audit count=%d want=1", got)
+	}
+	if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+		t.Fatalf("remove emitted realtime events: %+v", events)
+	}
+}

--- a/internal/mcp/project_membership_transport_contract_test.go
+++ b/internal/mcp/project_membership_transport_contract_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"scrumboy/internal/db"
@@ -182,7 +183,7 @@ func TestProjectMembershipMCPTransportAliasAndRealtimeMatrix(t *testing.T) {
 	}
 }
 
-func assertMembershipMCPError(t *testing.T, transport string, resp *http.Response, out map[string]any, wantStatus int, wantCode, wantMessage string) {
+func assertMembershipMCPError(t *testing.T, transport string, resp *http.Response, out map[string]any, wantStatus int, wantCode, wantMessage string) map[string]any {
 	t.Helper()
 	if transport == "legacy" {
 		if resp.StatusCode != wantStatus {
@@ -192,7 +193,7 @@ func assertMembershipMCPError(t *testing.T, transport string, resp *http.Respons
 		if !ok || errBody["code"] != wantCode || errBody["message"] != wantMessage {
 			t.Fatalf("legacy error=%+v", out)
 		}
-		return
+		return errBody
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("JSON-RPC status=%d response=%+v", resp.StatusCode, out)
@@ -209,6 +210,7 @@ func assertMembershipMCPError(t *testing.T, transport string, resp *http.Respons
 	if !ok || len(content) != 1 || content[0].(map[string]any)["text"] != wantMessage {
 		t.Fatalf("JSON-RPC content=%+v", result["content"])
 	}
+	return structured
 }
 
 func TestProjectMembershipMCPSemanticValidationPrecedesAccess(t *testing.T) {
@@ -409,11 +411,13 @@ func TestProjectMembershipMCPPostReadContracts(t *testing.T) {
 		wantStatus int
 		wantCode   string
 		wantMsg    string
+		forbidden  []string
 	}{
-		{name: "add generic read failure", operation: "add", transport: "legacy", readErr: errors.New("forced membership post-read failure"), wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL", wantMsg: "internal error"},
+		{name: "add generic read failure", operation: "add", transport: "legacy", readErr: errors.New("forced membership post-read failure"), wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL", wantMsg: "internal error", forbidden: []string{"forced membership post-read failure"}},
 		{name: "add wrapped not found", operation: "add", transport: "legacy", readErr: fmt.Errorf("wrapped membership read: %w", store.ErrNotFound), wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND", wantMsg: "not found"},
-		{name: "add target missing", operation: "add", transport: "legacy", members: []store.ProjectMember{}, wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL", wantMsg: "internal error"},
-		{name: "update generic read failure JSON-RPC", operation: "update", transport: "jsonrpc", readErr: errors.New("forced JSON-RPC membership post-read failure"), wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL", wantMsg: "internal error"},
+		{name: "add target missing", operation: "add", transport: "legacy", members: []store.ProjectMember{}, wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL", wantMsg: "internal error", forbidden: []string{"member not found after add"}},
+		{name: "add target missing JSON-RPC", operation: "add", transport: "jsonrpc", members: []store.ProjectMember{}, wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL", wantMsg: "internal error", forbidden: []string{"member not found after add"}},
+		{name: "update generic read failure JSON-RPC", operation: "update", transport: "jsonrpc", readErr: errors.New("forced JSON-RPC membership post-read failure"), wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL", wantMsg: "internal error", forbidden: []string{"forced JSON-RPC membership post-read failure"}},
 		{name: "update target missing", operation: "update", transport: "legacy", members: []store.ProjectMember{}, wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND", wantMsg: "not found"},
 	}
 
@@ -446,7 +450,22 @@ func TestProjectMembershipMCPPostReadContracts(t *testing.T) {
 			stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
 			defer stream.close()
 			resp, out := callTodoUpdateMCP(t, client, ts.URL, tt.transport, tool, args)
-			assertMembershipMCPError(t, tt.transport, resp, out, tt.wantStatus, tt.wantCode, tt.wantMsg)
+			publicError := assertMembershipMCPError(t, tt.transport, resp, out, tt.wantStatus, tt.wantCode, tt.wantMsg)
+			if tt.wantCode == "INTERNAL" {
+				details, ok := publicError["details"].(map[string]any)
+				if !ok || len(details) != 0 {
+					t.Fatalf("INTERNAL public details=%+v want empty object", publicError["details"])
+				}
+				encoded, err := json.Marshal(out)
+				if err != nil {
+					t.Fatalf("marshal public response: %v", err)
+				}
+				for _, forbidden := range tt.forbidden {
+					if strings.Contains(string(encoded), forbidden) {
+						t.Fatalf("public response leaked %q: %s", forbidden, encoded)
+					}
+				}
+			}
 			if wrapped.readCalls != 1 {
 				t.Fatalf("post-read calls=%d want=1", wrapped.readCalls)
 			}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.29.4"
+const Version = "3.29.5"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
 REST/MCP member add, role update, and remove now go through internal/application/membership, with transports left as thin wrappers and contract tests locking the paths.