### PR TITLE
Refactor/sprint lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.29.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags), **3.29.0** (MCP JSON-RPC error/`board_get` identity) - see those releases.
 
+## [3.29.8] - 2026-08-08
+
+### Changed
+
+- **Sprint mutations move behind application services** - REST and MCP sprint
+  definition, lifecycle, and deletion operations now use prepared application
+  services with narrow capability boundaries. Existing validation,
+  authorization, response, event, and compatibility contracts are preserved,
+  with comprehensive application, store, REST, and MCP contract coverage.
+
+### Fixed
+
+- **Sprint close mutations are project-scoped** - Closing a sprint now requires
+  both its project and sprint identity, preventing an authorized request for one
+  project from closing a sprint belonging to another project.
+
 ## [3.29.7] - 2026-08-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.29.7-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.29.8-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/internal/application/sprint/definition.go
+++ b/internal/application/sprint/definition.go
@@ -1,0 +1,85 @@
+// Package sprint defines application boundaries for sprint use cases.
+package sprint
+
+import (
+	"context"
+	"time"
+
+	"scrumboy/internal/store"
+)
+
+// CreateCommand contains definition values already decoded and converted by a
+// transport adapter. A later prepared capability binds project and requester
+// identity. The command performs no normalization or validation; the store
+// remains authoritative for sprint-definition policy.
+type CreateCommand struct {
+	Name           string
+	PlannedStartAt time.Time
+	PlannedEndAt   time.Time
+}
+
+// UpdateCommand preserves syntactic presence for the definition fields shared
+// by REST and MCP. Nil means omitted; a non-nil pointer remains supplied even
+// when it points to an empty string or zero time. Transport decoding and public
+// validation remain adapter-owned.
+type UpdateCommand struct {
+	Name           *string
+	PlannedStartAt *time.Time
+	PlannedEndAt   *time.Time
+}
+
+// HasFields reports syntactic field presence without applying validation,
+// semantic comparison, or a transport-specific write/no-write policy.
+func (c UpdateCommand) HasFields() bool {
+	return c.Name != nil || c.PlannedStartAt != nil || c.PlannedEndAt != nil
+}
+
+// MaterializeUpdateInput converts an application-owned command to the current
+// store vocabulary. It defensively copies supplied values and intentionally
+// performs no normalization, validation, authorization, or persistence.
+func MaterializeUpdateInput(command UpdateCommand) store.UpdateSprintInput {
+	input := store.UpdateSprintInput{}
+	if command.Name != nil {
+		value := *command.Name
+		input.Name = &value
+	}
+	if command.PlannedStartAt != nil {
+		value := *command.PlannedStartAt
+		input.PlannedStartAt = &value
+	}
+	if command.PlannedEndAt != nil {
+		value := *command.PlannedEndAt
+		input.PlannedEndAt = &value
+	}
+	return input
+}
+
+// DefinitionStore is the complete persistence capability for the create/update
+// sprint-definition subfamily. The store retains name, uniqueness, date,
+// lifecycle-state, numbering, persistence, and create-return-read policy.
+type DefinitionStore interface {
+	CreateSprint(
+		ctx context.Context,
+		projectID int64,
+		name string,
+		plannedStartAt time.Time,
+		plannedEndAt time.Time,
+	) (store.Sprint, error)
+
+	UpdateSprint(
+		ctx context.Context,
+		sprintID int64,
+		input store.UpdateSprintInput,
+	) error
+}
+
+// RoleStore is kept separate from definition persistence because both future
+// prepared services perform a fresh role lookup but retain distinct error
+// policies. The port returns the store result unchanged.
+type RoleStore interface {
+	GetProjectRole(
+		ctx context.Context,
+		projectID int64,
+		userID int64,
+	) (store.ProjectRole, error)
+}

--- a/internal/application/sprint/definition.go
+++ b/internal/application/sprint/definition.go
@@ -73,9 +73,10 @@ type DefinitionStore interface {
 	) error
 }
 
-// RoleStore is kept separate from definition persistence because both future
-// prepared services perform a fresh role lookup but retain distinct error
-// policies. The port returns the store result unchanged.
+// RoleStore is kept separate from definition, lifecycle, and deletion
+// persistence because their prepared REST and MCP services perform a fresh role
+// lookup while retaining transport-specific error policies. The port returns
+// the store result unchanged.
 type RoleStore interface {
 	GetProjectRole(
 		ctx context.Context,

--- a/internal/application/sprint/definition_test.go
+++ b/internal/application/sprint/definition_test.go
@@ -1,0 +1,143 @@
+package sprint
+
+import (
+	"testing"
+	"time"
+
+	"scrumboy/internal/store"
+)
+
+var _ DefinitionStore = (*store.Store)(nil)
+var _ RoleStore = (*store.Store)(nil)
+
+func TestUpdateCommandHasFieldsPreservesSyntacticPresence(t *testing.T) {
+	emptyName := ""
+	zeroTime := time.Time{}
+	start := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
+	end := start.Add(7 * 24 * time.Hour)
+
+	tests := []struct {
+		name    string
+		command UpdateCommand
+		want    bool
+	}{
+		{name: "all omitted", command: UpdateCommand{}, want: false},
+		{name: "name", command: UpdateCommand{Name: &emptyName}, want: true},
+		{name: "planned start", command: UpdateCommand{PlannedStartAt: &start}, want: true},
+		{name: "planned end", command: UpdateCommand{PlannedEndAt: &end}, want: true},
+		{name: "zero time remains present", command: UpdateCommand{PlannedStartAt: &zeroTime}, want: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.command.HasFields(); got != test.want {
+				t.Fatalf("HasFields()=%t, want %t for command %+v", got, test.want, test.command)
+			}
+		})
+	}
+}
+
+func TestMaterializeUpdateInputPreservesPresenceAndValues(t *testing.T) {
+	empty := MaterializeUpdateInput(UpdateCommand{})
+	if empty.Name != nil || empty.PlannedStartAt != nil || empty.PlannedEndAt != nil {
+		t.Fatalf("empty materialized input=%+v, want all fields omitted", empty)
+	}
+
+	emptyName := ""
+	zeroTime := time.Time{}
+	startLocation := time.FixedZone("checkpoint-two", 2*60*60)
+	start := time.Date(2026, time.August, 10, 12, 30, 45, 123000000, startLocation)
+	end := start.Add(9 * 24 * time.Hour)
+
+	tests := []struct {
+		name    string
+		command UpdateCommand
+		assert  func(*testing.T, store.UpdateSprintInput)
+	}{
+		{
+			name:    "empty name remains supplied",
+			command: UpdateCommand{Name: &emptyName},
+			assert: func(t *testing.T, got store.UpdateSprintInput) {
+				t.Helper()
+				if got.Name == nil || *got.Name != "" || got.PlannedStartAt != nil || got.PlannedEndAt != nil {
+					t.Fatalf("materialized input=%+v", got)
+				}
+			},
+		},
+		{
+			name:    "zero start remains supplied",
+			command: UpdateCommand{PlannedStartAt: &zeroTime},
+			assert: func(t *testing.T, got store.UpdateSprintInput) {
+				t.Helper()
+				if got.Name != nil || got.PlannedStartAt == nil || !got.PlannedStartAt.IsZero() || got.PlannedEndAt != nil {
+					t.Fatalf("materialized input=%+v", got)
+				}
+			},
+		},
+		{
+			name:    "planned end maps independently",
+			command: UpdateCommand{PlannedEndAt: &end},
+			assert: func(t *testing.T, got store.UpdateSprintInput) {
+				t.Helper()
+				if got.Name != nil || got.PlannedStartAt != nil || got.PlannedEndAt == nil || *got.PlannedEndAt != end {
+					t.Fatalf("materialized input=%+v", got)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.assert(t, MaterializeUpdateInput(test.command))
+		})
+	}
+
+	name := "Definition values"
+	all := MaterializeUpdateInput(UpdateCommand{
+		Name:           &name,
+		PlannedStartAt: &start,
+		PlannedEndAt:   &end,
+	})
+	if all.Name == nil || *all.Name != name ||
+		all.PlannedStartAt == nil || *all.PlannedStartAt != start ||
+		all.PlannedEndAt == nil || *all.PlannedEndAt != end {
+		t.Fatalf("fully materialized input=%+v", all)
+	}
+}
+
+func TestMaterializeUpdateInputIsolatesPointers(t *testing.T) {
+	name := "Original name"
+	location := time.FixedZone("pointer-isolation", -5*60*60)
+	start := time.Date(2026, time.August, 10, 9, 15, 30, 456000000, location)
+	end := start.Add(7 * 24 * time.Hour)
+	command := UpdateCommand{
+		Name:           &name,
+		PlannedStartAt: &start,
+		PlannedEndAt:   &end,
+	}
+
+	input := MaterializeUpdateInput(command)
+	if input.Name == command.Name || input.PlannedStartAt == command.PlannedStartAt || input.PlannedEndAt == command.PlannedEndAt {
+		t.Fatalf("materialized input retained command pointers: command=%+v input=%+v", command, input)
+	}
+
+	originalName := *input.Name
+	originalStart := *input.PlannedStartAt
+	originalEnd := *input.PlannedEndAt
+	*command.Name = "Changed command name"
+	*command.PlannedStartAt = command.PlannedStartAt.Add(24 * time.Hour)
+	*command.PlannedEndAt = command.PlannedEndAt.Add(48 * time.Hour)
+	if *input.Name != originalName || *input.PlannedStartAt != originalStart || *input.PlannedEndAt != originalEnd {
+		t.Fatalf("command mutation changed materialized input: command=%+v input=%+v", command, input)
+	}
+
+	inputName := "Changed input name"
+	inputStart := originalStart.Add(-24 * time.Hour)
+	inputEnd := originalEnd.Add(-48 * time.Hour)
+	*input.Name = inputName
+	*input.PlannedStartAt = inputStart
+	*input.PlannedEndAt = inputEnd
+	if *command.Name == inputName || *command.PlannedStartAt == inputStart || *command.PlannedEndAt == inputEnd {
+		t.Fatalf("materialized-input mutation changed command: command=%+v input=%+v", command, input)
+	}
+}

--- a/internal/application/sprint/lifecycle.go
+++ b/internal/application/sprint/lifecycle.go
@@ -1,0 +1,50 @@
+package sprint
+
+import "context"
+
+// TransitionTarget carries the resolved project identity and stored sprint
+// identity that a prepared lifecycle operation binds. It does not itself
+// authorize activation or close, and it intentionally carries no role, state,
+// time, slug, or transport snapshot.
+type TransitionTarget struct {
+	ProjectID int64
+	SprintID  int64
+}
+
+// DeletionTarget is distinct from TransitionTarget because sprint destruction
+// has different preparation, result, and side-effect semantics. It carries only
+// the resolved project identity and stored sprint identity; constructing it does
+// not authorize deletion.
+type DeletionTarget struct {
+	ProjectID int64
+	SprintID  int64
+}
+
+// TransitionStore is the project-scoped persistence capability shared by the
+// activation and close transition subfamily. The store retains authoritative
+// project, lifecycle-state, time, transaction, and timestamp invariants.
+type TransitionStore interface {
+	ActivateSprint(
+		ctx context.Context,
+		projectID int64,
+		sprintID int64,
+	) error
+
+	CloseSprint(
+		ctx context.Context,
+		projectID int64,
+		sprintID int64,
+	) error
+}
+
+// DeletionStore is kept separate from transition persistence so future
+// deletion services receive no activation or close capability. The store and
+// database retain project ownership, lifecycle-state compatibility, deletion,
+// and todo-detachment policy.
+type DeletionStore interface {
+	DeleteSprint(
+		ctx context.Context,
+		projectID int64,
+		sprintID int64,
+	) error
+}

--- a/internal/application/sprint/lifecycle_test.go
+++ b/internal/application/sprint/lifecycle_test.go
@@ -1,0 +1,6 @@
+package sprint
+
+import "scrumboy/internal/store"
+
+var _ TransitionStore = (*store.Store)(nil)
+var _ DeletionStore = (*store.Store)(nil)

--- a/internal/application/sprint/mcp_definition.go
+++ b/internal/application/sprint/mcp_definition.go
@@ -1,0 +1,201 @@
+package sprint
+
+import (
+	"context"
+	"errors"
+
+	"scrumboy/internal/store"
+)
+
+var (
+	// ErrSprintNotInProject reports that an MCP update target was read
+	// successfully but belongs to a different slug-resolved project.
+	ErrSprintNotInProject = errors.New("sprint definition target not in project")
+)
+
+// MCPAccessStore resolves the project-slug access boundary used by canonical
+// MCP sprint-definition mutations.
+type MCPAccessStore interface {
+	GetProjectContextBySlug(
+		ctx context.Context,
+		slug string,
+		mode store.Mode,
+	) (store.ProjectContext, error)
+}
+
+// SprintReadStore provides the target and post-mutation sprint reads used by
+// canonical MCP sprint-definition mutations.
+type SprintReadStore interface {
+	GetSprintByID(ctx context.Context, sprintID int64) (store.Sprint, error)
+}
+
+// MCPDefinitionServiceDependencies names the access, fresh-role,
+// definition-write, and sprint-read capabilities used by MCP definitions.
+type MCPDefinitionServiceDependencies struct {
+	Access      MCPAccessStore
+	Roles       RoleStore
+	Definitions DefinitionStore
+	Sprints     SprintReadStore
+}
+
+// MCPDefinitionService owns MCP project access, actor/fresh-role
+// authorization, update target verification, definition persistence, and the
+// update result read. It deliberately has no publication or transport
+// dependency.
+type MCPDefinitionService struct {
+	access      MCPAccessStore
+	roles       RoleStore
+	definitions DefinitionStore
+	sprints     SprintReadStore
+}
+
+func NewMCPDefinitionService(deps MCPDefinitionServiceDependencies) *MCPDefinitionService {
+	return &MCPDefinitionService{
+		access:      deps.Access,
+		roles:       deps.Roles,
+		definitions: deps.Definitions,
+		sprints:     deps.Sprints,
+	}
+}
+
+// MCPProjectTarget carries only the slug and mode needed to prepare an MCP
+// sprint-definition create capability.
+type MCPProjectTarget struct {
+	ProjectSlug string
+	Mode        store.Mode
+}
+
+// MCPSprintTarget carries only the slug, stored sprint ID, and mode needed to
+// prepare an MCP sprint-definition update capability.
+type MCPSprintTarget struct {
+	ProjectSlug string
+	SprintID    int64
+	Mode        store.Mode
+}
+
+// PreparedMCPCreate binds the exact authorized context and resolved project ID
+// to one subsequent MCP sprint-definition create.
+type PreparedMCPCreate struct {
+	ctx       context.Context
+	service   *MCPDefinitionService
+	projectID int64
+}
+
+// PreparedMCPUpdate binds the exact authorized context, target-verified stored
+// sprint ID, and pre-read sprint to one subsequent MCP definition update.
+type PreparedMCPUpdate struct {
+	ctx      context.Context
+	service  *MCPDefinitionService
+	sprintID int64
+	existing store.Sprint
+}
+
+// PrepareCreate preserves the characterized MCP order: project-slug access,
+// actor extraction, then a fresh role lookup.
+func (s *MCPDefinitionService) PrepareCreate(
+	ctx context.Context,
+	target MCPProjectTarget,
+) (*PreparedMCPCreate, error) {
+	projectID, err := s.authorize(ctx, target.ProjectSlug, target.Mode)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PreparedMCPCreate{
+		ctx:       ctx,
+		service:   s,
+		projectID: projectID,
+	}, nil
+}
+
+// PrepareUpdate preserves the characterized MCP authorization order, then
+// reads the requested stored sprint and verifies its resolved project.
+func (s *MCPDefinitionService) PrepareUpdate(
+	ctx context.Context,
+	target MCPSprintTarget,
+) (*PreparedMCPUpdate, error) {
+	projectID, err := s.authorize(ctx, target.ProjectSlug, target.Mode)
+	if err != nil {
+		return nil, err
+	}
+
+	existing, err := s.sprints.GetSprintByID(ctx, target.SprintID)
+	if err != nil {
+		return nil, err
+	}
+	if existing.ProjectID != projectID {
+		return nil, ErrSprintNotInProject
+	}
+
+	return &PreparedMCPUpdate{
+		ctx:      ctx,
+		service:  s,
+		sprintID: target.SprintID,
+		existing: existing,
+	}, nil
+}
+
+func (s *MCPDefinitionService) authorize(
+	ctx context.Context,
+	projectSlug string,
+	mode store.Mode,
+) (int64, error) {
+	projectContext, err := s.access.GetProjectContextBySlug(ctx, projectSlug, mode)
+	if err != nil {
+		return 0, err
+	}
+
+	userID, ok := store.UserIDFromContext(ctx)
+	if !ok {
+		return 0, ErrActorRequired
+	}
+
+	role, err := s.roles.GetProjectRole(ctx, projectContext.Project.ID, userID)
+	if err != nil {
+		return 0, err
+	}
+	if !role.HasMinimumRole(store.RoleMaintainer) {
+		return 0, ErrMaintainerRequired
+	}
+
+	return projectContext.Project.ID, nil
+}
+
+// Create persists one adapter-prepared definition and returns the exact store
+// result. MCP definition services are structurally unable to publish.
+func (p *PreparedMCPCreate) Create(command CreateCommand) (store.Sprint, error) {
+	sprint, err := p.service.definitions.CreateSprint(
+		p.ctx,
+		p.projectID,
+		command.Name,
+		command.PlannedStartAt,
+		command.PlannedEndAt,
+	)
+	if err != nil {
+		return store.Sprint{}, err
+	}
+	return sprint, nil
+}
+
+// Update returns the retained target for an empty command. A non-empty command
+// performs one definition write followed by one result read using the bound,
+// target-verified stored sprint ID.
+func (p *PreparedMCPUpdate) Update(command UpdateCommand) (store.Sprint, error) {
+	if !command.HasFields() {
+		return p.existing, nil
+	}
+
+	if err := p.service.definitions.UpdateSprint(
+		p.ctx,
+		p.sprintID,
+		MaterializeUpdateInput(command),
+	); err != nil {
+		return store.Sprint{}, err
+	}
+
+	updated, err := p.service.sprints.GetSprintByID(p.ctx, p.sprintID)
+	if err != nil {
+		return store.Sprint{}, err
+	}
+	return updated, nil
+}

--- a/internal/application/sprint/mcp_definition.go
+++ b/internal/application/sprint/mcp_definition.go
@@ -8,13 +8,13 @@ import (
 )
 
 var (
-	// ErrSprintNotInProject reports that an MCP update target was read
-	// successfully but belongs to a different slug-resolved project.
+	// ErrSprintNotInProject reports that a sprint-mutation target was read
+	// successfully but belongs to a different resolved project.
 	ErrSprintNotInProject = errors.New("sprint definition target not in project")
 )
 
-// MCPAccessStore resolves the project-slug access boundary used by canonical
-// MCP sprint-definition mutations.
+// MCPAccessStore resolves the project-slug access boundary shared by canonical
+// MCP sprint-definition, lifecycle, and deletion mutations.
 type MCPAccessStore interface {
 	GetProjectContextBySlug(
 		ctx context.Context,
@@ -23,8 +23,8 @@ type MCPAccessStore interface {
 	) (store.ProjectContext, error)
 }
 
-// SprintReadStore provides the target and post-mutation sprint reads used by
-// canonical MCP sprint-definition mutations.
+// SprintReadStore provides target and post-mutation sprint reads shared by
+// prepared sprint definition, lifecycle, and deletion operations.
 type SprintReadStore interface {
 	GetSprintByID(ctx context.Context, sprintID int64) (store.Sprint, error)
 }

--- a/internal/application/sprint/mcp_definition_test.go
+++ b/internal/application/sprint/mcp_definition_test.go
@@ -1,0 +1,804 @@
+package sprint
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"scrumboy/internal/store"
+)
+
+var _ MCPAccessStore = (*store.Store)(nil)
+var _ SprintReadStore = (*store.Store)(nil)
+
+type mcpDefinitionContextKey struct{}
+
+type mcpDefinitionAccessCall struct {
+	ctx  context.Context
+	slug string
+	mode store.Mode
+}
+
+type mcpDefinitionRoleCall struct {
+	ctx       context.Context
+	projectID int64
+	userID    int64
+}
+
+type mcpDefinitionReadCall struct {
+	ctx      context.Context
+	sprintID int64
+}
+
+type mcpDefinitionCreateCall struct {
+	ctx            context.Context
+	projectID      int64
+	name           string
+	plannedStartAt time.Time
+	plannedEndAt   time.Time
+}
+
+type mcpDefinitionUpdateCall struct {
+	ctx      context.Context
+	sprintID int64
+	input    store.UpdateSprintInput
+}
+
+type mcpDefinitionFake struct {
+	trace []string
+
+	projectContext store.ProjectContext
+	accessErr      error
+	accessCalls    []mcpDefinitionAccessCall
+
+	role      store.ProjectRole
+	roleErr   error
+	roleCalls []mcpDefinitionRoleCall
+
+	readResults         []store.Sprint
+	readErrors          []error
+	honorReadContextErr bool
+	readCalls           []mcpDefinitionReadCall
+
+	createResult          store.Sprint
+	createErr             error
+	honorCreateContextErr bool
+	createCalls           []mcpDefinitionCreateCall
+
+	updateErr             error
+	honorUpdateContextErr bool
+	updateCalls           []mcpDefinitionUpdateCall
+}
+
+var _ MCPAccessStore = (*mcpDefinitionFake)(nil)
+var _ RoleStore = (*mcpDefinitionFake)(nil)
+var _ DefinitionStore = (*mcpDefinitionFake)(nil)
+var _ SprintReadStore = (*mcpDefinitionFake)(nil)
+
+func (f *mcpDefinitionFake) GetProjectContextBySlug(
+	ctx context.Context,
+	slug string,
+	mode store.Mode,
+) (store.ProjectContext, error) {
+	f.trace = append(f.trace, "access")
+	f.accessCalls = append(f.accessCalls, mcpDefinitionAccessCall{ctx: ctx, slug: slug, mode: mode})
+	if f.accessErr != nil {
+		return store.ProjectContext{}, f.accessErr
+	}
+	return f.projectContext, nil
+}
+
+func (f *mcpDefinitionFake) GetProjectRole(
+	ctx context.Context,
+	projectID int64,
+	userID int64,
+) (store.ProjectRole, error) {
+	f.trace = append(f.trace, "role")
+	f.roleCalls = append(f.roleCalls, mcpDefinitionRoleCall{
+		ctx:       ctx,
+		projectID: projectID,
+		userID:    userID,
+	})
+	if f.roleErr != nil {
+		return "", f.roleErr
+	}
+	return f.role, nil
+}
+
+func (f *mcpDefinitionFake) GetSprintByID(
+	ctx context.Context,
+	sprintID int64,
+) (store.Sprint, error) {
+	callIndex := len(f.readCalls)
+	stage := "target"
+	if callIndex > 0 {
+		stage = "projection"
+	}
+	f.trace = append(f.trace, stage)
+	f.readCalls = append(f.readCalls, mcpDefinitionReadCall{ctx: ctx, sprintID: sprintID})
+	if f.honorReadContextErr && ctx.Err() != nil {
+		return store.Sprint{}, ctx.Err()
+	}
+	if callIndex < len(f.readErrors) && f.readErrors[callIndex] != nil {
+		return store.Sprint{}, f.readErrors[callIndex]
+	}
+	if callIndex < len(f.readResults) {
+		return f.readResults[callIndex], nil
+	}
+	return store.Sprint{}, nil
+}
+
+func (f *mcpDefinitionFake) CreateSprint(
+	ctx context.Context,
+	projectID int64,
+	name string,
+	plannedStartAt time.Time,
+	plannedEndAt time.Time,
+) (store.Sprint, error) {
+	f.trace = append(f.trace, "create")
+	f.createCalls = append(f.createCalls, mcpDefinitionCreateCall{
+		ctx:            ctx,
+		projectID:      projectID,
+		name:           name,
+		plannedStartAt: plannedStartAt,
+		plannedEndAt:   plannedEndAt,
+	})
+	if f.honorCreateContextErr && ctx.Err() != nil {
+		return store.Sprint{}, ctx.Err()
+	}
+	return f.createResult, f.createErr
+}
+
+func (f *mcpDefinitionFake) UpdateSprint(
+	ctx context.Context,
+	sprintID int64,
+	input store.UpdateSprintInput,
+) error {
+	f.trace = append(f.trace, "update")
+	f.updateCalls = append(f.updateCalls, mcpDefinitionUpdateCall{
+		ctx:      ctx,
+		sprintID: sprintID,
+		input:    input,
+	})
+	if f.honorUpdateContextErr && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return f.updateErr
+}
+
+func newMCPDefinitionTestService(fake *mcpDefinitionFake) *MCPDefinitionService {
+	return NewMCPDefinitionService(MCPDefinitionServiceDependencies{
+		Access:      fake,
+		Roles:       fake,
+		Definitions: fake,
+		Sprints:     fake,
+	})
+}
+
+func mcpDefinitionActorContext(userID int64, marker string) context.Context {
+	ctx := context.WithValue(context.Background(), mcpDefinitionContextKey{}, marker)
+	return store.WithUserID(ctx, userID)
+}
+
+func mcpDefinitionExisting() store.Sprint {
+	return store.Sprint{
+		ID:        907,
+		ProjectID: 41,
+		Number:    12,
+		Name:      "Existing sprint",
+		State:     "PLANNED",
+	}
+}
+
+func assertMCPDefinitionTrace(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("trace = %v, want %v", got, want)
+	}
+}
+
+func TestMCPDefinitionServiceConstructionIsInertAndPublicationFree(t *testing.T) {
+	fake := &mcpDefinitionFake{}
+	service := newMCPDefinitionTestService(fake)
+	if service == nil {
+		t.Fatal("NewMCPDefinitionService returned nil")
+	}
+	if len(fake.trace) != 0 {
+		t.Fatalf("construction performed dependency work: %v", fake.trace)
+	}
+
+	depsType := reflect.TypeOf(MCPDefinitionServiceDependencies{})
+	wantDependencyFields := []string{"Access", "Roles", "Definitions", "Sprints"}
+	gotDependencyFields := make([]string, 0, depsType.NumField())
+	for i := 0; i < depsType.NumField(); i++ {
+		gotDependencyFields = append(gotDependencyFields, depsType.Field(i).Name)
+	}
+	if !reflect.DeepEqual(gotDependencyFields, wantDependencyFields) {
+		t.Fatalf("dependency fields = %v, want %v", gotDependencyFields, wantDependencyFields)
+	}
+	for _, field := range gotDependencyFields {
+		lower := strings.ToLower(field)
+		if strings.Contains(lower, "publish") || strings.Contains(lower, "event") ||
+			strings.Contains(lower, "runtime") || strings.Contains(lower, "fanout") {
+			t.Fatalf("unexpected realtime dependency %q", field)
+		}
+	}
+}
+
+func TestMCPDefinitionPreparationAuthorization(t *testing.T) {
+	accessErr := errors.New("configured private access failure")
+	roleErr := errors.New("configured private role failure")
+	operations := []struct {
+		name    string
+		prepare func(*MCPDefinitionService, context.Context) (bool, error)
+		success []string
+	}{
+		{
+			name: "create",
+			prepare: func(service *MCPDefinitionService, ctx context.Context) (bool, error) {
+				prepared, err := service.PrepareCreate(ctx, MCPProjectTarget{
+					ProjectSlug: "  requested-slug  ",
+					Mode:        store.ModeFull,
+				})
+				return prepared != nil, err
+			},
+			success: []string{"access", "role"},
+		},
+		{
+			name: "update",
+			prepare: func(service *MCPDefinitionService, ctx context.Context) (bool, error) {
+				prepared, err := service.PrepareUpdate(ctx, MCPSprintTarget{
+					ProjectSlug: "  requested-slug  ",
+					SprintID:    907,
+					Mode:        store.ModeFull,
+				})
+				return prepared != nil, err
+			},
+			success: []string{"access", "role", "target"},
+		},
+	}
+	tests := []struct {
+		name         string
+		actor        bool
+		accessErr    error
+		role         store.ProjectRole
+		roleErr      error
+		wantPrepared bool
+		wantErr      error
+		wantTrace    []string
+	}{
+		{name: "access error remains raw", actor: true, accessErr: accessErr, wantErr: accessErr, wantTrace: []string{"access"}},
+		{name: "access cancellation remains raw", actor: true, accessErr: context.Canceled, wantErr: context.Canceled, wantTrace: []string{"access"}},
+		{name: "missing actor", wantErr: ErrActorRequired, wantTrace: []string{"access"}},
+		{name: "role error remains raw", actor: true, roleErr: roleErr, wantErr: roleErr, wantTrace: []string{"access", "role"}},
+		{name: "role cancellation remains raw", actor: true, roleErr: context.Canceled, wantErr: context.Canceled, wantTrace: []string{"access", "role"}},
+		{name: "contributor", actor: true, role: store.RoleContributor, wantErr: ErrMaintainerRequired, wantTrace: []string{"access", "role"}},
+		{name: "viewer", actor: true, role: store.RoleViewer, wantErr: ErrMaintainerRequired, wantTrace: []string{"access", "role"}},
+		{name: "non-member", actor: true, wantErr: ErrMaintainerRequired, wantTrace: []string{"access", "role"}},
+		{name: "maintainer", actor: true, role: store.RoleMaintainer, wantPrepared: true},
+		{name: "owner", actor: true, role: store.RoleOwner, wantPrepared: true},
+	}
+
+	for _, operation := range operations {
+		t.Run(operation.name, func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					fake := &mcpDefinitionFake{
+						projectContext: store.ProjectContext{
+							Project: store.Project{ID: 41},
+							Role:    store.RoleMaintainer,
+						},
+						accessErr:   tt.accessErr,
+						role:        tt.role,
+						roleErr:     tt.roleErr,
+						readResults: []store.Sprint{mcpDefinitionExisting()},
+					}
+					ctx := context.WithValue(context.Background(), mcpDefinitionContextKey{}, tt.name)
+					if tt.actor {
+						ctx = store.WithUserID(ctx, 73)
+					}
+
+					prepared, err := operation.prepare(newMCPDefinitionTestService(fake), ctx)
+					if prepared != tt.wantPrepared {
+						t.Fatalf("prepared = %v, want %v", prepared, tt.wantPrepared)
+					}
+					if err != tt.wantErr {
+						t.Fatalf("error = %v, want exact %v", err, tt.wantErr)
+					}
+					wantTrace := tt.wantTrace
+					if tt.wantPrepared {
+						wantTrace = operation.success
+					}
+					assertMCPDefinitionTrace(t, fake.trace, wantTrace...)
+
+					if len(fake.accessCalls) != 1 {
+						t.Fatalf("access calls = %d, want 1", len(fake.accessCalls))
+					}
+					accessCall := fake.accessCalls[0]
+					if accessCall.ctx != ctx || accessCall.slug != "  requested-slug  " || accessCall.mode != store.ModeFull {
+						t.Fatalf("access call = %#v", accessCall)
+					}
+					if len(fake.roleCalls) > 0 {
+						roleCall := fake.roleCalls[0]
+						if roleCall.ctx != ctx || roleCall.projectID != 41 || roleCall.userID != 73 {
+							t.Fatalf("role call = %#v", roleCall)
+						}
+					}
+					if tt.roleErr != nil && errors.Is(err, ErrMaintainerRequired) {
+						t.Fatalf("raw role error %v was collapsed", err)
+					}
+					if len(fake.createCalls) != 0 || len(fake.updateCalls) != 0 {
+						t.Fatalf("preparation performed mutation: create=%d update=%d", len(fake.createCalls), len(fake.updateCalls))
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestMCPDefinitionPreparationUsesFreshRole(t *testing.T) {
+	tests := []struct {
+		name         string
+		contextRole  store.ProjectRole
+		freshRole    store.ProjectRole
+		wantPrepared bool
+		wantErr      error
+	}{
+		{
+			name:        "context maintainer fresh viewer denied",
+			contextRole: store.RoleMaintainer,
+			freshRole:   store.RoleViewer,
+			wantErr:     ErrMaintainerRequired,
+		},
+		{
+			name:         "context viewer fresh maintainer allowed",
+			contextRole:  store.RoleViewer,
+			freshRole:    store.RoleMaintainer,
+			wantPrepared: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &mcpDefinitionFake{
+				projectContext: store.ProjectContext{
+					Project: store.Project{ID: 41},
+					Role:    tt.contextRole,
+				},
+				role: tt.freshRole,
+			}
+			prepared, err := newMCPDefinitionTestService(fake).PrepareCreate(
+				mcpDefinitionActorContext(73, tt.name),
+				MCPProjectTarget{ProjectSlug: "project", Mode: store.ModeFull},
+			)
+			if (prepared != nil) != tt.wantPrepared || err != tt.wantErr {
+				t.Fatalf("prepared = %v error = %v, want present %v error %v", prepared != nil, err, tt.wantPrepared, tt.wantErr)
+			}
+			assertMCPDefinitionTrace(t, fake.trace, "access", "role")
+		})
+	}
+}
+
+func TestMCPDefinitionPrepareUpdateTargetGate(t *testing.T) {
+	targetErr := errors.New("configured private target failure")
+	tests := []struct {
+		name         string
+		readResult   store.Sprint
+		readErr      error
+		wantPrepared bool
+		wantErr      error
+	}{
+		{name: "target read error remains raw", readErr: targetErr, wantErr: targetErr},
+		{name: "target cancellation remains raw", readErr: context.Canceled, wantErr: context.Canceled},
+		{name: "foreign project", readResult: store.Sprint{ID: 907, ProjectID: 99, Number: 12}, wantErr: ErrSprintNotInProject},
+		{name: "verified target", readResult: mcpDefinitionExisting(), wantPrepared: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &mcpDefinitionFake{
+				projectContext: store.ProjectContext{Project: store.Project{ID: 41}},
+				role:           store.RoleMaintainer,
+				readResults:    []store.Sprint{tt.readResult},
+				readErrors:     []error{tt.readErr},
+			}
+			ctx := mcpDefinitionActorContext(73, tt.name)
+			prepared, err := newMCPDefinitionTestService(fake).PrepareUpdate(ctx, MCPSprintTarget{
+				ProjectSlug: "project",
+				SprintID:    907,
+				Mode:        store.ModeFull,
+			})
+			if (prepared != nil) != tt.wantPrepared || err != tt.wantErr {
+				t.Fatalf("prepared = %v error = %v, want present %v error %v", prepared != nil, err, tt.wantPrepared, tt.wantErr)
+			}
+			assertMCPDefinitionTrace(t, fake.trace, "access", "role", "target")
+			if len(fake.readCalls) != 1 || fake.readCalls[0].ctx != ctx || fake.readCalls[0].sprintID != 907 {
+				t.Fatalf("target calls = %#v", fake.readCalls)
+			}
+			if len(fake.createCalls) != 0 || len(fake.updateCalls) != 0 {
+				t.Fatalf("target preparation mutated: create=%d update=%d", len(fake.createCalls), len(fake.updateCalls))
+			}
+		})
+	}
+
+	errText := ErrSprintNotInProject.Error()
+	if errText != "sprint definition target not in project" {
+		t.Fatalf("mismatch text = %q", errText)
+	}
+	if strings.Contains(errText, "41") || strings.Contains(errText, "907") || errors.Unwrap(ErrSprintNotInProject) != nil {
+		t.Fatalf("mismatch error leaks identity or wraps a cause: %q", errText)
+	}
+}
+
+func TestPreparedMCPDefinitionBindsTargetsByValue(t *testing.T) {
+	t.Run("create binds resolved project", func(t *testing.T) {
+		fake := &mcpDefinitionFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 41}},
+			role:           store.RoleMaintainer,
+		}
+		ctx := mcpDefinitionActorContext(73, "create-copy")
+		target := MCPProjectTarget{ProjectSlug: "original", Mode: store.ModeFull}
+		prepared, err := newMCPDefinitionTestService(fake).PrepareCreate(ctx, target)
+		if err != nil {
+			t.Fatalf("PrepareCreate: %v", err)
+		}
+		target.ProjectSlug = "replacement"
+		target.Mode = store.ModeAnonymous
+
+		if _, err := prepared.Create(CreateCommand{Name: "created"}); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if len(fake.createCalls) != 1 || fake.createCalls[0].ctx != ctx || fake.createCalls[0].projectID != 41 {
+			t.Fatalf("create calls = %#v", fake.createCalls)
+		}
+		if fake.accessCalls[0].slug != "original" || fake.accessCalls[0].mode != store.ModeFull {
+			t.Fatalf("access call = %#v", fake.accessCalls[0])
+		}
+	})
+
+	t.Run("update binds requested verified stored ID", func(t *testing.T) {
+		existing := mcpDefinitionExisting()
+		updated := store.Sprint{ID: 907, ProjectID: 41, Number: 12, Name: "Updated"}
+		fake := &mcpDefinitionFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 41}},
+			role:           store.RoleMaintainer,
+			readResults:    []store.Sprint{existing, updated},
+		}
+		ctx := mcpDefinitionActorContext(73, "update-copy")
+		target := MCPSprintTarget{ProjectSlug: "original", SprintID: 907, Mode: store.ModeFull}
+		prepared, err := newMCPDefinitionTestService(fake).PrepareUpdate(ctx, target)
+		if err != nil {
+			t.Fatalf("PrepareUpdate: %v", err)
+		}
+		target.ProjectSlug = "replacement"
+		target.SprintID = 888
+		target.Mode = store.ModeAnonymous
+
+		name := "Updated"
+		got, err := prepared.Update(UpdateCommand{Name: &name})
+		if err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+		if !reflect.DeepEqual(got, updated) {
+			t.Fatalf("result = %#v, want %#v", got, updated)
+		}
+		if existing.ID != 907 || existing.Number == existing.ID {
+			t.Fatalf("test identities are not distinct enough: %#v", existing)
+		}
+		if len(fake.updateCalls) != 1 || fake.updateCalls[0].sprintID != 907 {
+			t.Fatalf("update calls = %#v", fake.updateCalls)
+		}
+		if len(fake.readCalls) != 2 || fake.readCalls[0].sprintID != 907 || fake.readCalls[1].sprintID != 907 {
+			t.Fatalf("read calls = %#v", fake.readCalls)
+		}
+	})
+}
+
+func TestPreparedMCPCreateDelegatesAndReturnsExactResult(t *testing.T) {
+	start := time.Date(2026, time.September, 1, 2, 3, 4, 5, time.FixedZone("input", 3600))
+	end := start.Add(14 * 24 * time.Hour)
+	want := store.Sprint{ID: 907, ProjectID: 41, Number: 12, Name: "Returned", PlannedStartAt: start, PlannedEndAt: end}
+	fake := &mcpDefinitionFake{
+		projectContext: store.ProjectContext{Project: store.Project{ID: 41}},
+		role:           store.RoleMaintainer,
+		createResult:   want,
+	}
+	ctx := mcpDefinitionActorContext(73, "create-success")
+	prepared, err := newMCPDefinitionTestService(fake).PrepareCreate(ctx, MCPProjectTarget{
+		ProjectSlug: "project",
+		Mode:        store.ModeFull,
+	})
+	if err != nil {
+		t.Fatalf("PrepareCreate: %v", err)
+	}
+
+	got, err := prepared.Create(CreateCommand{Name: "Input", PlannedStartAt: start, PlannedEndAt: end})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("result = %#v, want exact %#v", got, want)
+	}
+	assertMCPDefinitionTrace(t, fake.trace, "access", "role", "create")
+	if len(fake.createCalls) != 1 || len(fake.readCalls) != 0 || len(fake.updateCalls) != 0 {
+		t.Fatalf("calls: create=%d read=%d update=%d", len(fake.createCalls), len(fake.readCalls), len(fake.updateCalls))
+	}
+	call := fake.createCalls[0]
+	if call.ctx != ctx || call.projectID != 41 || call.name != "Input" ||
+		!call.plannedStartAt.Equal(start) || call.plannedStartAt.Location() != start.Location() ||
+		!call.plannedEndAt.Equal(end) || call.plannedEndAt.Location() != end.Location() {
+		t.Fatalf("create call = %#v", call)
+	}
+}
+
+func TestPreparedMCPCreateFailureReturnsNoPartialResult(t *testing.T) {
+	createErr := errors.New("configured create return-read failure")
+	fake := &mcpDefinitionFake{
+		projectContext: store.ProjectContext{Project: store.Project{ID: 41}},
+		role:           store.RoleMaintainer,
+		createResult:   store.Sprint{ID: 907, ProjectID: 41, Name: "must not escape"},
+		createErr:      createErr,
+	}
+	prepared, err := newMCPDefinitionTestService(fake).PrepareCreate(
+		mcpDefinitionActorContext(73, "create-failure"),
+		MCPProjectTarget{ProjectSlug: "project", Mode: store.ModeFull},
+	)
+	if err != nil {
+		t.Fatalf("PrepareCreate: %v", err)
+	}
+
+	got, err := prepared.Create(CreateCommand{Name: "Input"})
+	if err != createErr {
+		t.Fatalf("error = %v, want exact %v", err, createErr)
+	}
+	if got != (store.Sprint{}) {
+		t.Fatalf("partial result escaped: %#v", got)
+	}
+	assertMCPDefinitionTrace(t, fake.trace, "access", "role", "create")
+	if len(fake.createCalls) != 1 || len(fake.readCalls) != 0 || len(fake.updateCalls) != 0 {
+		t.Fatalf("calls: create=%d read=%d update=%d", len(fake.createCalls), len(fake.readCalls), len(fake.updateCalls))
+	}
+}
+
+func TestPreparedMCPUpdateEmptyReturnsRetainedSprint(t *testing.T) {
+	existing := mcpDefinitionExisting()
+	fake := &mcpDefinitionFake{
+		projectContext: store.ProjectContext{Project: store.Project{ID: 41}},
+		role:           store.RoleMaintainer,
+		readResults:    []store.Sprint{existing},
+	}
+	ctx, cancel := context.WithCancel(mcpDefinitionActorContext(73, "empty"))
+	prepared, err := newMCPDefinitionTestService(fake).PrepareUpdate(ctx, MCPSprintTarget{
+		ProjectSlug: "project",
+		SprintID:    907,
+		Mode:        store.ModeFull,
+	})
+	if err != nil {
+		t.Fatalf("PrepareUpdate: %v", err)
+	}
+	cancel()
+
+	got, err := prepared.Update(UpdateCommand{})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !reflect.DeepEqual(got, existing) {
+		t.Fatalf("result = %#v, want retained %#v", got, existing)
+	}
+	assertMCPDefinitionTrace(t, fake.trace, "access", "role", "target")
+	if len(fake.readCalls) != 1 || len(fake.updateCalls) != 0 || len(fake.createCalls) != 0 {
+		t.Fatalf("calls: read=%d update=%d create=%d", len(fake.readCalls), len(fake.updateCalls), len(fake.createCalls))
+	}
+}
+
+func TestPreparedMCPUpdateDelegatesThenReadsExactResult(t *testing.T) {
+	start := time.Date(2026, time.October, 2, 3, 4, 5, 6, time.FixedZone("patch", -7200))
+	end := start.Add(21 * 24 * time.Hour)
+	name := "Renamed"
+	existing := mcpDefinitionExisting()
+	updated := existing
+	updated.Name = name
+	updated.PlannedStartAt = start
+	updated.PlannedEndAt = end
+	fake := &mcpDefinitionFake{
+		projectContext: store.ProjectContext{Project: store.Project{ID: 41}},
+		role:           store.RoleMaintainer,
+		readResults:    []store.Sprint{existing, updated},
+	}
+	ctx := mcpDefinitionActorContext(73, "update-success")
+	prepared, err := newMCPDefinitionTestService(fake).PrepareUpdate(ctx, MCPSprintTarget{
+		ProjectSlug: "project",
+		SprintID:    907,
+		Mode:        store.ModeFull,
+	})
+	if err != nil {
+		t.Fatalf("PrepareUpdate: %v", err)
+	}
+	command := UpdateCommand{Name: &name, PlannedStartAt: &start, PlannedEndAt: &end}
+
+	got, err := prepared.Update(command)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !reflect.DeepEqual(got, updated) {
+		t.Fatalf("result = %#v, want exact %#v", got, updated)
+	}
+	assertMCPDefinitionTrace(t, fake.trace, "access", "role", "target", "update", "projection")
+	if len(fake.updateCalls) != 1 || len(fake.readCalls) != 2 {
+		t.Fatalf("calls: update=%d read=%d", len(fake.updateCalls), len(fake.readCalls))
+	}
+	call := fake.updateCalls[0]
+	if call.ctx != ctx || call.sprintID != 907 || fake.readCalls[1].ctx != ctx || fake.readCalls[1].sprintID != 907 {
+		t.Fatalf("update = %#v projection = %#v", call, fake.readCalls[1])
+	}
+	if call.input.Name == nil || *call.input.Name != name || call.input.Name == command.Name ||
+		call.input.PlannedStartAt == nil || !call.input.PlannedStartAt.Equal(start) || call.input.PlannedStartAt == command.PlannedStartAt ||
+		call.input.PlannedEndAt == nil || !call.input.PlannedEndAt.Equal(end) || call.input.PlannedEndAt == command.PlannedEndAt {
+		t.Fatalf("materialized input = %#v", call.input)
+	}
+}
+
+func TestPreparedMCPUpdatePreservesExplicitEmptyAndZero(t *testing.T) {
+	emptyName := ""
+	zeroTime := time.Time{}
+	existing := mcpDefinitionExisting()
+	fake := &mcpDefinitionFake{
+		projectContext: store.ProjectContext{Project: store.Project{ID: 41}},
+		role:           store.RoleMaintainer,
+		readResults:    []store.Sprint{existing, existing},
+	}
+	prepared, err := newMCPDefinitionTestService(fake).PrepareUpdate(
+		mcpDefinitionActorContext(73, "explicit-empty"),
+		MCPSprintTarget{ProjectSlug: "project", SprintID: 907, Mode: store.ModeFull},
+	)
+	if err != nil {
+		t.Fatalf("PrepareUpdate: %v", err)
+	}
+
+	if _, err := prepared.Update(UpdateCommand{Name: &emptyName, PlannedStartAt: &zeroTime}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	input := fake.updateCalls[0].input
+	if input.Name == nil || *input.Name != "" || input.PlannedStartAt == nil || !input.PlannedStartAt.IsZero() || input.PlannedEndAt != nil {
+		t.Fatalf("input = %#v", input)
+	}
+}
+
+func TestPreparedMCPUpdateFailuresReturnNoPartialResult(t *testing.T) {
+	t.Run("mutation failure suppresses projection", func(t *testing.T) {
+		updateErr := errors.New("configured update failure")
+		existing := mcpDefinitionExisting()
+		fake := &mcpDefinitionFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 41}},
+			role:           store.RoleMaintainer,
+			readResults:    []store.Sprint{existing},
+			updateErr:      updateErr,
+		}
+		prepared, err := newMCPDefinitionTestService(fake).PrepareUpdate(
+			mcpDefinitionActorContext(73, "update-failure"),
+			MCPSprintTarget{ProjectSlug: "project", SprintID: 907, Mode: store.ModeFull},
+		)
+		if err != nil {
+			t.Fatalf("PrepareUpdate: %v", err)
+		}
+
+		got, err := prepared.Update(UpdateCommand{Name: stringPointer("changed")})
+		if err != updateErr {
+			t.Fatalf("error = %v, want exact %v", err, updateErr)
+		}
+		if got != (store.Sprint{}) {
+			t.Fatalf("partial result escaped: %#v", got)
+		}
+		assertMCPDefinitionTrace(t, fake.trace, "access", "role", "target", "update")
+		if len(fake.updateCalls) != 1 || len(fake.readCalls) != 1 {
+			t.Fatalf("calls: update=%d read=%d", len(fake.updateCalls), len(fake.readCalls))
+		}
+	})
+
+	t.Run("committed update projection failure", func(t *testing.T) {
+		projectionErr := errors.New("configured private projection failure")
+		existing := mcpDefinitionExisting()
+		fake := &mcpDefinitionFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 41}},
+			role:           store.RoleMaintainer,
+			readResults:    []store.Sprint{existing, {ID: 907, ProjectID: 41, Name: "must not escape"}},
+			readErrors:     []error{nil, projectionErr},
+		}
+		prepared, err := newMCPDefinitionTestService(fake).PrepareUpdate(
+			mcpDefinitionActorContext(73, "projection-failure"),
+			MCPSprintTarget{ProjectSlug: "project", SprintID: 907, Mode: store.ModeFull},
+		)
+		if err != nil {
+			t.Fatalf("PrepareUpdate: %v", err)
+		}
+
+		got, err := prepared.Update(UpdateCommand{Name: stringPointer("committed")})
+		if err != projectionErr {
+			t.Fatalf("error = %v, want exact %v", err, projectionErr)
+		}
+		if got != (store.Sprint{}) {
+			t.Fatalf("partial result escaped: %#v", got)
+		}
+		assertMCPDefinitionTrace(t, fake.trace, "access", "role", "target", "update", "projection")
+		if len(fake.updateCalls) != 1 || len(fake.readCalls) != 2 {
+			t.Fatalf("calls: update=%d read=%d", len(fake.updateCalls), len(fake.readCalls))
+		}
+	})
+}
+
+func TestPreparedMCPDefinitionUsesCancelledBoundContext(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		fake := &mcpDefinitionFake{
+			projectContext:        store.ProjectContext{Project: store.Project{ID: 41}},
+			role:                  store.RoleMaintainer,
+			honorCreateContextErr: true,
+		}
+		ctx, cancel := context.WithCancel(mcpDefinitionActorContext(73, "cancel-create"))
+		prepared, err := newMCPDefinitionTestService(fake).PrepareCreate(ctx, MCPProjectTarget{ProjectSlug: "project", Mode: store.ModeFull})
+		if err != nil {
+			t.Fatalf("PrepareCreate: %v", err)
+		}
+		cancel()
+
+		got, err := prepared.Create(CreateCommand{Name: "cancelled"})
+		if err != context.Canceled || got != (store.Sprint{}) {
+			t.Fatalf("result = %#v error = %v, want zero/context.Canceled", got, err)
+		}
+		assertMCPDefinitionTrace(t, fake.trace, "access", "role", "create")
+		if len(fake.createCalls) != 1 || fake.createCalls[0].ctx != ctx {
+			t.Fatalf("create calls = %#v", fake.createCalls)
+		}
+	})
+
+	t.Run("update mutation", func(t *testing.T) {
+		existing := mcpDefinitionExisting()
+		fake := &mcpDefinitionFake{
+			projectContext:        store.ProjectContext{Project: store.Project{ID: 41}},
+			role:                  store.RoleMaintainer,
+			readResults:           []store.Sprint{existing},
+			honorUpdateContextErr: true,
+		}
+		ctx, cancel := context.WithCancel(mcpDefinitionActorContext(73, "cancel-update"))
+		prepared, err := newMCPDefinitionTestService(fake).PrepareUpdate(ctx, MCPSprintTarget{ProjectSlug: "project", SprintID: 907, Mode: store.ModeFull})
+		if err != nil {
+			t.Fatalf("PrepareUpdate: %v", err)
+		}
+		cancel()
+
+		got, err := prepared.Update(UpdateCommand{Name: stringPointer("cancelled")})
+		if err != context.Canceled || got != (store.Sprint{}) {
+			t.Fatalf("result = %#v error = %v, want zero/context.Canceled", got, err)
+		}
+		assertMCPDefinitionTrace(t, fake.trace, "access", "role", "target", "update")
+		if len(fake.updateCalls) != 1 || fake.updateCalls[0].ctx != ctx || len(fake.readCalls) != 1 {
+			t.Fatalf("update calls = %#v reads = %#v", fake.updateCalls, fake.readCalls)
+		}
+	})
+
+	t.Run("update projection", func(t *testing.T) {
+		existing := mcpDefinitionExisting()
+		fake := &mcpDefinitionFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 41}},
+			role:           store.RoleMaintainer,
+			readResults:    []store.Sprint{existing},
+			readErrors:     []error{nil, context.Canceled},
+		}
+		ctx := mcpDefinitionActorContext(73, "cancel-projection")
+		prepared, err := newMCPDefinitionTestService(fake).PrepareUpdate(ctx, MCPSprintTarget{ProjectSlug: "project", SprintID: 907, Mode: store.ModeFull})
+		if err != nil {
+			t.Fatalf("PrepareUpdate: %v", err)
+		}
+
+		got, err := prepared.Update(UpdateCommand{Name: stringPointer("committed")})
+		if err != context.Canceled || got != (store.Sprint{}) {
+			t.Fatalf("result = %#v error = %v, want zero/context.Canceled", got, err)
+		}
+		assertMCPDefinitionTrace(t, fake.trace, "access", "role", "target", "update", "projection")
+		if len(fake.updateCalls) != 1 || len(fake.readCalls) != 2 || fake.readCalls[1].ctx != ctx {
+			t.Fatalf("update calls = %#v reads = %#v", fake.updateCalls, fake.readCalls)
+		}
+	})
+}

--- a/internal/application/sprint/mcp_deletion.go
+++ b/internal/application/sprint/mcp_deletion.go
@@ -1,0 +1,84 @@
+package sprint
+
+import (
+	"context"
+
+	"scrumboy/internal/store"
+)
+
+// MCPDeletionTarget is distinct from MCPLifecycleTarget so destructive and
+// transition preparation cannot be interchanged accidentally.
+type MCPDeletionTarget struct {
+	ProjectSlug string
+	SprintID    int64
+	Mode        store.Mode
+}
+
+// MCPDeletionServiceDependencies exposes only the access, role, target-read,
+// and deletion capabilities needed by MCP sprint deletion.
+type MCPDeletionServiceDependencies struct {
+	Access    MCPAccessStore
+	Roles     RoleStore
+	Sprints   SprintReadStore
+	Deletions DeletionStore
+}
+
+// MCPDeletionService owns the MCP deletion preparation gate and one deletion.
+// It deliberately has no transition, projection-read, or publisher capability.
+type MCPDeletionService struct {
+	access    MCPAccessStore
+	roles     RoleStore
+	sprints   SprintReadStore
+	deletions DeletionStore
+}
+
+func NewMCPDeletionService(deps MCPDeletionServiceDependencies) *MCPDeletionService {
+	return &MCPDeletionService{
+		access:    deps.Access,
+		roles:     deps.Roles,
+		sprints:   deps.Sprints,
+		deletions: deps.Deletions,
+	}
+}
+
+// PreparedMCPDelete binds the exact context plus the resolved project and
+// requested stored sprint identities to one deletion.
+type PreparedMCPDelete struct {
+	ctx       context.Context
+	service   *MCPDeletionService
+	projectID int64
+	sprintID  int64
+}
+
+// PrepareDelete applies the common MCP authorization and target gate without
+// introducing a lifecycle-state restriction.
+func (s *MCPDeletionService) PrepareDelete(
+	ctx context.Context,
+	target MCPDeletionTarget,
+) (*PreparedMCPDelete, error) {
+	projectID, _, err := prepareMCPSprintMutationTarget(
+		ctx,
+		s.access,
+		s.roles,
+		s.sprints,
+		target.ProjectSlug,
+		target.Mode,
+		target.SprintID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PreparedMCPDelete{
+		ctx:       ctx,
+		service:   s,
+		projectID: projectID,
+		sprintID:  target.SprintID,
+	}, nil
+}
+
+// Delete performs exactly one project-scoped deletion and returns its raw
+// error. Public success projection remains adapter-owned.
+func (p *PreparedMCPDelete) Delete() error {
+	return p.service.deletions.DeleteSprint(p.ctx, p.projectID, p.sprintID)
+}

--- a/internal/application/sprint/mcp_deletion_test.go
+++ b/internal/application/sprint/mcp_deletion_test.go
@@ -1,0 +1,143 @@
+package sprint
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+func TestMCPDeletionServiceConstructionIsInertAndPublicationFree(t *testing.T) {
+	fake := newMCPLifecycleFake(store.SprintStatePlanned)
+	service := newMCPDeletionTestService(fake)
+	if service == nil {
+		t.Fatal("NewMCPDeletionService returned nil")
+	}
+	if len(fake.trace) != 0 {
+		t.Fatalf("construction performed dependency work: %v", fake.trace)
+	}
+
+	depsType := reflect.TypeOf(MCPDeletionServiceDependencies{})
+	wantFields := []string{"Access", "Roles", "Sprints", "Deletions"}
+	gotFields := make([]string, 0, depsType.NumField())
+	for i := 0; i < depsType.NumField(); i++ {
+		gotFields = append(gotFields, depsType.Field(i).Name)
+	}
+	if !reflect.DeepEqual(gotFields, wantFields) {
+		t.Fatalf("dependency fields = %v, want %v", gotFields, wantFields)
+	}
+	for _, field := range gotFields {
+		name := strings.ToLower(field)
+		if strings.Contains(name, "publish") || strings.Contains(name, "event") || strings.Contains(name, "fanout") {
+			t.Fatalf("unexpected realtime dependency %q", field)
+		}
+	}
+}
+
+func TestMCPDeletionPreparationAcceptsEveryLifecycleState(t *testing.T) {
+	for _, state := range []string{
+		store.SprintStatePlanned,
+		store.SprintStateActive,
+		store.SprintStateClosed,
+	} {
+		t.Run(state, func(t *testing.T) {
+			fake := newMCPLifecycleFake(state)
+			prepared, err := newMCPDeletionTestService(fake).PrepareDelete(
+				mcpLifecycleContext(149, state),
+				MCPDeletionTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull},
+			)
+			if err != nil || prepared == nil {
+				t.Fatalf("PrepareDelete() = %v, %v; want capability, nil", prepared, err)
+			}
+			if fake.nowCalls != 0 {
+				t.Fatalf("deletion consulted transition clock %d times", fake.nowCalls)
+			}
+			assertMCPLifecycleTrace(t, fake.trace, "access", "role", "target")
+		})
+	}
+}
+
+func TestMCPDeletionSuccessBindsIdentityAndHasNoPostRead(t *testing.T) {
+	fake := newMCPLifecycleFake(store.SprintStateActive)
+	ctx := mcpLifecycleContext(151, "delete success")
+	target := MCPDeletionTarget{ProjectSlug: "original", SprintID: 907, Mode: store.ModeFull}
+	prepared, err := newMCPDeletionTestService(fake).PrepareDelete(ctx, target)
+	if err != nil {
+		t.Fatalf("PrepareDelete: %v", err)
+	}
+	target.ProjectSlug = "replacement"
+	target.SprintID = 999
+	target.Mode = store.ModeAnonymous
+
+	if err := prepared.Delete(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(fake.deleteCalls) != 1 {
+		t.Fatalf("delete calls = %d, want 1", len(fake.deleteCalls))
+	}
+	call := fake.deleteCalls[0]
+	if call.ctx != ctx || call.projectID != 71 || call.sprintID != 907 {
+		t.Fatalf("delete call = %+v, want exact bound context/resolved project/requested sprint", call)
+	}
+	if !fake.deleteCommitted {
+		t.Fatal("delete did not commit")
+	}
+	if len(fake.readCalls) != 1 {
+		t.Fatalf("read calls = %d, want target only", len(fake.readCalls))
+	}
+	assertMCPLifecycleTrace(t, fake.trace, "access", "role", "target", "delete")
+}
+
+func TestMCPDeletionMutationFailurePassesThroughWithoutRetry(t *testing.T) {
+	fake := newMCPLifecycleFake(store.SprintStateClosed)
+	deleteErr := errors.New("private deletion failure")
+	fake.deleteErr = deleteErr
+	prepared, err := newMCPDeletionTestService(fake).PrepareDelete(
+		mcpLifecycleContext(157, "delete failure"),
+		MCPDeletionTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull},
+	)
+	if err != nil {
+		t.Fatalf("PrepareDelete: %v", err)
+	}
+	if err := prepared.Delete(); err != deleteErr {
+		t.Fatalf("error = %v, want exact %v", err, deleteErr)
+	}
+	if len(fake.deleteCalls) != 1 || len(fake.readCalls) != 1 {
+		t.Fatalf("delete/read calls = %d/%d, want 1/1", len(fake.deleteCalls), len(fake.readCalls))
+	}
+	if fake.deleteCommitted {
+		t.Fatal("failed deletion marked committed")
+	}
+	assertMCPLifecycleTrace(t, fake.trace, "access", "role", "target", "delete")
+}
+
+func TestMCPDeletionCancellationAfterPreparationUsesBoundContext(t *testing.T) {
+	fake := newMCPLifecycleFake(store.SprintStatePlanned)
+	fake.honorContext = true
+	ctx, cancel := context.WithCancel(mcpLifecycleContext(163, "delete cancellation"))
+	prepared, err := newMCPDeletionTestService(fake).PrepareDelete(
+		ctx,
+		MCPDeletionTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull},
+	)
+	if err != nil {
+		t.Fatalf("PrepareDelete: %v", err)
+	}
+	cancel()
+
+	if err := prepared.Delete(); err != context.Canceled {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if len(fake.deleteCalls) != 1 || fake.deleteCalls[0].ctx != ctx {
+		t.Fatalf("delete calls = %+v, want exact cancelled bound context", fake.deleteCalls)
+	}
+	if len(fake.readCalls) != 1 {
+		t.Fatalf("read calls = %d, want no post-delete read", len(fake.readCalls))
+	}
+	if fake.deleteCommitted {
+		t.Fatal("cancelled deletion marked committed")
+	}
+	assertMCPLifecycleTrace(t, fake.trace, "access", "role", "target", "delete")
+}

--- a/internal/application/sprint/mcp_lifecycle.go
+++ b/internal/application/sprint/mcp_lifecycle.go
@@ -1,0 +1,203 @@
+package sprint
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"scrumboy/internal/store"
+)
+
+var (
+	// ErrSprintMustBePlanned classifies the MCP activation precondition without
+	// embedding transport fields, codes, or target identity.
+	ErrSprintMustBePlanned = errors.New("sprint must be planned to activate")
+	// ErrSprintEndNotAfterNow classifies the MCP preparation-time schedule
+	// precondition. The store retains its own authoritative mutation-time check.
+	ErrSprintEndNotAfterNow = errors.New("sprint end must be after now")
+	// ErrSprintMustBeActive classifies the MCP close precondition without
+	// embedding transport fields, codes, or target identity.
+	ErrSprintMustBeActive = errors.New("sprint must be active to close")
+)
+
+// MCPLifecycleTarget carries only adapter-validated transport identity. Access,
+// fresh-role authorization, and sprint ownership are established by preparation.
+type MCPLifecycleTarget struct {
+	ProjectSlug string
+	SprintID    int64
+	Mode        store.Mode
+}
+
+// MCPLifecycleServiceDependencies names the least capabilities required for
+// MCP activation and close orchestration. It deliberately has no publisher.
+type MCPLifecycleServiceDependencies struct {
+	Access      MCPAccessStore
+	Roles       RoleStore
+	Sprints     SprintReadStore
+	Transitions TransitionStore
+	Now         func() time.Time
+}
+
+// MCPLifecycleService owns MCP access, fresh-role authorization, target and
+// state preparation, transition persistence, and post-write sprint projection.
+type MCPLifecycleService struct {
+	access      MCPAccessStore
+	roles       RoleStore
+	sprints     SprintReadStore
+	transitions TransitionStore
+	now         func() time.Time
+}
+
+func NewMCPLifecycleService(deps MCPLifecycleServiceDependencies) *MCPLifecycleService {
+	now := deps.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &MCPLifecycleService{
+		access:      deps.Access,
+		roles:       deps.Roles,
+		sprints:     deps.Sprints,
+		transitions: deps.Transitions,
+		now:         now,
+	}
+}
+
+// PreparedMCPActivate binds the exact context plus the resolved project and
+// requested stored sprint identities to one activation.
+type PreparedMCPActivate struct {
+	ctx       context.Context
+	service   *MCPLifecycleService
+	projectID int64
+	sprintID  int64
+}
+
+// PreparedMCPClose binds the exact context plus the resolved project and
+// requested stored sprint identities to one close.
+type PreparedMCPClose struct {
+	ctx       context.Context
+	service   *MCPLifecycleService
+	projectID int64
+	sprintID  int64
+}
+
+// PrepareActivate preserves MCP's access, fresh-role, target, state, and time
+// ordering. Its time check is a preparation precondition, not a replacement for
+// the store's authoritative mutation-time validation.
+func (s *MCPLifecycleService) PrepareActivate(
+	ctx context.Context,
+	target MCPLifecycleTarget,
+) (*PreparedMCPActivate, error) {
+	projectID, existing, err := prepareMCPSprintMutationTarget(
+		ctx,
+		s.access,
+		s.roles,
+		s.sprints,
+		target.ProjectSlug,
+		target.Mode,
+		target.SprintID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if existing.State != store.SprintStatePlanned {
+		return nil, ErrSprintMustBePlanned
+	}
+	if !existing.PlannedEndAt.After(s.now().UTC()) {
+		return nil, ErrSprintEndNotAfterNow
+	}
+
+	return &PreparedMCPActivate{
+		ctx:       ctx,
+		service:   s,
+		projectID: projectID,
+		sprintID:  target.SprintID,
+	}, nil
+}
+
+// PrepareClose preserves MCP's access, fresh-role, target, and ACTIVE-state
+// ordering. Close has no application clock dependency.
+func (s *MCPLifecycleService) PrepareClose(
+	ctx context.Context,
+	target MCPLifecycleTarget,
+) (*PreparedMCPClose, error) {
+	projectID, existing, err := prepareMCPSprintMutationTarget(
+		ctx,
+		s.access,
+		s.roles,
+		s.sprints,
+		target.ProjectSlug,
+		target.Mode,
+		target.SprintID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if existing.State != store.SprintStateActive {
+		return nil, ErrSprintMustBeActive
+	}
+
+	return &PreparedMCPClose{
+		ctx:       ctx,
+		service:   s,
+		projectID: projectID,
+		sprintID:  target.SprintID,
+	}, nil
+}
+
+// Activate performs one store transition and, only after success, one result
+// read. It deliberately performs no second application time check.
+func (p *PreparedMCPActivate) Activate() (store.Sprint, error) {
+	if err := p.service.transitions.ActivateSprint(p.ctx, p.projectID, p.sprintID); err != nil {
+		return store.Sprint{}, err
+	}
+	return p.service.sprints.GetSprintByID(p.ctx, p.sprintID)
+}
+
+// Close performs one store transition and, only after success, one result read.
+func (p *PreparedMCPClose) Close() (store.Sprint, error) {
+	if err := p.service.transitions.CloseSprint(p.ctx, p.projectID, p.sprintID); err != nil {
+		return store.Sprint{}, err
+	}
+	return p.service.sprints.GetSprintByID(p.ctx, p.sprintID)
+}
+
+// prepareMCPSprintMutationTarget is the shared existence and authorization gate
+// for MCP lifecycle and deletion operations. The returned sprint proves target
+// state/project membership; its identity never replaces the requested ID.
+func prepareMCPSprintMutationTarget(
+	ctx context.Context,
+	access MCPAccessStore,
+	roles RoleStore,
+	sprints SprintReadStore,
+	projectSlug string,
+	mode store.Mode,
+	sprintID int64,
+) (int64, store.Sprint, error) {
+	projectContext, err := access.GetProjectContextBySlug(ctx, projectSlug, mode)
+	if err != nil {
+		return 0, store.Sprint{}, err
+	}
+
+	actorID, ok := store.UserIDFromContext(ctx)
+	if !ok {
+		return 0, store.Sprint{}, ErrActorRequired
+	}
+
+	projectID := projectContext.Project.ID
+	role, err := roles.GetProjectRole(ctx, projectID, actorID)
+	if err != nil {
+		return 0, store.Sprint{}, err
+	}
+	if !role.HasMinimumRole(store.RoleMaintainer) {
+		return 0, store.Sprint{}, ErrMaintainerRequired
+	}
+
+	existing, err := sprints.GetSprintByID(ctx, sprintID)
+	if err != nil {
+		return 0, store.Sprint{}, err
+	}
+	if existing.ProjectID != projectID {
+		return 0, store.Sprint{}, ErrSprintNotInProject
+	}
+	return projectID, existing, nil
+}

--- a/internal/application/sprint/mcp_lifecycle_test.go
+++ b/internal/application/sprint/mcp_lifecycle_test.go
@@ -1,0 +1,822 @@
+package sprint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"scrumboy/internal/store"
+)
+
+var _ MCPAccessStore = (*store.Store)(nil)
+var _ RoleStore = (*store.Store)(nil)
+var _ SprintReadStore = (*store.Store)(nil)
+var _ TransitionStore = (*store.Store)(nil)
+var _ DeletionStore = (*store.Store)(nil)
+
+type mcpLifecycleContextKey struct{}
+
+type mcpLifecycleAccessCall struct {
+	ctx  context.Context
+	slug string
+	mode store.Mode
+}
+
+type mcpLifecycleRoleCall struct {
+	ctx       context.Context
+	projectID int64
+	userID    int64
+}
+
+type mcpLifecycleReadCall struct {
+	ctx      context.Context
+	sprintID int64
+}
+
+type mcpLifecycleMutationCall struct {
+	ctx       context.Context
+	projectID int64
+	sprintID  int64
+}
+
+type mcpLifecycleFake struct {
+	trace []string
+
+	honorContext bool
+
+	projectContext store.ProjectContext
+	accessErr      error
+	accessCalls    []mcpLifecycleAccessCall
+
+	role      store.ProjectRole
+	roleErr   error
+	roleCalls []mcpLifecycleRoleCall
+
+	readResults []store.Sprint
+	readErrors  []error
+	readCalls   []mcpLifecycleReadCall
+
+	activateErr       error
+	activateCalls     []mcpLifecycleMutationCall
+	activateCommitted bool
+	afterActivate     func()
+
+	closeErr       error
+	closeCalls     []mcpLifecycleMutationCall
+	closeCommitted bool
+	afterClose     func()
+
+	deleteErr       error
+	deleteCalls     []mcpLifecycleMutationCall
+	deleteCommitted bool
+
+	nowValue time.Time
+	nowCalls int
+}
+
+var _ MCPAccessStore = (*mcpLifecycleFake)(nil)
+var _ RoleStore = (*mcpLifecycleFake)(nil)
+var _ SprintReadStore = (*mcpLifecycleFake)(nil)
+var _ TransitionStore = (*mcpLifecycleFake)(nil)
+var _ DeletionStore = (*mcpLifecycleFake)(nil)
+
+func (f *mcpLifecycleFake) GetProjectContextBySlug(
+	ctx context.Context,
+	slug string,
+	mode store.Mode,
+) (store.ProjectContext, error) {
+	f.trace = append(f.trace, "access")
+	f.accessCalls = append(f.accessCalls, mcpLifecycleAccessCall{ctx: ctx, slug: slug, mode: mode})
+	if f.honorContext && ctx.Err() != nil {
+		return store.ProjectContext{}, ctx.Err()
+	}
+	if f.accessErr != nil {
+		return store.ProjectContext{}, f.accessErr
+	}
+	return f.projectContext, nil
+}
+
+func (f *mcpLifecycleFake) GetProjectRole(
+	ctx context.Context,
+	projectID int64,
+	userID int64,
+) (store.ProjectRole, error) {
+	f.trace = append(f.trace, "role")
+	f.roleCalls = append(f.roleCalls, mcpLifecycleRoleCall{ctx: ctx, projectID: projectID, userID: userID})
+	if f.honorContext && ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	if f.roleErr != nil {
+		return "", f.roleErr
+	}
+	return f.role, nil
+}
+
+func (f *mcpLifecycleFake) GetSprintByID(ctx context.Context, sprintID int64) (store.Sprint, error) {
+	index := len(f.readCalls)
+	stage := "target"
+	if index > 0 {
+		stage = "projection"
+	}
+	f.trace = append(f.trace, stage)
+	f.readCalls = append(f.readCalls, mcpLifecycleReadCall{ctx: ctx, sprintID: sprintID})
+	if f.honorContext && ctx.Err() != nil {
+		return store.Sprint{}, ctx.Err()
+	}
+	if index < len(f.readErrors) && f.readErrors[index] != nil {
+		return store.Sprint{}, f.readErrors[index]
+	}
+	if index < len(f.readResults) {
+		return f.readResults[index], nil
+	}
+	return store.Sprint{}, nil
+}
+
+func (f *mcpLifecycleFake) ActivateSprint(ctx context.Context, projectID, sprintID int64) error {
+	f.trace = append(f.trace, "activate")
+	f.activateCalls = append(f.activateCalls, mcpLifecycleMutationCall{ctx: ctx, projectID: projectID, sprintID: sprintID})
+	if f.honorContext && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if f.activateErr != nil {
+		return f.activateErr
+	}
+	f.activateCommitted = true
+	if f.afterActivate != nil {
+		f.afterActivate()
+	}
+	return nil
+}
+
+func (f *mcpLifecycleFake) CloseSprint(ctx context.Context, projectID, sprintID int64) error {
+	f.trace = append(f.trace, "close")
+	f.closeCalls = append(f.closeCalls, mcpLifecycleMutationCall{ctx: ctx, projectID: projectID, sprintID: sprintID})
+	if f.honorContext && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if f.closeErr != nil {
+		return f.closeErr
+	}
+	f.closeCommitted = true
+	if f.afterClose != nil {
+		f.afterClose()
+	}
+	return nil
+}
+
+func (f *mcpLifecycleFake) DeleteSprint(ctx context.Context, projectID, sprintID int64) error {
+	f.trace = append(f.trace, "delete")
+	f.deleteCalls = append(f.deleteCalls, mcpLifecycleMutationCall{ctx: ctx, projectID: projectID, sprintID: sprintID})
+	if f.honorContext && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	f.deleteCommitted = true
+	return nil
+}
+
+func (f *mcpLifecycleFake) Now() time.Time {
+	f.trace = append(f.trace, "now")
+	f.nowCalls++
+	return f.nowValue
+}
+
+func newMCPLifecycleTestService(fake *mcpLifecycleFake) *MCPLifecycleService {
+	return NewMCPLifecycleService(MCPLifecycleServiceDependencies{
+		Access:      fake,
+		Roles:       fake,
+		Sprints:     fake,
+		Transitions: fake,
+		Now:         fake.Now,
+	})
+}
+
+func newMCPDeletionTestService(fake *mcpLifecycleFake) *MCPDeletionService {
+	return NewMCPDeletionService(MCPDeletionServiceDependencies{
+		Access:    fake,
+		Roles:     fake,
+		Sprints:   fake,
+		Deletions: fake,
+	})
+}
+
+func newMCPLifecycleFake(state string) *mcpLifecycleFake {
+	now := time.Date(2026, time.August, 8, 15, 0, 0, 0, time.UTC)
+	return &mcpLifecycleFake{
+		projectContext: store.ProjectContext{
+			Project: store.Project{ID: 71, Slug: "resolved-slug"},
+			Role:    store.RoleViewer,
+		},
+		role: store.RoleMaintainer,
+		readResults: []store.Sprint{
+			{
+				ID:           907,
+				ProjectID:    71,
+				Name:         "Before mutation",
+				State:        state,
+				PlannedEndAt: now.Add(24 * time.Hour),
+			},
+			{
+				ID:           907,
+				ProjectID:    71,
+				Name:         "After mutation",
+				State:        state,
+				PlannedEndAt: now.Add(24 * time.Hour),
+			},
+		},
+		nowValue: now,
+	}
+}
+
+func mcpLifecycleContext(userID int64, marker string) context.Context {
+	ctx := context.WithValue(context.Background(), mcpLifecycleContextKey{}, marker)
+	return store.WithUserID(ctx, userID)
+}
+
+func assertMCPLifecycleTrace(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("trace = %v, want %v", got, want)
+	}
+}
+
+func assertZeroSprint(t *testing.T, got store.Sprint) {
+	t.Helper()
+	if !reflect.DeepEqual(got, store.Sprint{}) {
+		t.Fatalf("sprint = %+v, want zero value", got)
+	}
+}
+
+func TestMCPLifecycleServiceConstructionIsInertAndPublicationFree(t *testing.T) {
+	fake := newMCPLifecycleFake(store.SprintStatePlanned)
+	service := newMCPLifecycleTestService(fake)
+	if service == nil {
+		t.Fatal("NewMCPLifecycleService returned nil")
+	}
+	if len(fake.trace) != 0 {
+		t.Fatalf("construction performed dependency work: %v", fake.trace)
+	}
+
+	depsType := reflect.TypeOf(MCPLifecycleServiceDependencies{})
+	wantFields := []string{"Access", "Roles", "Sprints", "Transitions", "Now"}
+	gotFields := make([]string, 0, depsType.NumField())
+	for i := 0; i < depsType.NumField(); i++ {
+		gotFields = append(gotFields, depsType.Field(i).Name)
+	}
+	if !reflect.DeepEqual(gotFields, wantFields) {
+		t.Fatalf("dependency fields = %v, want %v", gotFields, wantFields)
+	}
+	for _, field := range gotFields {
+		name := strings.ToLower(field)
+		if strings.Contains(name, "publish") || strings.Contains(name, "event") || strings.Contains(name, "fanout") {
+			t.Fatalf("unexpected realtime dependency %q", field)
+		}
+	}
+}
+
+func TestMCPLifecyclePreparationAuthorization(t *testing.T) {
+	accessErr := errors.New("private access failure")
+	roleErr := errors.New("private role failure")
+	type operation struct {
+		name    string
+		state   string
+		prepare func(*MCPLifecycleService, *MCPDeletionService, context.Context) (bool, error)
+		success []string
+	}
+	operations := []operation{
+		{
+			name:  "activate",
+			state: store.SprintStatePlanned,
+			prepare: func(lifecycle *MCPLifecycleService, _ *MCPDeletionService, ctx context.Context) (bool, error) {
+				prepared, err := lifecycle.PrepareActivate(ctx, MCPLifecycleTarget{ProjectSlug: " requested ", SprintID: 907, Mode: store.ModeFull})
+				return prepared != nil, err
+			},
+			success: []string{"access", "role", "target", "now"},
+		},
+		{
+			name:  "close",
+			state: store.SprintStateActive,
+			prepare: func(lifecycle *MCPLifecycleService, _ *MCPDeletionService, ctx context.Context) (bool, error) {
+				prepared, err := lifecycle.PrepareClose(ctx, MCPLifecycleTarget{ProjectSlug: " requested ", SprintID: 907, Mode: store.ModeFull})
+				return prepared != nil, err
+			},
+			success: []string{"access", "role", "target"},
+		},
+		{
+			name:  "delete",
+			state: store.SprintStateClosed,
+			prepare: func(_ *MCPLifecycleService, deletion *MCPDeletionService, ctx context.Context) (bool, error) {
+				prepared, err := deletion.PrepareDelete(ctx, MCPDeletionTarget{ProjectSlug: " requested ", SprintID: 907, Mode: store.ModeFull})
+				return prepared != nil, err
+			},
+			success: []string{"access", "role", "target"},
+		},
+	}
+	cases := []struct {
+		name         string
+		actor        bool
+		role         store.ProjectRole
+		accessErr    error
+		roleErr      error
+		wantErr      error
+		wantPrepared bool
+		trace        []string
+	}{
+		{name: "access failure", actor: true, role: store.RoleMaintainer, accessErr: accessErr, wantErr: accessErr, trace: []string{"access"}},
+		{name: "access cancellation", actor: true, role: store.RoleMaintainer, accessErr: context.Canceled, wantErr: context.Canceled, trace: []string{"access"}},
+		{name: "missing actor", role: store.RoleMaintainer, wantErr: ErrActorRequired, trace: []string{"access"}},
+		{name: "role failure", actor: true, role: store.RoleMaintainer, roleErr: roleErr, wantErr: roleErr, trace: []string{"access", "role"}},
+		{name: "role cancellation", actor: true, role: store.RoleMaintainer, roleErr: context.Canceled, wantErr: context.Canceled, trace: []string{"access", "role"}},
+		{name: "viewer", actor: true, role: store.RoleViewer, wantErr: ErrMaintainerRequired, trace: []string{"access", "role"}},
+		{name: "contributor", actor: true, role: store.RoleContributor, wantErr: ErrMaintainerRequired, trace: []string{"access", "role"}},
+		{name: "nonmember", actor: true, role: "", wantErr: ErrMaintainerRequired, trace: []string{"access", "role"}},
+		{name: "maintainer", actor: true, role: store.RoleMaintainer, wantPrepared: true},
+		{name: "compatible owner", actor: true, role: store.RoleOwner, wantPrepared: true},
+	}
+
+	for _, op := range operations {
+		t.Run(op.name, func(t *testing.T) {
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					fake := newMCPLifecycleFake(op.state)
+					fake.role = tc.role
+					fake.accessErr = tc.accessErr
+					fake.roleErr = tc.roleErr
+					ctx := context.WithValue(context.Background(), mcpLifecycleContextKey{}, op.name+"/"+tc.name)
+					if tc.actor {
+						ctx = store.WithUserID(ctx, 83)
+					}
+
+					prepared, err := op.prepare(newMCPLifecycleTestService(fake), newMCPDeletionTestService(fake), ctx)
+					if err != tc.wantErr {
+						t.Fatalf("error = %v, want exact %v", err, tc.wantErr)
+					}
+					if prepared != tc.wantPrepared {
+						t.Fatalf("prepared = %v, want %v", prepared, tc.wantPrepared)
+					}
+					wantTrace := tc.trace
+					if tc.wantPrepared {
+						wantTrace = op.success
+					}
+					assertMCPLifecycleTrace(t, fake.trace, wantTrace...)
+					if len(fake.accessCalls) != 1 || fake.accessCalls[0].ctx != ctx || fake.accessCalls[0].slug != " requested " || fake.accessCalls[0].mode != store.ModeFull {
+						t.Fatalf("access calls = %+v, want exact bound arguments", fake.accessCalls)
+					}
+					if tc.actor && tc.accessErr == nil && len(fake.roleCalls) == 1 {
+						call := fake.roleCalls[0]
+						if call.ctx != ctx || call.projectID != 71 || call.userID != 83 {
+							t.Fatalf("role call = %+v, want bound context/project/actor", call)
+						}
+					}
+					if tc.wantPrepared {
+						if len(fake.readCalls) != 1 || fake.readCalls[0].ctx != ctx || fake.readCalls[0].sprintID != 907 {
+							t.Fatalf("target calls = %+v, want exact bound context/requested sprint", fake.readCalls)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestMCPLifecyclePreparationUsesFreshRole(t *testing.T) {
+	operations := []struct {
+		name    string
+		state   string
+		prepare func(*mcpLifecycleFake) (bool, error)
+	}{
+		{name: "activate", state: store.SprintStatePlanned, prepare: func(fake *mcpLifecycleFake) (bool, error) {
+			prepared, err := newMCPLifecycleTestService(fake).PrepareActivate(mcpLifecycleContext(89, "activate"), MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+			return prepared != nil, err
+		}},
+		{name: "close", state: store.SprintStateActive, prepare: func(fake *mcpLifecycleFake) (bool, error) {
+			prepared, err := newMCPLifecycleTestService(fake).PrepareClose(mcpLifecycleContext(89, "close"), MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+			return prepared != nil, err
+		}},
+		{name: "delete", state: store.SprintStateClosed, prepare: func(fake *mcpLifecycleFake) (bool, error) {
+			prepared, err := newMCPDeletionTestService(fake).PrepareDelete(mcpLifecycleContext(89, "delete"), MCPDeletionTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+			return prepared != nil, err
+		}},
+	}
+	cases := []struct {
+		name        string
+		contextRole store.ProjectRole
+		freshRole   store.ProjectRole
+		wantErr     error
+	}{
+		{name: "stale maintainer denied by fresh viewer", contextRole: store.RoleMaintainer, freshRole: store.RoleViewer, wantErr: ErrMaintainerRequired},
+		{name: "stale viewer allowed by fresh maintainer", contextRole: store.RoleViewer, freshRole: store.RoleMaintainer},
+	}
+	for _, op := range operations {
+		t.Run(op.name, func(t *testing.T) {
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					fake := newMCPLifecycleFake(op.state)
+					fake.projectContext.Role = tc.contextRole
+					fake.role = tc.freshRole
+					prepared, err := op.prepare(fake)
+					if err != tc.wantErr {
+						t.Fatalf("error = %v, want exact %v", err, tc.wantErr)
+					}
+					if prepared != (tc.wantErr == nil) {
+						t.Fatalf("prepared = %v for error %v", prepared, err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestMCPLifecyclePreparationTargetFailures(t *testing.T) {
+	readErr := errors.New("private target read failure")
+	cases := []struct {
+		name    string
+		prepare func(*mcpLifecycleFake) (bool, error)
+	}{
+		{name: "activate", prepare: func(fake *mcpLifecycleFake) (bool, error) {
+			prepared, err := newMCPLifecycleTestService(fake).PrepareActivate(mcpLifecycleContext(97, "activate"), MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+			return prepared != nil, err
+		}},
+		{name: "close", prepare: func(fake *mcpLifecycleFake) (bool, error) {
+			prepared, err := newMCPLifecycleTestService(fake).PrepareClose(mcpLifecycleContext(97, "close"), MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+			return prepared != nil, err
+		}},
+		{name: "delete", prepare: func(fake *mcpLifecycleFake) (bool, error) {
+			prepared, err := newMCPDeletionTestService(fake).PrepareDelete(mcpLifecycleContext(97, "delete"), MCPDeletionTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+			return prepared != nil, err
+		}},
+	}
+	for _, tc := range cases {
+		for _, failure := range []struct {
+			name string
+			err  error
+		}{{name: "read failure", err: readErr}, {name: "read cancellation", err: context.Canceled}} {
+			t.Run(tc.name+" "+failure.name, func(t *testing.T) {
+				fake := newMCPLifecycleFake(store.SprintStateActive)
+				fake.readErrors = []error{failure.err}
+				prepared, err := tc.prepare(fake)
+				if prepared || err != failure.err {
+					t.Fatalf("prepared/error = %v/%v, want false/exact %v", prepared, err, failure.err)
+				}
+				assertMCPLifecycleTrace(t, fake.trace, "access", "role", "target")
+			})
+		}
+		t.Run(tc.name+" project mismatch", func(t *testing.T) {
+			fake := newMCPLifecycleFake(store.SprintStateActive)
+			fake.readResults[0].ProjectID = 72
+			prepared, err := tc.prepare(fake)
+			if prepared || err != ErrSprintNotInProject {
+				t.Fatalf("prepared/error = %v/%v, want false/%v", prepared, err, ErrSprintNotInProject)
+			}
+			assertMCPLifecycleTrace(t, fake.trace, "access", "role", "target")
+		})
+	}
+}
+
+func TestMCPLifecyclePrepareActivatePolicyAndClock(t *testing.T) {
+	cases := []struct {
+		name        string
+		state       string
+		endOffset   time.Duration
+		wantErr     error
+		wantNow     int
+		wantTrace   []string
+		wantPrepare bool
+	}{
+		{name: "active", state: store.SprintStateActive, wantErr: ErrSprintMustBePlanned, wantTrace: []string{"access", "role", "target"}},
+		{name: "closed", state: store.SprintStateClosed, wantErr: ErrSprintMustBePlanned, wantTrace: []string{"access", "role", "target"}},
+		{name: "end equal now", state: store.SprintStatePlanned, wantErr: ErrSprintEndNotAfterNow, wantNow: 1, wantTrace: []string{"access", "role", "target", "now"}},
+		{name: "end before now", state: store.SprintStatePlanned, endOffset: -time.Second, wantErr: ErrSprintEndNotAfterNow, wantNow: 1, wantTrace: []string{"access", "role", "target", "now"}},
+		{name: "end after now", state: store.SprintStatePlanned, endOffset: time.Second, wantNow: 1, wantPrepare: true, wantTrace: []string{"access", "role", "target", "now"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := newMCPLifecycleFake(tc.state)
+			fake.readResults[0].PlannedEndAt = fake.nowValue.Add(tc.endOffset)
+			prepared, err := newMCPLifecycleTestService(fake).PrepareActivate(
+				mcpLifecycleContext(101, tc.name),
+				MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull},
+			)
+			if err != tc.wantErr || (prepared != nil) != tc.wantPrepare {
+				t.Fatalf("prepared/error = %v/%v, want %v/%v", prepared != nil, err, tc.wantPrepare, tc.wantErr)
+			}
+			if fake.nowCalls != tc.wantNow {
+				t.Fatalf("clock calls = %d, want %d", fake.nowCalls, tc.wantNow)
+			}
+			assertMCPLifecycleTrace(t, fake.trace, tc.wantTrace...)
+		})
+	}
+
+	t.Run("nil clock uses production default", func(t *testing.T) {
+		fake := newMCPLifecycleFake(store.SprintStatePlanned)
+		fake.readResults[0].PlannedEndAt = time.Now().UTC().Add(24 * time.Hour)
+		service := NewMCPLifecycleService(MCPLifecycleServiceDependencies{
+			Access: fake, Roles: fake, Sprints: fake, Transitions: fake,
+		})
+		prepared, err := service.PrepareActivate(mcpLifecycleContext(103, "nil clock"), MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+		if err != nil || prepared == nil {
+			t.Fatalf("PrepareActivate() = %v, %v; want capability, nil", prepared, err)
+		}
+		assertMCPLifecycleTrace(t, fake.trace, "access", "role", "target")
+	})
+}
+
+func TestMCPLifecyclePrepareClosePolicy(t *testing.T) {
+	for _, state := range []string{store.SprintStatePlanned, store.SprintStateClosed} {
+		t.Run(state, func(t *testing.T) {
+			fake := newMCPLifecycleFake(state)
+			prepared, err := newMCPLifecycleTestService(fake).PrepareClose(mcpLifecycleContext(107, state), MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+			if prepared != nil || err != ErrSprintMustBeActive {
+				t.Fatalf("PrepareClose() = %v, %v; want nil, %v", prepared, err, ErrSprintMustBeActive)
+			}
+			if fake.nowCalls != 0 {
+				t.Fatalf("close consulted clock %d times", fake.nowCalls)
+			}
+			assertMCPLifecycleTrace(t, fake.trace, "access", "role", "target")
+		})
+	}
+}
+
+func TestMCPLifecycleSuccessfulTransitionsBindIdentityAndReturnProjection(t *testing.T) {
+	type operation struct {
+		name      string
+		state     string
+		prepare   func(*MCPLifecycleService, context.Context, MCPLifecycleTarget) (func() (store.Sprint, error), error)
+		trace     []string
+		calls     func(*mcpLifecycleFake) []mcpLifecycleMutationCall
+		committed func(*mcpLifecycleFake) bool
+	}
+	operations := []operation{
+		{
+			name: "activate", state: store.SprintStatePlanned,
+			prepare: func(service *MCPLifecycleService, ctx context.Context, target MCPLifecycleTarget) (func() (store.Sprint, error), error) {
+				prepared, err := service.PrepareActivate(ctx, target)
+				if err != nil {
+					return nil, err
+				}
+				return prepared.Activate, nil
+			},
+			trace:     []string{"access", "role", "target", "now", "activate", "projection"},
+			calls:     func(fake *mcpLifecycleFake) []mcpLifecycleMutationCall { return fake.activateCalls },
+			committed: func(fake *mcpLifecycleFake) bool { return fake.activateCommitted },
+		},
+		{
+			name: "close", state: store.SprintStateActive,
+			prepare: func(service *MCPLifecycleService, ctx context.Context, target MCPLifecycleTarget) (func() (store.Sprint, error), error) {
+				prepared, err := service.PrepareClose(ctx, target)
+				if err != nil {
+					return nil, err
+				}
+				return prepared.Close, nil
+			},
+			trace:     []string{"access", "role", "target", "close", "projection"},
+			calls:     func(fake *mcpLifecycleFake) []mcpLifecycleMutationCall { return fake.closeCalls },
+			committed: func(fake *mcpLifecycleFake) bool { return fake.closeCommitted },
+		},
+	}
+	for _, op := range operations {
+		t.Run(op.name, func(t *testing.T) {
+			fake := newMCPLifecycleFake(op.state)
+			ctx := mcpLifecycleContext(109, op.name)
+			target := MCPLifecycleTarget{ProjectSlug: "original", SprintID: 907, Mode: store.ModeFull}
+			execute, err := op.prepare(newMCPLifecycleTestService(fake), ctx, target)
+			if err != nil {
+				t.Fatalf("prepare: %v", err)
+			}
+			target.ProjectSlug = "replacement"
+			target.SprintID = 999
+			target.Mode = store.ModeAnonymous
+
+			got, err := execute()
+			if err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if !reflect.DeepEqual(got, fake.readResults[1]) {
+				t.Fatalf("result = %+v, want exact projection %+v", got, fake.readResults[1])
+			}
+			calls := op.calls(fake)
+			if len(calls) != 1 || calls[0].ctx != ctx || calls[0].projectID != 71 || calls[0].sprintID != 907 {
+				t.Fatalf("mutation calls = %+v, want one bound call", calls)
+			}
+			if len(fake.readCalls) != 2 || fake.readCalls[1].ctx != ctx || fake.readCalls[1].sprintID != 907 {
+				t.Fatalf("read calls = %+v, want target and bound projection", fake.readCalls)
+			}
+			if !op.committed(fake) {
+				t.Fatal("mutation did not commit")
+			}
+			assertMCPLifecycleTrace(t, fake.trace, op.trace...)
+		})
+	}
+}
+
+func TestMCPLifecycleMutationFailuresPassThroughWithoutProjection(t *testing.T) {
+	mutationErr := errors.New("private transition failure")
+	cases := []struct {
+		name    string
+		state   string
+		prepare func(*MCPLifecycleService, context.Context) (func() (store.Sprint, error), error)
+	}{
+		{name: "activate", state: store.SprintStatePlanned, prepare: func(service *MCPLifecycleService, ctx context.Context) (func() (store.Sprint, error), error) {
+			prepared, err := service.PrepareActivate(ctx, MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+			if err != nil {
+				return nil, err
+			}
+			return prepared.Activate, nil
+		}},
+		{name: "close", state: store.SprintStateActive, prepare: func(service *MCPLifecycleService, ctx context.Context) (func() (store.Sprint, error), error) {
+			prepared, err := service.PrepareClose(ctx, MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+			if err != nil {
+				return nil, err
+			}
+			return prepared.Close, nil
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := newMCPLifecycleFake(tc.state)
+			if tc.name == "activate" {
+				fake.activateErr = mutationErr
+			} else {
+				fake.closeErr = mutationErr
+			}
+			execute, err := tc.prepare(newMCPLifecycleTestService(fake), mcpLifecycleContext(113, tc.name))
+			if err != nil {
+				t.Fatalf("prepare: %v", err)
+			}
+			got, err := execute()
+			if err != mutationErr {
+				t.Fatalf("error = %v, want exact %v", err, mutationErr)
+			}
+			assertZeroSprint(t, got)
+			if len(fake.readCalls) != 1 {
+				t.Fatalf("read calls = %d, want target only", len(fake.readCalls))
+			}
+			want := []string{"access", "role", "target", tc.name}
+			if tc.name == "activate" {
+				want = []string{"access", "role", "target", "now", "activate"}
+			}
+			assertMCPLifecycleTrace(t, fake.trace, want...)
+		})
+	}
+}
+
+func TestMCPLifecycleActivateStoreTimeFailureRemainsRaw(t *testing.T) {
+	fake := newMCPLifecycleFake(store.SprintStatePlanned)
+	storeTimeErr := fmt.Errorf("activate sprint: %w: sprint end date is on or before now", store.ErrValidation)
+	fake.activateErr = storeTimeErr
+	prepared, err := newMCPLifecycleTestService(fake).PrepareActivate(mcpLifecycleContext(127, "store time"), MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	got, err := prepared.Activate()
+	if err != storeTimeErr {
+		t.Fatalf("error = %v, want exact raw store error %v", err, storeTimeErr)
+	}
+	if errors.Is(err, ErrSprintEndNotAfterNow) {
+		t.Fatalf("store-time failure was converted to preparation sentinel: %v", err)
+	}
+	if !errors.Is(err, store.ErrValidation) {
+		t.Fatalf("error no longer exposes store validation cause: %v", err)
+	}
+	assertZeroSprint(t, got)
+	if fake.nowCalls != 1 {
+		t.Fatalf("clock calls = %d, want preparation-only call", fake.nowCalls)
+	}
+	assertMCPLifecycleTrace(t, fake.trace, "access", "role", "target", "now", "activate")
+}
+
+func TestMCPLifecycleProjectionFailuresOccurAfterCommittedMutation(t *testing.T) {
+	projectionErr := errors.New("private projection failure")
+	cases := []struct{ name, state string }{{"activate", store.SprintStatePlanned}, {"close", store.SprintStateActive}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := newMCPLifecycleFake(tc.state)
+			fake.readErrors = []error{nil, projectionErr}
+			service := newMCPLifecycleTestService(fake)
+			var execute func() (store.Sprint, error)
+			if tc.name == "activate" {
+				prepared, err := service.PrepareActivate(mcpLifecycleContext(131, tc.name), MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+				if err != nil {
+					t.Fatalf("prepare: %v", err)
+				}
+				execute = prepared.Activate
+			} else {
+				prepared, err := service.PrepareClose(mcpLifecycleContext(131, tc.name), MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+				if err != nil {
+					t.Fatalf("prepare: %v", err)
+				}
+				execute = prepared.Close
+			}
+			got, err := execute()
+			if err != projectionErr {
+				t.Fatalf("error = %v, want exact %v", err, projectionErr)
+			}
+			assertZeroSprint(t, got)
+			if tc.name == "activate" && !fake.activateCommitted {
+				t.Fatal("activation was not committed before projection failure")
+			}
+			if tc.name == "close" && !fake.closeCommitted {
+				t.Fatal("close was not committed before projection failure")
+			}
+			want := []string{"access", "role", "target", tc.name, "projection"}
+			if tc.name == "activate" {
+				want = []string{"access", "role", "target", "now", "activate", "projection"}
+			}
+			assertMCPLifecycleTrace(t, fake.trace, want...)
+		})
+	}
+}
+
+func TestMCPLifecycleCancellationAfterPreparation(t *testing.T) {
+	cases := []struct{ name, state string }{{"activate", store.SprintStatePlanned}, {"close", store.SprintStateActive}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := newMCPLifecycleFake(tc.state)
+			fake.honorContext = true
+			ctx, cancel := context.WithCancel(mcpLifecycleContext(137, tc.name))
+			service := newMCPLifecycleTestService(fake)
+			var execute func() (store.Sprint, error)
+			if tc.name == "activate" {
+				prepared, err := service.PrepareActivate(ctx, MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+				if err != nil {
+					t.Fatalf("prepare: %v", err)
+				}
+				execute = prepared.Activate
+			} else {
+				prepared, err := service.PrepareClose(ctx, MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+				if err != nil {
+					t.Fatalf("prepare: %v", err)
+				}
+				execute = prepared.Close
+			}
+			cancel()
+			got, err := execute()
+			if err != context.Canceled {
+				t.Fatalf("error = %v, want context.Canceled", err)
+			}
+			assertZeroSprint(t, got)
+			if len(fake.readCalls) != 1 {
+				t.Fatalf("read calls = %d, want no projection", len(fake.readCalls))
+			}
+			calls := fake.activateCalls
+			if tc.name == "close" {
+				calls = fake.closeCalls
+			}
+			if len(calls) != 1 || calls[0].ctx != ctx {
+				t.Fatalf("mutation calls = %+v, want exact cancelled bound context", calls)
+			}
+		})
+	}
+}
+
+func TestMCPLifecycleProjectionCancellationOccursAfterCommittedMutation(t *testing.T) {
+	cases := []struct{ name, state string }{{"activate", store.SprintStatePlanned}, {"close", store.SprintStateActive}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := newMCPLifecycleFake(tc.state)
+			fake.honorContext = true
+			ctx, cancel := context.WithCancel(mcpLifecycleContext(139, tc.name))
+			if tc.name == "activate" {
+				fake.afterActivate = cancel
+			} else {
+				fake.afterClose = cancel
+			}
+			service := newMCPLifecycleTestService(fake)
+			var execute func() (store.Sprint, error)
+			if tc.name == "activate" {
+				prepared, err := service.PrepareActivate(ctx, MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+				if err != nil {
+					t.Fatalf("prepare: %v", err)
+				}
+				execute = prepared.Activate
+			} else {
+				prepared, err := service.PrepareClose(ctx, MCPLifecycleTarget{ProjectSlug: "board", SprintID: 907, Mode: store.ModeFull})
+				if err != nil {
+					t.Fatalf("prepare: %v", err)
+				}
+				execute = prepared.Close
+			}
+			got, err := execute()
+			if err != context.Canceled {
+				t.Fatalf("error = %v, want context.Canceled", err)
+			}
+			assertZeroSprint(t, got)
+			if len(fake.readCalls) != 2 || fake.readCalls[1].ctx != ctx {
+				t.Fatalf("read calls = %+v, want cancelled projection", fake.readCalls)
+			}
+			if tc.name == "activate" && !fake.activateCommitted {
+				t.Fatal("activation was not committed")
+			}
+			if tc.name == "close" && !fake.closeCommitted {
+				t.Fatal("close was not committed")
+			}
+		})
+	}
+}

--- a/internal/application/sprint/rest_definition.go
+++ b/internal/application/sprint/rest_definition.go
@@ -8,11 +8,12 @@ import (
 )
 
 var (
-	// ErrActorRequired reports that the exact context supplied to REST
-	// preparation does not contain an authenticated requester.
+	// ErrActorRequired reports that the exact context supplied to sprint
+	// definition preparation does not contain an authenticated requester.
 	ErrActorRequired = errors.New("sprint definition actor required")
-	// ErrMaintainerRequired preserves the canonical REST policy that collapses
-	// role lookup failures and insufficient roles into one authorization result.
+	// ErrMaintainerRequired reports that the authenticated requester lacks the
+	// required role. REST preparation also deliberately uses this result to
+	// collapse role lookup failures; MCP preparation returns those failures raw.
 	ErrMaintainerRequired = errors.New("sprint definition maintainer required")
 )
 

--- a/internal/application/sprint/rest_definition.go
+++ b/internal/application/sprint/rest_definition.go
@@ -1,0 +1,169 @@
+package sprint
+
+import (
+	"context"
+	"errors"
+
+	"scrumboy/internal/store"
+)
+
+var (
+	// ErrActorRequired reports that the exact context supplied to REST
+	// preparation does not contain an authenticated requester.
+	ErrActorRequired = errors.New("sprint definition actor required")
+	// ErrMaintainerRequired preserves the canonical REST policy that collapses
+	// role lookup failures and insufficient roles into one authorization result.
+	ErrMaintainerRequired = errors.New("sprint definition maintainer required")
+)
+
+// RESTDefinitionPublisher exposes the two semantic invalidations produced by
+// successful canonical REST sprint-definition mutations. The HTTP adapter
+// remains responsible for translating them to runtime refresh reasons.
+type RESTDefinitionPublisher interface {
+	PublishSprintCreated(ctx context.Context, projectID int64)
+	PublishSprintUpdated(ctx context.Context, projectID int64)
+}
+
+type nopRESTDefinitionPublisher struct{}
+
+func (nopRESTDefinitionPublisher) PublishSprintCreated(context.Context, int64) {}
+func (nopRESTDefinitionPublisher) PublishSprintUpdated(context.Context, int64) {}
+
+// RESTDefinitionServiceDependencies names the fresh-role, definition-write,
+// and ancillary publication capabilities used by REST sprint definitions.
+type RESTDefinitionServiceDependencies struct {
+	Roles       RoleStore
+	Definitions DefinitionStore
+	Publisher   RESTDefinitionPublisher
+}
+
+// RESTDefinitionService owns the canonical REST actor/fresh-role gate,
+// definition-write sequencing, and post-write semantic publication.
+type RESTDefinitionService struct {
+	roles       RoleStore
+	definitions DefinitionStore
+	publisher   RESTDefinitionPublisher
+}
+
+func NewRESTDefinitionService(deps RESTDefinitionServiceDependencies) *RESTDefinitionService {
+	publisher := deps.Publisher
+	if publisher == nil {
+		publisher = nopRESTDefinitionPublisher{}
+	}
+	return &RESTDefinitionService{
+		roles:       deps.Roles,
+		definitions: deps.Definitions,
+		publisher:   publisher,
+	}
+}
+
+// ResolvedRESTProjectTarget carries only the numeric project identity already
+// resolved by the shared REST board router.
+type ResolvedRESTProjectTarget struct {
+	ProjectID int64
+}
+
+// ResolvedRESTSprintTarget carries the route-resolved project identity and the
+// stored global sprint ID already read and project-verified by the REST adapter.
+type ResolvedRESTSprintTarget struct {
+	ProjectID int64
+	SprintID  int64
+}
+
+// PreparedRESTCreate binds the exact authorized context and project identity
+// to one subsequent REST sprint-definition create.
+type PreparedRESTCreate struct {
+	ctx       context.Context
+	service   *RESTDefinitionService
+	projectID int64
+}
+
+// PreparedRESTUpdate binds the exact authorized context, project identity, and
+// verified stored sprint ID to one subsequent REST sprint-definition update.
+type PreparedRESTUpdate struct {
+	ctx       context.Context
+	service   *RESTDefinitionService
+	projectID int64
+	sprintID  int64
+}
+
+// PrepareCreate preserves the current REST authorization order after shared
+// board-router access and before transport-owned body decoding.
+func (s *RESTDefinitionService) PrepareCreate(
+	ctx context.Context,
+	target ResolvedRESTProjectTarget,
+) (*PreparedRESTCreate, error) {
+	if err := s.authorize(ctx, target.ProjectID); err != nil {
+		return nil, err
+	}
+	return &PreparedRESTCreate{
+		ctx:       ctx,
+		service:   s,
+		projectID: target.ProjectID,
+	}, nil
+}
+
+// PrepareUpdate preserves the current REST authorization order after the
+// adapter has read the stored sprint and verified its project identity.
+func (s *RESTDefinitionService) PrepareUpdate(
+	ctx context.Context,
+	target ResolvedRESTSprintTarget,
+) (*PreparedRESTUpdate, error) {
+	if err := s.authorize(ctx, target.ProjectID); err != nil {
+		return nil, err
+	}
+	return &PreparedRESTUpdate{
+		ctx:       ctx,
+		service:   s,
+		projectID: target.ProjectID,
+		sprintID:  target.SprintID,
+	}, nil
+}
+
+func (s *RESTDefinitionService) authorize(ctx context.Context, projectID int64) error {
+	userID, ok := store.UserIDFromContext(ctx)
+	if !ok {
+		return ErrActorRequired
+	}
+
+	role, err := s.roles.GetProjectRole(ctx, projectID, userID)
+	if err != nil || !role.HasMinimumRole(store.RoleMaintainer) {
+		// The canonical REST route deliberately discards role lookup causes,
+		// including cancellation, and maps both branches to the same fixed 403.
+		return ErrMaintainerRequired
+	}
+	return nil
+}
+
+// Create persists one adapter-prepared definition and publishes the semantic
+// REST invalidation only after CreateSprint returns a sprint without error.
+func (p *PreparedRESTCreate) Create(command CreateCommand) (store.Sprint, error) {
+	sprint, err := p.service.definitions.CreateSprint(
+		p.ctx,
+		p.projectID,
+		command.Name,
+		command.PlannedStartAt,
+		command.PlannedEndAt,
+	)
+	if err != nil {
+		return store.Sprint{}, err
+	}
+
+	p.service.publisher.PublishSprintCreated(p.ctx, p.projectID)
+	return sprint, nil
+}
+
+// Update persists one adapter-prepared command, including an empty command,
+// and publishes the semantic REST invalidation only after persistence succeeds.
+func (p *PreparedRESTUpdate) Update(command UpdateCommand) error {
+	if err := p.service.definitions.UpdateSprint(
+		p.ctx,
+		p.sprintID,
+		MaterializeUpdateInput(command),
+	); err != nil {
+		return err
+	}
+
+	p.service.publisher.PublishSprintUpdated(p.ctx, p.projectID)
+	return nil
+}

--- a/internal/application/sprint/rest_definition.go
+++ b/internal/application/sprint/rest_definition.go
@@ -9,11 +9,12 @@ import (
 
 var (
 	// ErrActorRequired reports that the exact context supplied to sprint
-	// definition preparation does not contain an authenticated requester.
+	// mutation preparation does not contain an authenticated requester.
 	ErrActorRequired = errors.New("sprint definition actor required")
 	// ErrMaintainerRequired reports that the authenticated requester lacks the
-	// required role. REST preparation also deliberately uses this result to
-	// collapse role lookup failures; MCP preparation returns those failures raw.
+	// required role. REST mutation preparation deliberately also uses this
+	// result to collapse role lookup failures; MCP preparation returns those
+	// failures raw.
 	ErrMaintainerRequired = errors.New("sprint definition maintainer required")
 )
 

--- a/internal/application/sprint/rest_definition_test.go
+++ b/internal/application/sprint/rest_definition_test.go
@@ -1,0 +1,605 @@
+package sprint
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"scrumboy/internal/store"
+)
+
+type restDefinitionContextKey struct{}
+
+type restDefinitionRoleCall struct {
+	ctx       context.Context
+	projectID int64
+	userID    int64
+}
+
+type restDefinitionCreateCall struct {
+	ctx            context.Context
+	projectID      int64
+	name           string
+	plannedStartAt time.Time
+	plannedEndAt   time.Time
+}
+
+type restDefinitionUpdateCall struct {
+	ctx      context.Context
+	sprintID int64
+	input    store.UpdateSprintInput
+}
+
+type restDefinitionPublishCall struct {
+	kind      string
+	ctx       context.Context
+	projectID int64
+}
+
+type restDefinitionFake struct {
+	trace []string
+
+	role      store.ProjectRole
+	roleErr   error
+	roleCalls []restDefinitionRoleCall
+
+	createResult          store.Sprint
+	createErr             error
+	useCreateContextError bool
+	createCalls           []restDefinitionCreateCall
+
+	updateErr             error
+	useUpdateContextError bool
+	updateCalls           []restDefinitionUpdateCall
+
+	publishCalls []restDefinitionPublishCall
+}
+
+var _ RoleStore = (*restDefinitionFake)(nil)
+var _ DefinitionStore = (*restDefinitionFake)(nil)
+var _ RESTDefinitionPublisher = (*restDefinitionFake)(nil)
+
+func (f *restDefinitionFake) GetProjectRole(
+	ctx context.Context,
+	projectID int64,
+	userID int64,
+) (store.ProjectRole, error) {
+	f.trace = append(f.trace, "role")
+	f.roleCalls = append(f.roleCalls, restDefinitionRoleCall{
+		ctx:       ctx,
+		projectID: projectID,
+		userID:    userID,
+	})
+	if f.roleErr != nil {
+		return "", f.roleErr
+	}
+	return f.role, nil
+}
+
+func (f *restDefinitionFake) CreateSprint(
+	ctx context.Context,
+	projectID int64,
+	name string,
+	plannedStartAt time.Time,
+	plannedEndAt time.Time,
+) (store.Sprint, error) {
+	f.trace = append(f.trace, "create")
+	f.createCalls = append(f.createCalls, restDefinitionCreateCall{
+		ctx:            ctx,
+		projectID:      projectID,
+		name:           name,
+		plannedStartAt: plannedStartAt,
+		plannedEndAt:   plannedEndAt,
+	})
+	if f.useCreateContextError && ctx.Err() != nil {
+		return store.Sprint{}, ctx.Err()
+	}
+	return f.createResult, f.createErr
+}
+
+func (f *restDefinitionFake) UpdateSprint(
+	ctx context.Context,
+	sprintID int64,
+	input store.UpdateSprintInput,
+) error {
+	f.trace = append(f.trace, "update")
+	f.updateCalls = append(f.updateCalls, restDefinitionUpdateCall{
+		ctx:      ctx,
+		sprintID: sprintID,
+		input:    input,
+	})
+	if f.useUpdateContextError && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return f.updateErr
+}
+
+func (f *restDefinitionFake) PublishSprintCreated(ctx context.Context, projectID int64) {
+	f.trace = append(f.trace, "publish-created")
+	f.publishCalls = append(f.publishCalls, restDefinitionPublishCall{
+		kind:      "created",
+		ctx:       ctx,
+		projectID: projectID,
+	})
+}
+
+func (f *restDefinitionFake) PublishSprintUpdated(ctx context.Context, projectID int64) {
+	f.trace = append(f.trace, "publish-updated")
+	f.publishCalls = append(f.publishCalls, restDefinitionPublishCall{
+		kind:      "updated",
+		ctx:       ctx,
+		projectID: projectID,
+	})
+}
+
+func newRESTDefinitionService(fake *restDefinitionFake) *RESTDefinitionService {
+	return NewRESTDefinitionService(RESTDefinitionServiceDependencies{
+		Roles:       fake,
+		Definitions: fake,
+		Publisher:   fake,
+	})
+}
+
+func restDefinitionActorContext(userID int64, marker string) context.Context {
+	ctx := context.WithValue(context.Background(), restDefinitionContextKey{}, marker)
+	return store.WithUserID(ctx, userID)
+}
+
+func TestRESTDefinitionPrepareAuthorization(t *testing.T) {
+	configuredRoleErr := errors.New("configured private role failure")
+	operations := []struct {
+		name    string
+		prepare func(*RESTDefinitionService, context.Context) (bool, error)
+	}{
+		{
+			name: "create",
+			prepare: func(service *RESTDefinitionService, ctx context.Context) (bool, error) {
+				prepared, err := service.PrepareCreate(ctx, ResolvedRESTProjectTarget{ProjectID: 41})
+				return prepared != nil, err
+			},
+		},
+		{
+			name: "update",
+			prepare: func(service *RESTDefinitionService, ctx context.Context) (bool, error) {
+				prepared, err := service.PrepareUpdate(ctx, ResolvedRESTSprintTarget{
+					ProjectID: 41,
+					SprintID:  907,
+				})
+				return prepared != nil, err
+			},
+		},
+	}
+	tests := []struct {
+		name          string
+		ctx           context.Context
+		role          store.ProjectRole
+		roleErr       error
+		wantPrepared  bool
+		wantErr       error
+		wantRoleCalls int
+	}{
+		{
+			name:          "missing actor",
+			ctx:           context.WithValue(context.Background(), restDefinitionContextKey{}, "missing"),
+			wantErr:       ErrActorRequired,
+			wantRoleCalls: 0,
+		},
+		{
+			name:          "owner",
+			ctx:           restDefinitionActorContext(73, "owner"),
+			role:          store.RoleOwner,
+			wantPrepared:  true,
+			wantRoleCalls: 1,
+		},
+		{
+			name:          "maintainer",
+			ctx:           restDefinitionActorContext(73, "maintainer"),
+			role:          store.RoleMaintainer,
+			wantPrepared:  true,
+			wantRoleCalls: 1,
+		},
+		{
+			name:          "contributor",
+			ctx:           restDefinitionActorContext(73, "contributor"),
+			role:          store.RoleContributor,
+			wantErr:       ErrMaintainerRequired,
+			wantRoleCalls: 1,
+		},
+		{
+			name:          "viewer",
+			ctx:           restDefinitionActorContext(73, "viewer"),
+			role:          store.RoleViewer,
+			wantErr:       ErrMaintainerRequired,
+			wantRoleCalls: 1,
+		},
+		{
+			name:          "non-member",
+			ctx:           restDefinitionActorContext(73, "non-member"),
+			wantErr:       ErrMaintainerRequired,
+			wantRoleCalls: 1,
+		},
+		{
+			name:          "role lookup failure discards cause",
+			ctx:           restDefinitionActorContext(73, "role-error"),
+			roleErr:       configuredRoleErr,
+			wantErr:       ErrMaintainerRequired,
+			wantRoleCalls: 1,
+		},
+		{
+			name:          "role cancellation discards cause",
+			ctx:           restDefinitionActorContext(73, "role-cancellation"),
+			roleErr:       context.Canceled,
+			wantErr:       ErrMaintainerRequired,
+			wantRoleCalls: 1,
+		},
+	}
+
+	for _, operation := range operations {
+		t.Run(operation.name, func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					fake := &restDefinitionFake{role: tt.role, roleErr: tt.roleErr}
+					prepared, err := operation.prepare(newRESTDefinitionService(fake), tt.ctx)
+
+					if prepared != tt.wantPrepared {
+						t.Fatalf("prepared = %v, want %v", prepared, tt.wantPrepared)
+					}
+					if err != tt.wantErr {
+						t.Fatalf("error = %v, want exact %v", err, tt.wantErr)
+					}
+					if tt.roleErr != nil && errors.Is(err, tt.roleErr) {
+						t.Fatalf("error %v unexpectedly preserves discarded role cause %v", err, tt.roleErr)
+					}
+					if len(fake.roleCalls) != tt.wantRoleCalls {
+						t.Fatalf("role calls = %d, want %d", len(fake.roleCalls), tt.wantRoleCalls)
+					}
+					if tt.wantRoleCalls == 1 {
+						call := fake.roleCalls[0]
+						if call.ctx != tt.ctx || call.ctx.Value(restDefinitionContextKey{}) != tt.ctx.Value(restDefinitionContextKey{}) {
+							t.Fatal("role lookup did not receive the exact marked context")
+						}
+						if call.projectID != 41 || call.userID != 73 {
+							t.Fatalf("role args = project %d user %d, want project 41 user 73", call.projectID, call.userID)
+						}
+					}
+					if len(fake.createCalls) != 0 || len(fake.updateCalls) != 0 || len(fake.publishCalls) != 0 {
+						t.Fatalf("preparation performed later work: create=%d update=%d publish=%d", len(fake.createCalls), len(fake.updateCalls), len(fake.publishCalls))
+					}
+					var wantTrace []string
+					if tt.wantRoleCalls == 1 {
+						wantTrace = []string{"role"}
+					}
+					if !reflect.DeepEqual(fake.trace, wantTrace) {
+						t.Fatalf("trace = %v, want %v", fake.trace, wantTrace)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestRESTDefinitionPrepareBindsDistinctTargetsByValue(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		fake := &restDefinitionFake{role: store.RoleMaintainer}
+		ctx := restDefinitionActorContext(73, "create-copy")
+		target := ResolvedRESTProjectTarget{ProjectID: 41}
+		prepared, err := newRESTDefinitionService(fake).PrepareCreate(ctx, target)
+		if err != nil {
+			t.Fatalf("PrepareCreate: %v", err)
+		}
+		target.ProjectID = 999
+
+		if _, err := prepared.Create(CreateCommand{Name: "copy"}); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if got := fake.createCalls[0].projectID; got != 41 {
+			t.Fatalf("create project = %d, want bound 41", got)
+		}
+		if got := fake.publishCalls[0].projectID; got != 41 {
+			t.Fatalf("publish project = %d, want bound 41", got)
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		fake := &restDefinitionFake{role: store.RoleMaintainer}
+		ctx := restDefinitionActorContext(73, "update-copy")
+		target := ResolvedRESTSprintTarget{ProjectID: 41, SprintID: 907}
+		prepared, err := newRESTDefinitionService(fake).PrepareUpdate(ctx, target)
+		if err != nil {
+			t.Fatalf("PrepareUpdate: %v", err)
+		}
+		target.ProjectID = 999
+		target.SprintID = 888
+
+		if err := prepared.Update(UpdateCommand{}); err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+		if got := fake.updateCalls[0].sprintID; got != 907 {
+			t.Fatalf("update sprint = %d, want bound stored ID 907", got)
+		}
+		if got := fake.publishCalls[0].projectID; got != 41 {
+			t.Fatalf("publish project = %d, want bound 41", got)
+		}
+	})
+}
+
+func TestPreparedRESTCreateDelegatesAndPublishes(t *testing.T) {
+	start := time.Date(2026, time.September, 1, 2, 3, 4, 5, time.UTC)
+	end := start.Add(14 * 24 * time.Hour)
+	wantSprint := store.Sprint{
+		ID:             907,
+		ProjectID:      812,
+		Number:         12,
+		Name:           "Returned sprint",
+		PlannedStartAt: start,
+		PlannedEndAt:   end,
+		State:          "PLANNED",
+	}
+	fake := &restDefinitionFake{
+		role:         store.RoleMaintainer,
+		createResult: wantSprint,
+	}
+	ctx := restDefinitionActorContext(73, "create-success")
+	prepared, err := newRESTDefinitionService(fake).PrepareCreate(ctx, ResolvedRESTProjectTarget{ProjectID: 41})
+	if err != nil {
+		t.Fatalf("PrepareCreate: %v", err)
+	}
+
+	gotSprint, err := prepared.Create(CreateCommand{
+		Name:           "Input sprint",
+		PlannedStartAt: start,
+		PlannedEndAt:   end,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !reflect.DeepEqual(gotSprint, wantSprint) {
+		t.Fatalf("sprint = %#v, want exact %#v", gotSprint, wantSprint)
+	}
+	if !reflect.DeepEqual(fake.trace, []string{"role", "create", "publish-created"}) {
+		t.Fatalf("trace = %v", fake.trace)
+	}
+	if len(fake.roleCalls) != 1 || len(fake.createCalls) != 1 || len(fake.updateCalls) != 0 || len(fake.publishCalls) != 1 {
+		t.Fatalf("calls: role=%d create=%d update=%d publish=%d", len(fake.roleCalls), len(fake.createCalls), len(fake.updateCalls), len(fake.publishCalls))
+	}
+	createCall := fake.createCalls[0]
+	if createCall.ctx != ctx || createCall.ctx.Value(restDefinitionContextKey{}) != "create-success" {
+		t.Fatal("create did not receive exact bound context")
+	}
+	if createCall.projectID != 41 || createCall.name != "Input sprint" || !createCall.plannedStartAt.Equal(start) || !createCall.plannedEndAt.Equal(end) {
+		t.Fatalf("create args = %#v", createCall)
+	}
+	publishCall := fake.publishCalls[0]
+	if publishCall.kind != "created" || publishCall.ctx != ctx || publishCall.projectID != 41 {
+		t.Fatalf("publish = %#v, want created with bound context/project", publishCall)
+	}
+}
+
+func TestPreparedRESTUpdateDelegatesAndPublishes(t *testing.T) {
+	start := time.Date(2026, time.October, 2, 3, 4, 5, 6, time.UTC)
+	end := start.Add(21 * 24 * time.Hour)
+	emptyName := ""
+	zeroTime := time.Time{}
+	tests := []struct {
+		name    string
+		command UpdateCommand
+		assert  func(*testing.T, store.UpdateSprintInput)
+	}{
+		{
+			name: "all fields",
+			command: UpdateCommand{
+				Name:           stringPointer("Renamed"),
+				PlannedStartAt: timePointer(start),
+				PlannedEndAt:   timePointer(end),
+			},
+			assert: func(t *testing.T, input store.UpdateSprintInput) {
+				t.Helper()
+				if input.Name == nil || *input.Name != "Renamed" || input.PlannedStartAt == nil || !input.PlannedStartAt.Equal(start) || input.PlannedEndAt == nil || !input.PlannedEndAt.Equal(end) {
+					t.Fatalf("materialized input = %#v", input)
+				}
+			},
+		},
+		{
+			name:    "all fields omitted still writes",
+			command: UpdateCommand{},
+			assert: func(t *testing.T, input store.UpdateSprintInput) {
+				t.Helper()
+				if input.Name != nil || input.PlannedStartAt != nil || input.PlannedEndAt != nil {
+					t.Fatalf("empty input = %#v, want all nil", input)
+				}
+			},
+		},
+		{
+			name: "explicit empty and zero remain supplied",
+			command: UpdateCommand{
+				Name:           &emptyName,
+				PlannedStartAt: &zeroTime,
+			},
+			assert: func(t *testing.T, input store.UpdateSprintInput) {
+				t.Helper()
+				if input.Name == nil || *input.Name != "" || input.PlannedStartAt == nil || !input.PlannedStartAt.IsZero() || input.PlannedEndAt != nil {
+					t.Fatalf("explicit empty input = %#v", input)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &restDefinitionFake{role: store.RoleOwner}
+			ctx := restDefinitionActorContext(73, "update-success")
+			prepared, err := newRESTDefinitionService(fake).PrepareUpdate(ctx, ResolvedRESTSprintTarget{
+				ProjectID: 41,
+				SprintID:  907,
+			})
+			if err != nil {
+				t.Fatalf("PrepareUpdate: %v", err)
+			}
+
+			if err := prepared.Update(tt.command); err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+			if !reflect.DeepEqual(fake.trace, []string{"role", "update", "publish-updated"}) {
+				t.Fatalf("trace = %v", fake.trace)
+			}
+			if len(fake.roleCalls) != 1 || len(fake.createCalls) != 0 || len(fake.updateCalls) != 1 || len(fake.publishCalls) != 1 {
+				t.Fatalf("calls: role=%d create=%d update=%d publish=%d", len(fake.roleCalls), len(fake.createCalls), len(fake.updateCalls), len(fake.publishCalls))
+			}
+			call := fake.updateCalls[0]
+			if call.ctx != ctx || call.ctx.Value(restDefinitionContextKey{}) != "update-success" || call.sprintID != 907 {
+				t.Fatalf("update binding = ctx marker %v sprint %d", call.ctx.Value(restDefinitionContextKey{}), call.sprintID)
+			}
+			tt.assert(t, call.input)
+			if tt.command.Name != nil && call.input.Name == tt.command.Name {
+				t.Fatal("materialized name pointer aliases command")
+			}
+			if tt.command.PlannedStartAt != nil && call.input.PlannedStartAt == tt.command.PlannedStartAt {
+				t.Fatal("materialized start pointer aliases command")
+			}
+			if tt.command.PlannedEndAt != nil && call.input.PlannedEndAt == tt.command.PlannedEndAt {
+				t.Fatal("materialized end pointer aliases command")
+			}
+			publishCall := fake.publishCalls[0]
+			if publishCall.kind != "updated" || publishCall.ctx != ctx || publishCall.projectID != 41 {
+				t.Fatalf("publish = %#v, want updated with bound context/project", publishCall)
+			}
+		})
+	}
+}
+
+func TestPreparedRESTDefinitionFailuresSuppressPublication(t *testing.T) {
+	t.Run("create returns no partial result", func(t *testing.T) {
+		createErr := errors.New("configured create failure")
+		fake := &restDefinitionFake{
+			role:         store.RoleMaintainer,
+			createResult: store.Sprint{ID: 907, ProjectID: 41, Name: "must not escape"},
+			createErr:    createErr,
+		}
+		prepared, err := newRESTDefinitionService(fake).PrepareCreate(
+			restDefinitionActorContext(73, "create-failure"),
+			ResolvedRESTProjectTarget{ProjectID: 41},
+		)
+		if err != nil {
+			t.Fatalf("PrepareCreate: %v", err)
+		}
+
+		got, err := prepared.Create(CreateCommand{Name: "failure"})
+		if err != createErr {
+			t.Fatalf("error = %v, want exact %v", err, createErr)
+		}
+		if got != (store.Sprint{}) {
+			t.Fatalf("partial sprint escaped: %#v", got)
+		}
+		if !reflect.DeepEqual(fake.trace, []string{"role", "create"}) || len(fake.createCalls) != 1 || len(fake.updateCalls) != 0 || len(fake.publishCalls) != 0 {
+			t.Fatalf("trace/calls = %v create=%d update=%d publish=%d", fake.trace, len(fake.createCalls), len(fake.updateCalls), len(fake.publishCalls))
+		}
+	})
+
+	t.Run("update returns raw error", func(t *testing.T) {
+		updateErr := errors.New("configured update failure")
+		fake := &restDefinitionFake{role: store.RoleMaintainer, updateErr: updateErr}
+		prepared, err := newRESTDefinitionService(fake).PrepareUpdate(
+			restDefinitionActorContext(73, "update-failure"),
+			ResolvedRESTSprintTarget{ProjectID: 41, SprintID: 907},
+		)
+		if err != nil {
+			t.Fatalf("PrepareUpdate: %v", err)
+		}
+
+		err = prepared.Update(UpdateCommand{})
+		if err != updateErr {
+			t.Fatalf("error = %v, want exact %v", err, updateErr)
+		}
+		if !reflect.DeepEqual(fake.trace, []string{"role", "update"}) || len(fake.createCalls) != 0 || len(fake.updateCalls) != 1 || len(fake.publishCalls) != 0 {
+			t.Fatalf("trace/calls = %v create=%d update=%d publish=%d", fake.trace, len(fake.createCalls), len(fake.updateCalls), len(fake.publishCalls))
+		}
+	})
+}
+
+func TestPreparedRESTDefinitionUsesCancelledBoundContext(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		fake := &restDefinitionFake{role: store.RoleMaintainer, useCreateContextError: true}
+		ctx, cancel := context.WithCancel(restDefinitionActorContext(73, "cancel-create"))
+		prepared, err := newRESTDefinitionService(fake).PrepareCreate(ctx, ResolvedRESTProjectTarget{ProjectID: 41})
+		if err != nil {
+			t.Fatalf("PrepareCreate: %v", err)
+		}
+		cancel()
+
+		_, err = prepared.Create(CreateCommand{Name: "cancelled"})
+		if err != context.Canceled {
+			t.Fatalf("error = %v, want context.Canceled", err)
+		}
+		if fake.createCalls[0].ctx != ctx || !reflect.DeepEqual(fake.trace, []string{"role", "create"}) || len(fake.createCalls) != 1 || len(fake.publishCalls) != 0 {
+			t.Fatalf("trace/calls = %v create=%d publish=%d", fake.trace, len(fake.createCalls), len(fake.publishCalls))
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		fake := &restDefinitionFake{role: store.RoleMaintainer, useUpdateContextError: true}
+		ctx, cancel := context.WithCancel(restDefinitionActorContext(73, "cancel-update"))
+		prepared, err := newRESTDefinitionService(fake).PrepareUpdate(ctx, ResolvedRESTSprintTarget{ProjectID: 41, SprintID: 907})
+		if err != nil {
+			t.Fatalf("PrepareUpdate: %v", err)
+		}
+		cancel()
+
+		err = prepared.Update(UpdateCommand{})
+		if err != context.Canceled {
+			t.Fatalf("error = %v, want context.Canceled", err)
+		}
+		if fake.updateCalls[0].ctx != ctx || !reflect.DeepEqual(fake.trace, []string{"role", "update"}) || len(fake.updateCalls) != 1 || len(fake.publishCalls) != 0 {
+			t.Fatalf("trace/calls = %v update=%d publish=%d", fake.trace, len(fake.updateCalls), len(fake.publishCalls))
+		}
+	})
+}
+
+func TestRESTDefinitionServiceNilPublisher(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		fake := &restDefinitionFake{role: store.RoleMaintainer}
+		service := NewRESTDefinitionService(RESTDefinitionServiceDependencies{
+			Roles:       fake,
+			Definitions: fake,
+			Publisher:   nil,
+		})
+		prepared, err := service.PrepareCreate(restDefinitionActorContext(73, "nil-create"), ResolvedRESTProjectTarget{ProjectID: 41})
+		if err != nil {
+			t.Fatalf("PrepareCreate: %v", err)
+		}
+		if _, err := prepared.Create(CreateCommand{Name: "nil publisher"}); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if !reflect.DeepEqual(fake.trace, []string{"role", "create"}) || len(fake.createCalls) != 1 {
+			t.Fatalf("trace = %v, create calls = %d", fake.trace, len(fake.createCalls))
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		fake := &restDefinitionFake{role: store.RoleMaintainer}
+		service := NewRESTDefinitionService(RESTDefinitionServiceDependencies{
+			Roles:       fake,
+			Definitions: fake,
+			Publisher:   nil,
+		})
+		prepared, err := service.PrepareUpdate(restDefinitionActorContext(73, "nil-update"), ResolvedRESTSprintTarget{ProjectID: 41, SprintID: 907})
+		if err != nil {
+			t.Fatalf("PrepareUpdate: %v", err)
+		}
+		if err := prepared.Update(UpdateCommand{}); err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+		if !reflect.DeepEqual(fake.trace, []string{"role", "update"}) || len(fake.updateCalls) != 1 {
+			t.Fatalf("trace = %v, update calls = %d", fake.trace, len(fake.updateCalls))
+		}
+	})
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+func timePointer(value time.Time) *time.Time {
+	return &value
+}

--- a/internal/application/sprint/rest_deletion.go
+++ b/internal/application/sprint/rest_deletion.go
@@ -1,0 +1,80 @@
+package sprint
+
+import "context"
+
+// RESTDeletionPublisher exposes the semantic invalidation produced by a
+// successful canonical REST sprint deletion. The HTTP adapter remains
+// responsible for translating it to the runtime refresh reason.
+type RESTDeletionPublisher interface {
+	PublishSprintDeleted(ctx context.Context, projectID int64)
+}
+
+type nopRESTDeletionPublisher struct{}
+
+func (nopRESTDeletionPublisher) PublishSprintDeleted(context.Context, int64) {}
+
+// RESTDeletionServiceDependencies names the fresh-role, deletion-write, and
+// semantic publication capabilities used by canonical REST sprint deletion.
+// Target lookup is intentionally absent because the shared REST item route has
+// already completed that existence/project gate before deletion preparation.
+type RESTDeletionServiceDependencies struct {
+	Roles     RoleStore
+	Deletions DeletionStore
+	Publisher RESTDeletionPublisher
+}
+
+// RESTDeletionService owns canonical REST actor/fresh-role authorization,
+// deletion sequencing, and post-write semantic publication.
+type RESTDeletionService struct {
+	roles     RoleStore
+	deletions DeletionStore
+	publisher RESTDeletionPublisher
+}
+
+func NewRESTDeletionService(deps RESTDeletionServiceDependencies) *RESTDeletionService {
+	publisher := deps.Publisher
+	if publisher == nil {
+		publisher = nopRESTDeletionPublisher{}
+	}
+	return &RESTDeletionService{
+		roles:     deps.Roles,
+		deletions: deps.Deletions,
+		publisher: publisher,
+	}
+}
+
+// PreparedRESTDelete binds the exact authorized context and copied numeric
+// identities to one subsequent REST sprint deletion.
+type PreparedRESTDelete struct {
+	ctx       context.Context
+	service   *RESTDeletionService
+	projectID int64
+	sprintID  int64
+}
+
+// PrepareDelete preserves the DELETE-specific actor and fresh-role gate after
+// the adapter-owned shared item-route target read and project comparison.
+func (s *RESTDeletionService) PrepareDelete(
+	ctx context.Context,
+	target DeletionTarget,
+) (*PreparedRESTDelete, error) {
+	if err := authorizeRESTLifecycleMutation(ctx, s.roles, target.ProjectID); err != nil {
+		return nil, err
+	}
+	return &PreparedRESTDelete{
+		ctx:       ctx,
+		service:   s,
+		projectID: target.ProjectID,
+		sprintID:  target.SprintID,
+	}, nil
+}
+
+// Delete performs exactly one project-scoped deletion and publishes only after
+// persistence succeeds.
+func (p *PreparedRESTDelete) Delete() error {
+	if err := p.service.deletions.DeleteSprint(p.ctx, p.projectID, p.sprintID); err != nil {
+		return err
+	}
+	p.service.publisher.PublishSprintDeleted(p.ctx, p.projectID)
+	return nil
+}

--- a/internal/application/sprint/rest_deletion_test.go
+++ b/internal/application/sprint/rest_deletion_test.go
@@ -1,0 +1,144 @@
+package sprint
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+func newRESTDeletionService(fake *restLifecycleFake) *RESTDeletionService {
+	return NewRESTDeletionService(RESTDeletionServiceDependencies{
+		Roles:     fake,
+		Deletions: fake,
+		Publisher: fake,
+	})
+}
+
+func TestRESTDeletionPrepareAuthorization(t *testing.T) {
+	const projectID int64 = 83
+	const sprintID int64 = 977
+	const actorID int64 = 53
+
+	t.Run("missing actor", func(t *testing.T) {
+		fake := &restLifecycleFake{role: store.RoleMaintainer}
+		prepared, err := newRESTDeletionService(fake).PrepareDelete(context.Background(), DeletionTarget{ProjectID: projectID, SprintID: sprintID})
+		if !errors.Is(err, ErrActorRequired) || prepared != nil {
+			t.Fatalf("PrepareDelete() = (%v, %v), want (nil, ErrActorRequired)", prepared, err)
+		}
+		assertRESTLifecycleTrace(t, fake)
+	})
+
+	roleDependencyErr := errors.New("role dependency failed")
+	for _, tc := range []struct {
+		name    string
+		role    store.ProjectRole
+		roleErr error
+		wantErr bool
+	}{
+		{name: "maintainer", role: store.RoleMaintainer},
+		{name: "compatible owner", role: store.RoleOwner},
+		{name: "contributor", role: store.RoleContributor, wantErr: true},
+		{name: "viewer", role: store.RoleViewer, wantErr: true},
+		{name: "nonmember", wantErr: true},
+		{name: "role dependency failure", roleErr: roleDependencyErr, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := store.WithUserID(context.Background(), actorID)
+			fake := &restLifecycleFake{role: tc.role, roleErr: tc.roleErr}
+			prepared, err := newRESTDeletionService(fake).PrepareDelete(ctx, DeletionTarget{ProjectID: projectID, SprintID: sprintID})
+			if tc.wantErr {
+				if !errors.Is(err, ErrMaintainerRequired) || prepared != nil {
+					t.Fatalf("PrepareDelete() = (%v, %v), want (nil, ErrMaintainerRequired)", prepared, err)
+				}
+			} else if err != nil || prepared == nil {
+				t.Fatalf("PrepareDelete() = (%v, %v), want prepared capability", prepared, err)
+			}
+			assertRESTLifecycleTrace(t, fake, "role")
+			if len(fake.roles) != 1 || fake.roles[0].ctx != ctx || fake.roles[0].projectID != projectID || fake.roles[0].userID != actorID {
+				t.Fatalf("role calls = %+v, want exact context, project %d, actor %d", fake.roles, projectID, actorID)
+			}
+			if len(fake.reads) != 0 || len(fake.deletes) != 0 || len(fake.deleted) != 0 {
+				t.Fatalf("preparation used later or read capabilities: reads=%d deletes=%d publications=%d", len(fake.reads), len(fake.deletes), len(fake.deleted))
+			}
+		})
+	}
+}
+
+func TestRESTDeletionBindsTargetAndPublishesAfterPersistence(t *testing.T) {
+	target := DeletionTarget{ProjectID: 89, SprintID: 983}
+	original := target
+	ctx := store.WithUserID(context.Background(), 59)
+	fake := &restLifecycleFake{role: store.RoleMaintainer}
+	prepared, err := newRESTDeletionService(fake).PrepareDelete(ctx, target)
+	if err != nil {
+		t.Fatalf("PrepareDelete() error = %v", err)
+	}
+	target.ProjectID = 107
+	target.SprintID = 109
+
+	if err := prepared.Delete(); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	assertRESTLifecycleTrace(t, fake, "role", "delete", "publish_deleted")
+	if len(fake.deletes) != 1 || fake.deletes[0].ctx != ctx || fake.deletes[0].projectID != original.ProjectID || fake.deletes[0].sprintID != original.SprintID {
+		t.Fatalf("delete calls = %+v, want exact bound context, project %d, sprint %d", fake.deletes, original.ProjectID, original.SprintID)
+	}
+	if len(fake.deleted) != 1 || fake.deleted[0].ctx != ctx || fake.deleted[0].projectID != original.ProjectID {
+		t.Fatalf("deletion publications = %+v, want exact bound context and project %d", fake.deleted, original.ProjectID)
+	}
+	if len(fake.reads) != 0 || len(fake.activated) != 0 || len(fake.closed) != 0 {
+		t.Fatalf("deletion used unrelated capabilities: reads=%d activated=%d closed=%d", len(fake.reads), len(fake.activated), len(fake.closed))
+	}
+}
+
+func TestRESTDeletionFailurePassesThroughWithoutPublication(t *testing.T) {
+	deleteErr := errors.New("delete failed")
+	fake := &restLifecycleFake{role: store.RoleMaintainer, deleteErr: deleteErr}
+	prepared, err := newRESTDeletionService(fake).PrepareDelete(store.WithUserID(context.Background(), 61), DeletionTarget{ProjectID: 97, SprintID: 991})
+	if err != nil {
+		t.Fatalf("PrepareDelete() error = %v", err)
+	}
+	if err := prepared.Delete(); err != deleteErr {
+		t.Fatalf("Delete() error = %v, want %v", err, deleteErr)
+	}
+	assertRESTLifecycleTrace(t, fake, "role", "delete")
+	if len(fake.deletes) != 1 || len(fake.deleted) != 0 {
+		t.Fatalf("calls = delete %d publish %d, want 1 and 0", len(fake.deletes), len(fake.deleted))
+	}
+}
+
+func TestRESTDeletionCancellationAfterPreparationUsesBoundContext(t *testing.T) {
+	base, cancel := context.WithCancel(context.Background())
+	ctx := store.WithUserID(base, 67)
+	fake := &restLifecycleFake{role: store.RoleMaintainer, honorContext: true}
+	prepared, err := newRESTDeletionService(fake).PrepareDelete(ctx, DeletionTarget{ProjectID: 101, SprintID: 997})
+	if err != nil {
+		t.Fatalf("PrepareDelete() error = %v", err)
+	}
+	cancel()
+	if err := prepared.Delete(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Delete() error = %v, want context.Canceled", err)
+	}
+	assertRESTLifecycleTrace(t, fake, "role", "delete")
+	if len(fake.deletes) != 1 || fake.deletes[0].ctx != ctx || len(fake.deleted) != 0 {
+		t.Fatalf("cancellation calls = %+v publications=%d", fake.deletes, len(fake.deleted))
+	}
+}
+
+func TestRESTDeletionNilPublisherIsNoop(t *testing.T) {
+	fake := &restLifecycleFake{role: store.RoleMaintainer}
+	service := NewRESTDeletionService(RESTDeletionServiceDependencies{Roles: fake, Deletions: fake})
+	prepared, err := service.PrepareDelete(store.WithUserID(context.Background(), 71), DeletionTarget{ProjectID: 103, SprintID: 1009})
+	if err != nil {
+		t.Fatalf("PrepareDelete() error = %v", err)
+	}
+	if err := prepared.Delete(); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	assertRESTLifecycleTrace(t, fake, "role", "delete")
+	if len(fake.deletes) != 1 {
+		t.Fatalf("delete calls = %d, want 1", len(fake.deletes))
+	}
+}

--- a/internal/application/sprint/rest_lifecycle.go
+++ b/internal/application/sprint/rest_lifecycle.go
@@ -1,0 +1,152 @@
+package sprint
+
+import (
+	"context"
+
+	"scrumboy/internal/store"
+)
+
+// RESTTransitionPublisher exposes the semantic invalidations produced by
+// successful canonical REST sprint transitions. The HTTP adapter remains
+// responsible for translating them to runtime refresh reasons.
+type RESTTransitionPublisher interface {
+	PublishSprintActivated(ctx context.Context, projectID int64)
+	PublishSprintClosed(ctx context.Context, projectID int64)
+}
+
+type nopRESTTransitionPublisher struct{}
+
+func (nopRESTTransitionPublisher) PublishSprintActivated(context.Context, int64) {}
+func (nopRESTTransitionPublisher) PublishSprintClosed(context.Context, int64)    {}
+
+// RESTLifecycleServiceDependencies names the fresh-role, close-target-read,
+// transition-write, and semantic publication capabilities used by canonical
+// REST sprint transitions.
+type RESTLifecycleServiceDependencies struct {
+	Roles       RoleStore
+	Sprints     SprintReadStore
+	Transitions TransitionStore
+	Publisher   RESTTransitionPublisher
+}
+
+// RESTLifecycleService owns canonical REST actor/fresh-role authorization,
+// close target verification, transition sequencing, and post-write semantic
+// publication. It deliberately owns no transport parsing, state policy, clock,
+// or runtime event vocabulary.
+type RESTLifecycleService struct {
+	roles       RoleStore
+	sprints     SprintReadStore
+	transitions TransitionStore
+	publisher   RESTTransitionPublisher
+}
+
+func NewRESTLifecycleService(deps RESTLifecycleServiceDependencies) *RESTLifecycleService {
+	publisher := deps.Publisher
+	if publisher == nil {
+		publisher = nopRESTTransitionPublisher{}
+	}
+	return &RESTLifecycleService{
+		roles:       deps.Roles,
+		sprints:     deps.Sprints,
+		transitions: deps.Transitions,
+		publisher:   publisher,
+	}
+}
+
+// PreparedRESTActivate binds the exact authorized context and copied numeric
+// identities to one subsequent REST sprint activation.
+type PreparedRESTActivate struct {
+	ctx       context.Context
+	service   *RESTLifecycleService
+	projectID int64
+	sprintID  int64
+}
+
+// PreparedRESTClose binds the exact authorized context and copied numeric
+// identities after the close target has passed its project-identity gate.
+type PreparedRESTClose struct {
+	ctx       context.Context
+	service   *RESTLifecycleService
+	projectID int64
+	sprintID  int64
+}
+
+// PrepareActivate preserves REST's actor and fresh-role gate without adding a
+// sprint read, lifecycle-state precheck, or time policy.
+func (s *RESTLifecycleService) PrepareActivate(
+	ctx context.Context,
+	target TransitionTarget,
+) (*PreparedRESTActivate, error) {
+	if err := authorizeRESTLifecycleMutation(ctx, s.roles, target.ProjectID); err != nil {
+		return nil, err
+	}
+	return &PreparedRESTActivate{
+		ctx:       ctx,
+		service:   s,
+		projectID: target.ProjectID,
+		sprintID:  target.SprintID,
+	}, nil
+}
+
+// PrepareClose preserves REST's actor/fresh-role/target-read ordering. The
+// target read is an existence and project-identity gate; state policy and the
+// final project-scoped mutation remain authoritative in the store.
+func (s *RESTLifecycleService) PrepareClose(
+	ctx context.Context,
+	target TransitionTarget,
+) (*PreparedRESTClose, error) {
+	if err := authorizeRESTLifecycleMutation(ctx, s.roles, target.ProjectID); err != nil {
+		return nil, err
+	}
+
+	sprint, err := s.sprints.GetSprintByID(ctx, target.SprintID)
+	if err != nil {
+		return nil, err
+	}
+	if sprint.ProjectID != target.ProjectID {
+		return nil, ErrSprintNotInProject
+	}
+
+	return &PreparedRESTClose{
+		ctx:       ctx,
+		service:   s,
+		projectID: target.ProjectID,
+		sprintID:  target.SprintID,
+	}, nil
+}
+
+func authorizeRESTLifecycleMutation(ctx context.Context, roles RoleStore, projectID int64) error {
+	userID, ok := store.UserIDFromContext(ctx)
+	if !ok {
+		return ErrActorRequired
+	}
+
+	role, err := roles.GetProjectRole(ctx, projectID, userID)
+	if err != nil || !role.HasMinimumRole(store.RoleMaintainer) {
+		// Canonical REST deliberately collapses role dependency failures and
+		// insufficient authority into the same fixed forbidden result.
+		return ErrMaintainerRequired
+	}
+	return nil
+}
+
+// Activate performs exactly one project-scoped transition and publishes only
+// after persistence succeeds. A successful idempotent store result remains a
+// publishable REST success.
+func (p *PreparedRESTActivate) Activate() error {
+	if err := p.service.transitions.ActivateSprint(p.ctx, p.projectID, p.sprintID); err != nil {
+		return err
+	}
+	p.service.publisher.PublishSprintActivated(p.ctx, p.projectID)
+	return nil
+}
+
+// Close performs exactly one project-scoped transition and publishes only
+// after persistence succeeds.
+func (p *PreparedRESTClose) Close() error {
+	if err := p.service.transitions.CloseSprint(p.ctx, p.projectID, p.sprintID); err != nil {
+		return err
+	}
+	p.service.publisher.PublishSprintClosed(p.ctx, p.projectID)
+	return nil
+}

--- a/internal/application/sprint/rest_lifecycle_test.go
+++ b/internal/application/sprint/rest_lifecycle_test.go
@@ -1,0 +1,471 @@
+package sprint
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+type restLifecycleRoleCall struct {
+	ctx       context.Context
+	projectID int64
+	userID    int64
+}
+
+type restLifecycleReadCall struct {
+	ctx      context.Context
+	sprintID int64
+}
+
+type restLifecycleMutationCall struct {
+	ctx       context.Context
+	projectID int64
+	sprintID  int64
+}
+
+type restLifecyclePublicationCall struct {
+	ctx       context.Context
+	projectID int64
+}
+
+type restLifecycleFake struct {
+	trace []string
+
+	honorContext bool
+
+	role    store.ProjectRole
+	roleErr error
+	roles   []restLifecycleRoleCall
+
+	sprint    store.Sprint
+	sprintErr error
+	reads     []restLifecycleReadCall
+
+	activateErr error
+	activates   []restLifecycleMutationCall
+	closeErr    error
+	closes      []restLifecycleMutationCall
+	deleteErr   error
+	deletes     []restLifecycleMutationCall
+
+	activated []restLifecyclePublicationCall
+	closed    []restLifecyclePublicationCall
+	deleted   []restLifecyclePublicationCall
+}
+
+func (f *restLifecycleFake) GetProjectRole(
+	ctx context.Context,
+	projectID int64,
+	userID int64,
+) (store.ProjectRole, error) {
+	f.trace = append(f.trace, "role")
+	f.roles = append(f.roles, restLifecycleRoleCall{ctx: ctx, projectID: projectID, userID: userID})
+	if f.honorContext && ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	if f.roleErr != nil {
+		return "", f.roleErr
+	}
+	return f.role, nil
+}
+
+func (f *restLifecycleFake) GetSprintByID(ctx context.Context, sprintID int64) (store.Sprint, error) {
+	f.trace = append(f.trace, "read")
+	f.reads = append(f.reads, restLifecycleReadCall{ctx: ctx, sprintID: sprintID})
+	if f.honorContext && ctx.Err() != nil {
+		return store.Sprint{}, ctx.Err()
+	}
+	if f.sprintErr != nil {
+		return store.Sprint{}, f.sprintErr
+	}
+	return f.sprint, nil
+}
+
+func (f *restLifecycleFake) ActivateSprint(ctx context.Context, projectID, sprintID int64) error {
+	f.trace = append(f.trace, "activate")
+	f.activates = append(f.activates, restLifecycleMutationCall{ctx: ctx, projectID: projectID, sprintID: sprintID})
+	if f.honorContext && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return f.activateErr
+}
+
+func (f *restLifecycleFake) CloseSprint(ctx context.Context, projectID, sprintID int64) error {
+	f.trace = append(f.trace, "close")
+	f.closes = append(f.closes, restLifecycleMutationCall{ctx: ctx, projectID: projectID, sprintID: sprintID})
+	if f.honorContext && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return f.closeErr
+}
+
+func (f *restLifecycleFake) DeleteSprint(ctx context.Context, projectID, sprintID int64) error {
+	f.trace = append(f.trace, "delete")
+	f.deletes = append(f.deletes, restLifecycleMutationCall{ctx: ctx, projectID: projectID, sprintID: sprintID})
+	if f.honorContext && ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return f.deleteErr
+}
+
+func (f *restLifecycleFake) PublishSprintActivated(ctx context.Context, projectID int64) {
+	f.trace = append(f.trace, "publish_activated")
+	f.activated = append(f.activated, restLifecyclePublicationCall{ctx: ctx, projectID: projectID})
+}
+
+func (f *restLifecycleFake) PublishSprintClosed(ctx context.Context, projectID int64) {
+	f.trace = append(f.trace, "publish_closed")
+	f.closed = append(f.closed, restLifecyclePublicationCall{ctx: ctx, projectID: projectID})
+}
+
+func (f *restLifecycleFake) PublishSprintDeleted(ctx context.Context, projectID int64) {
+	f.trace = append(f.trace, "publish_deleted")
+	f.deleted = append(f.deleted, restLifecyclePublicationCall{ctx: ctx, projectID: projectID})
+}
+
+var _ RoleStore = (*restLifecycleFake)(nil)
+var _ SprintReadStore = (*restLifecycleFake)(nil)
+var _ TransitionStore = (*restLifecycleFake)(nil)
+var _ DeletionStore = (*restLifecycleFake)(nil)
+var _ RESTTransitionPublisher = (*restLifecycleFake)(nil)
+var _ RESTDeletionPublisher = (*restLifecycleFake)(nil)
+
+func newRESTLifecycleService(fake *restLifecycleFake) *RESTLifecycleService {
+	return NewRESTLifecycleService(RESTLifecycleServiceDependencies{
+		Roles:       fake,
+		Sprints:     fake,
+		Transitions: fake,
+		Publisher:   fake,
+	})
+}
+
+func assertRESTLifecycleTrace(t *testing.T, fake *restLifecycleFake, want ...string) {
+	t.Helper()
+	if !reflect.DeepEqual(fake.trace, want) {
+		t.Fatalf("trace = %v, want %v", fake.trace, want)
+	}
+}
+
+func TestRESTLifecyclePrepareActivateAuthorization(t *testing.T) {
+	const projectID int64 = 41
+	const sprintID int64 = 907
+	const actorID int64 = 13
+
+	t.Run("missing actor", func(t *testing.T) {
+		fake := &restLifecycleFake{role: store.RoleMaintainer}
+		prepared, err := newRESTLifecycleService(fake).PrepareActivate(context.Background(), TransitionTarget{ProjectID: projectID, SprintID: sprintID})
+		if !errors.Is(err, ErrActorRequired) || prepared != nil {
+			t.Fatalf("PrepareActivate() = (%v, %v), want (nil, ErrActorRequired)", prepared, err)
+		}
+		assertRESTLifecycleTrace(t, fake)
+	})
+
+	roleDependencyErr := errors.New("role dependency failed")
+	for _, tc := range []struct {
+		name    string
+		role    store.ProjectRole
+		roleErr error
+		wantErr bool
+	}{
+		{name: "maintainer", role: store.RoleMaintainer},
+		{name: "compatible owner", role: store.RoleOwner},
+		{name: "contributor", role: store.RoleContributor, wantErr: true},
+		{name: "viewer", role: store.RoleViewer, wantErr: true},
+		{name: "nonmember", wantErr: true},
+		{name: "role dependency failure", roleErr: roleDependencyErr, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := store.WithUserID(context.Background(), actorID)
+			fake := &restLifecycleFake{role: tc.role, roleErr: tc.roleErr}
+			prepared, err := newRESTLifecycleService(fake).PrepareActivate(ctx, TransitionTarget{ProjectID: projectID, SprintID: sprintID})
+			if tc.wantErr {
+				if !errors.Is(err, ErrMaintainerRequired) || prepared != nil {
+					t.Fatalf("PrepareActivate() = (%v, %v), want (nil, ErrMaintainerRequired)", prepared, err)
+				}
+			} else if err != nil || prepared == nil {
+				t.Fatalf("PrepareActivate() = (%v, %v), want prepared capability", prepared, err)
+			}
+			assertRESTLifecycleTrace(t, fake, "role")
+			if len(fake.roles) != 1 {
+				t.Fatalf("role calls = %d, want 1", len(fake.roles))
+			}
+			call := fake.roles[0]
+			if call.ctx != ctx || call.projectID != projectID || call.userID != actorID {
+				t.Fatalf("role call = %+v, want exact context, project %d, actor %d", call, projectID, actorID)
+			}
+			if len(fake.reads) != 0 || len(fake.activates) != 0 || len(fake.activated) != 0 {
+				t.Fatalf("preparation performed later work: reads=%d activates=%d publications=%d", len(fake.reads), len(fake.activates), len(fake.activated))
+			}
+		})
+	}
+
+	t.Run("role cancellation is collapsed", func(t *testing.T) {
+		base, cancel := context.WithCancel(context.Background())
+		ctx := store.WithUserID(base, actorID)
+		cancel()
+		fake := &restLifecycleFake{role: store.RoleMaintainer, honorContext: true}
+		prepared, err := newRESTLifecycleService(fake).PrepareActivate(ctx, TransitionTarget{ProjectID: projectID, SprintID: sprintID})
+		if !errors.Is(err, ErrMaintainerRequired) || prepared != nil {
+			t.Fatalf("PrepareActivate() = (%v, %v), want (nil, ErrMaintainerRequired)", prepared, err)
+		}
+		assertRESTLifecycleTrace(t, fake, "role")
+		if len(fake.roles) != 1 || fake.roles[0].ctx != ctx {
+			t.Fatalf("role calls = %+v, want cancelled bound context", fake.roles)
+		}
+	})
+}
+
+func TestRESTLifecyclePrepareCloseTargetGateAndBinding(t *testing.T) {
+	const actorID int64 = 17
+	target := TransitionTarget{ProjectID: 43, SprintID: 911}
+	ctx := store.WithUserID(context.Background(), actorID)
+	fake := &restLifecycleFake{
+		role:   store.RoleMaintainer,
+		sprint: store.Sprint{ID: target.SprintID, ProjectID: target.ProjectID},
+	}
+	prepared, err := newRESTLifecycleService(fake).PrepareClose(ctx, target)
+	if err != nil {
+		t.Fatalf("PrepareClose() error = %v", err)
+	}
+	if prepared == nil {
+		t.Fatal("PrepareClose() returned nil capability")
+	}
+	assertRESTLifecycleTrace(t, fake, "role", "read")
+	if len(fake.roles) != 1 || fake.roles[0].ctx != ctx || fake.roles[0].projectID != target.ProjectID || fake.roles[0].userID != actorID {
+		t.Fatalf("role calls = %+v, want exact bound authorization call", fake.roles)
+	}
+	if len(fake.reads) != 1 || fake.reads[0].ctx != ctx || fake.reads[0].sprintID != target.SprintID {
+		t.Fatalf("read calls = %+v, want exact bound target read", fake.reads)
+	}
+
+	original := target
+	target.ProjectID = 99
+	target.SprintID = 1001
+	if err := prepared.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	assertRESTLifecycleTrace(t, fake, "role", "read", "close", "publish_closed")
+	if len(fake.closes) != 1 || fake.closes[0].ctx != ctx || fake.closes[0].projectID != original.ProjectID || fake.closes[0].sprintID != original.SprintID {
+		t.Fatalf("close calls = %+v, want bound project %d sprint %d", fake.closes, original.ProjectID, original.SprintID)
+	}
+	if len(fake.closed) != 1 || fake.closed[0].ctx != ctx || fake.closed[0].projectID != original.ProjectID {
+		t.Fatalf("close publications = %+v, want exact bound context and project %d", fake.closed, original.ProjectID)
+	}
+}
+
+func TestRESTLifecyclePrepareCloseFailures(t *testing.T) {
+	const projectID int64 = 43
+	const sprintID int64 = 911
+	ctx := store.WithUserID(context.Background(), 17)
+	readErr := errors.New("read failed")
+	roleErr := errors.New("role failed")
+
+	t.Run("missing actor short circuits authorization", func(t *testing.T) {
+		fake := &restLifecycleFake{role: store.RoleMaintainer}
+		prepared, err := newRESTLifecycleService(fake).PrepareClose(context.Background(), TransitionTarget{ProjectID: projectID, SprintID: sprintID})
+		if !errors.Is(err, ErrActorRequired) || prepared != nil {
+			t.Fatalf("PrepareClose() = (%v, %v), want (nil, ErrActorRequired)", prepared, err)
+		}
+		assertRESTLifecycleTrace(t, fake)
+	})
+
+	for _, tc := range []struct {
+		name      string
+		fake      *restLifecycleFake
+		wantErr   error
+		wantTrace []string
+	}{
+		{
+			name:      "authorization short circuits read",
+			fake:      &restLifecycleFake{roleErr: roleErr},
+			wantErr:   ErrMaintainerRequired,
+			wantTrace: []string{"role"},
+		},
+		{
+			name:      "read error passes through",
+			fake:      &restLifecycleFake{role: store.RoleMaintainer, sprintErr: readErr},
+			wantErr:   readErr,
+			wantTrace: []string{"role", "read"},
+		},
+		{
+			name:      "foreign project is classified",
+			fake:      &restLifecycleFake{role: store.RoleMaintainer, sprint: store.Sprint{ID: sprintID, ProjectID: projectID + 1}},
+			wantErr:   ErrSprintNotInProject,
+			wantTrace: []string{"role", "read"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prepared, err := newRESTLifecycleService(tc.fake).PrepareClose(ctx, TransitionTarget{ProjectID: projectID, SprintID: sprintID})
+			if !errors.Is(err, tc.wantErr) || prepared != nil {
+				t.Fatalf("PrepareClose() = (%v, %v), want (nil, %v)", prepared, err, tc.wantErr)
+			}
+			if tc.wantErr == readErr && err != readErr {
+				t.Fatalf("PrepareClose() wrapped read error: got %v, want identical %v", err, readErr)
+			}
+			assertRESTLifecycleTrace(t, tc.fake, tc.wantTrace...)
+			if len(tc.fake.closes) != 0 || len(tc.fake.closed) != 0 {
+				t.Fatalf("failed preparation performed operation: closes=%d publications=%d", len(tc.fake.closes), len(tc.fake.closed))
+			}
+		})
+	}
+}
+
+func TestRESTLifecyclePrepareActivateBindsTargetAndPublishesAfterPersistence(t *testing.T) {
+	target := TransitionTarget{ProjectID: 47, SprintID: 919}
+	original := target
+	ctx := store.WithUserID(context.Background(), 19)
+	fake := &restLifecycleFake{role: store.RoleMaintainer}
+	prepared, err := newRESTLifecycleService(fake).PrepareActivate(ctx, target)
+	if err != nil {
+		t.Fatalf("PrepareActivate() error = %v", err)
+	}
+	target.ProjectID = 101
+	target.SprintID = 103
+
+	if err := prepared.Activate(); err != nil {
+		t.Fatalf("Activate() error = %v", err)
+	}
+	assertRESTLifecycleTrace(t, fake, "role", "activate", "publish_activated")
+	if len(fake.activates) != 1 || fake.activates[0].ctx != ctx || fake.activates[0].projectID != original.ProjectID || fake.activates[0].sprintID != original.SprintID {
+		t.Fatalf("activate calls = %+v, want exact bound context, project %d, sprint %d", fake.activates, original.ProjectID, original.SprintID)
+	}
+	if len(fake.activated) != 1 || fake.activated[0].ctx != ctx || fake.activated[0].projectID != original.ProjectID {
+		t.Fatalf("activation publications = %+v, want exact bound context and project %d", fake.activated, original.ProjectID)
+	}
+	if len(fake.reads) != 0 || len(fake.closed) != 0 || len(fake.deleted) != 0 {
+		t.Fatalf("activation used unrelated capabilities: reads=%d closed=%d deleted=%d", len(fake.reads), len(fake.closed), len(fake.deleted))
+	}
+}
+
+func TestRESTLifecycleRepeatedActivationSuccessStillPublishes(t *testing.T) {
+	ctx := store.WithUserID(context.Background(), 23)
+	fake := &restLifecycleFake{role: store.RoleMaintainer}
+	prepared, err := newRESTLifecycleService(fake).PrepareActivate(ctx, TransitionTarget{ProjectID: 53, SprintID: 929})
+	if err != nil {
+		t.Fatalf("PrepareActivate() error = %v", err)
+	}
+
+	// The fake's nil result models the store's successful idempotent return. The
+	// service has no state input and must treat every successful return alike.
+	if err := prepared.Activate(); err != nil {
+		t.Fatalf("Activate() error = %v", err)
+	}
+	assertRESTLifecycleTrace(t, fake, "role", "activate", "publish_activated")
+	if len(fake.activates) != 1 || len(fake.activated) != 1 {
+		t.Fatalf("calls = activate %d publish %d, want 1 and 1", len(fake.activates), len(fake.activated))
+	}
+}
+
+func TestRESTLifecycleMutationFailuresPassThroughWithoutPublication(t *testing.T) {
+	activateErr := errors.New("activate failed")
+	closeErr := errors.New("close failed")
+
+	t.Run("activate", func(t *testing.T) {
+		fake := &restLifecycleFake{role: store.RoleMaintainer, activateErr: activateErr}
+		prepared, err := newRESTLifecycleService(fake).PrepareActivate(store.WithUserID(context.Background(), 29), TransitionTarget{ProjectID: 59, SprintID: 937})
+		if err != nil {
+			t.Fatalf("PrepareActivate() error = %v", err)
+		}
+		err = prepared.Activate()
+		if err != activateErr {
+			t.Fatalf("Activate() error = %v, want %v", err, activateErr)
+		}
+		assertRESTLifecycleTrace(t, fake, "role", "activate")
+		if len(fake.activates) != 1 || len(fake.activated) != 0 {
+			t.Fatalf("calls = activate %d publish %d, want 1 and 0", len(fake.activates), len(fake.activated))
+		}
+	})
+
+	t.Run("close", func(t *testing.T) {
+		fake := &restLifecycleFake{
+			role:     store.RoleMaintainer,
+			sprint:   store.Sprint{ID: 941, ProjectID: 61},
+			closeErr: closeErr,
+		}
+		prepared, err := newRESTLifecycleService(fake).PrepareClose(store.WithUserID(context.Background(), 31), TransitionTarget{ProjectID: 61, SprintID: 941})
+		if err != nil {
+			t.Fatalf("PrepareClose() error = %v", err)
+		}
+		err = prepared.Close()
+		if err != closeErr {
+			t.Fatalf("Close() error = %v, want %v", err, closeErr)
+		}
+		assertRESTLifecycleTrace(t, fake, "role", "read", "close")
+		if len(fake.closes) != 1 || len(fake.closed) != 0 {
+			t.Fatalf("calls = close %d publish %d, want 1 and 0", len(fake.closes), len(fake.closed))
+		}
+	})
+}
+
+func TestRESTLifecycleCancellationAfterPreparationUsesBoundContext(t *testing.T) {
+	t.Run("activate", func(t *testing.T) {
+		base, cancel := context.WithCancel(context.Background())
+		ctx := store.WithUserID(base, 37)
+		fake := &restLifecycleFake{role: store.RoleMaintainer, honorContext: true}
+		prepared, err := newRESTLifecycleService(fake).PrepareActivate(ctx, TransitionTarget{ProjectID: 67, SprintID: 947})
+		if err != nil {
+			t.Fatalf("PrepareActivate() error = %v", err)
+		}
+		cancel()
+		if err := prepared.Activate(); !errors.Is(err, context.Canceled) {
+			t.Fatalf("Activate() error = %v, want context.Canceled", err)
+		}
+		assertRESTLifecycleTrace(t, fake, "role", "activate")
+		if len(fake.activates) != 1 || fake.activates[0].ctx != ctx || len(fake.activated) != 0 {
+			t.Fatalf("cancellation calls = %+v publications=%d", fake.activates, len(fake.activated))
+		}
+	})
+
+	t.Run("close", func(t *testing.T) {
+		base, cancel := context.WithCancel(context.Background())
+		ctx := store.WithUserID(base, 41)
+		fake := &restLifecycleFake{
+			role:         store.RoleMaintainer,
+			sprint:       store.Sprint{ID: 953, ProjectID: 71},
+			honorContext: true,
+		}
+		prepared, err := newRESTLifecycleService(fake).PrepareClose(ctx, TransitionTarget{ProjectID: 71, SprintID: 953})
+		if err != nil {
+			t.Fatalf("PrepareClose() error = %v", err)
+		}
+		cancel()
+		if err := prepared.Close(); !errors.Is(err, context.Canceled) {
+			t.Fatalf("Close() error = %v, want context.Canceled", err)
+		}
+		assertRESTLifecycleTrace(t, fake, "role", "read", "close")
+		if len(fake.reads) != 1 || len(fake.closes) != 1 || fake.closes[0].ctx != ctx || len(fake.closed) != 0 {
+			t.Fatalf("cancellation calls = reads %d closes %+v publications=%d", len(fake.reads), fake.closes, len(fake.closed))
+		}
+	})
+}
+
+func TestRESTLifecycleNilPublisherIsNoop(t *testing.T) {
+	t.Run("activate", func(t *testing.T) {
+		fake := &restLifecycleFake{role: store.RoleMaintainer}
+		service := NewRESTLifecycleService(RESTLifecycleServiceDependencies{Roles: fake, Sprints: fake, Transitions: fake})
+		prepared, err := service.PrepareActivate(store.WithUserID(context.Background(), 43), TransitionTarget{ProjectID: 73, SprintID: 967})
+		if err != nil {
+			t.Fatalf("PrepareActivate() error = %v", err)
+		}
+		if err := prepared.Activate(); err != nil {
+			t.Fatalf("Activate() error = %v", err)
+		}
+		assertRESTLifecycleTrace(t, fake, "role", "activate")
+	})
+
+	t.Run("close", func(t *testing.T) {
+		fake := &restLifecycleFake{role: store.RoleMaintainer, sprint: store.Sprint{ID: 971, ProjectID: 79}}
+		service := NewRESTLifecycleService(RESTLifecycleServiceDependencies{Roles: fake, Sprints: fake, Transitions: fake})
+		prepared, err := service.PrepareClose(store.WithUserID(context.Background(), 47), TransitionTarget{ProjectID: 79, SprintID: 971})
+		if err != nil {
+			t.Fatalf("PrepareClose() error = %v", err)
+		}
+		if err := prepared.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+		assertRESTLifecycleTrace(t, fake, "role", "read", "close")
+	})
+}

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -35,6 +35,30 @@ func (p sprintDefinitionPublisher) PublishSprintUpdated(ctx context.Context, pro
 	p.server.emitRefreshNeeded(ctx, projectID, "sprint_updated")
 }
 
+type sprintTransitionPublisher struct {
+	server *Server
+}
+
+var _ sprintapp.RESTTransitionPublisher = sprintTransitionPublisher{}
+
+func (p sprintTransitionPublisher) PublishSprintActivated(ctx context.Context, projectID int64) {
+	p.server.emitRefreshNeeded(ctx, projectID, "sprint_activated")
+}
+
+func (p sprintTransitionPublisher) PublishSprintClosed(ctx context.Context, projectID int64) {
+	p.server.emitRefreshNeeded(ctx, projectID, "sprint_closed")
+}
+
+type sprintDeletionPublisher struct {
+	server *Server
+}
+
+var _ sprintapp.RESTDeletionPublisher = sprintDeletionPublisher{}
+
+func (p sprintDeletionPublisher) PublishSprintDeleted(ctx context.Context, projectID int64) {
+	p.server.emitRefreshNeeded(ctx, projectID, "sprint_deleted")
+}
+
 type membershipMutationPublisher struct {
 	server *Server
 }

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	membershipapp "scrumboy/internal/application/membership"
+	sprintapp "scrumboy/internal/application/sprint"
 	todolinkapp "scrumboy/internal/application/todolink"
 	"scrumboy/internal/eventbus"
 	"scrumboy/internal/store"
@@ -18,6 +19,20 @@ var _ todolinkapp.RESTMutationPublisher = todoLinkMutationPublisher{}
 
 func (p todoLinkMutationPublisher) PublishTodoLinksUpdated(ctx context.Context, projectID int64) {
 	p.server.emitRefreshNeeded(ctx, projectID, "todo_links_updated")
+}
+
+type sprintDefinitionPublisher struct {
+	server *Server
+}
+
+var _ sprintapp.RESTDefinitionPublisher = sprintDefinitionPublisher{}
+
+func (p sprintDefinitionPublisher) PublishSprintCreated(ctx context.Context, projectID int64) {
+	p.server.emitRefreshNeeded(ctx, projectID, "sprint_created")
+}
+
+func (p sprintDefinitionPublisher) PublishSprintUpdated(ctx context.Context, projectID int64) {
+	p.server.emitRefreshNeeded(ctx, projectID, "sprint_updated")
 }
 
 type membershipMutationPublisher struct {

--- a/internal/httpapi/routing_board.go
+++ b/internal/httpapi/routing_board.go
@@ -958,7 +958,16 @@ func (s *Server) handleBoardSprintRoutes(w http.ResponseWriter, r *http.Request,
 			writeError(w, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
 			return true
 		}
-		if err := s.store.CloseSprint(ctx, sprintID); err != nil {
+		target, err := s.store.GetSprintByID(ctx, sprintID)
+		if err != nil {
+			writeStoreErr(w, err, true)
+			return true
+		}
+		if target.ProjectID != project.ID {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+			return true
+		}
+		if err := s.store.CloseSprint(ctx, project.ID, sprintID); err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}

--- a/internal/httpapi/routing_board.go
+++ b/internal/httpapi/routing_board.go
@@ -38,6 +38,19 @@ func writeSprintDefinitionPrepareError(w http.ResponseWriter, err error) {
 	}
 }
 
+func writeSprintLifecyclePrepareError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, sprintapp.ErrActorRequired):
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
+	case errors.Is(err, sprintapp.ErrMaintainerRequired):
+		writeError(w, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
+	case errors.Is(err, sprintapp.ErrSprintNotInProject):
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+	default:
+		writeStoreErr(w, err, true)
+	}
+}
+
 func (s *Server) handleBoard(w http.ResponseWriter, r *http.Request, rest []string) {
 	if len(rest) == 0 {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", "not found", nil)
@@ -874,21 +887,18 @@ func (s *Server) handleBoardSprintRoutes(w http.ResponseWriter, r *http.Request,
 
 		case http.MethodDelete:
 			ctx := s.requestContext(r)
-			userID, ok := store.UserIDFromContext(ctx)
-			if !ok {
-				writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
+			prepared, err := s.sprintDeletions.PrepareDelete(ctx, sprintapp.DeletionTarget{
+				ProjectID: project.ID,
+				SprintID:  sprintID,
+			})
+			if err != nil {
+				writeSprintLifecyclePrepareError(w, err)
 				return true
 			}
-			role, err := s.store.GetProjectRole(ctx, project.ID, userID)
-			if err != nil || !role.HasMinimumRole(store.RoleMaintainer) {
-				writeError(w, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
-				return true
-			}
-			if err := s.store.DeleteSprint(ctx, project.ID, sprintID); err != nil {
+			if err := prepared.Delete(); err != nil {
 				writeStoreErr(w, err, true)
 				return true
 			}
-			s.emitRefreshNeeded(s.requestContext(r), project.ID, "sprint_deleted")
 			w.WriteHeader(http.StatusNoContent)
 			return true
 
@@ -921,21 +931,18 @@ func (s *Server) handleBoardSprintRoutes(w http.ResponseWriter, r *http.Request,
 			return true
 		}
 		ctx := s.requestContext(r)
-		userID, ok := store.UserIDFromContext(ctx)
-		if !ok {
-			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
+		prepared, err := s.sprintLifecycle.PrepareActivate(ctx, sprintapp.TransitionTarget{
+			ProjectID: project.ID,
+			SprintID:  sprintID,
+		})
+		if err != nil {
+			writeSprintLifecyclePrepareError(w, err)
 			return true
 		}
-		role, err := s.store.GetProjectRole(ctx, project.ID, userID)
-		if err != nil || !role.HasMinimumRole(store.RoleMaintainer) {
-			writeError(w, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
-			return true
-		}
-		if err := s.store.ActivateSprint(ctx, project.ID, sprintID); err != nil {
+		if err := prepared.Activate(); err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}
-		s.emitRefreshNeeded(s.requestContext(r), project.ID, "sprint_activated")
 		w.WriteHeader(http.StatusNoContent)
 		return true
 	}
@@ -948,30 +955,18 @@ func (s *Server) handleBoardSprintRoutes(w http.ResponseWriter, r *http.Request,
 			return true
 		}
 		ctx := s.requestContext(r)
-		userID, ok := store.UserIDFromContext(ctx)
-		if !ok {
-			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
-			return true
-		}
-		role, err := s.store.GetProjectRole(ctx, project.ID, userID)
-		if err != nil || !role.HasMinimumRole(store.RoleMaintainer) {
-			writeError(w, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
-			return true
-		}
-		target, err := s.store.GetSprintByID(ctx, sprintID)
+		prepared, err := s.sprintLifecycle.PrepareClose(ctx, sprintapp.TransitionTarget{
+			ProjectID: project.ID,
+			SprintID:  sprintID,
+		})
 		if err != nil {
+			writeSprintLifecyclePrepareError(w, err)
+			return true
+		}
+		if err := prepared.Close(); err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}
-		if target.ProjectID != project.ID {
-			writeError(w, http.StatusNotFound, "NOT_FOUND", "not found", nil)
-			return true
-		}
-		if err := s.store.CloseSprint(ctx, project.ID, sprintID); err != nil {
-			writeStoreErr(w, err, true)
-			return true
-		}
-		s.emitRefreshNeeded(s.requestContext(r), project.ID, "sprint_closed")
 		w.WriteHeader(http.StatusNoContent)
 		return true
 	}

--- a/internal/httpapi/routing_board.go
+++ b/internal/httpapi/routing_board.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	sprintapp "scrumboy/internal/application/sprint"
 	todoapp "scrumboy/internal/application/todo"
 	todolinkapp "scrumboy/internal/application/todolink"
 	workflowapp "scrumboy/internal/application/workflow"
@@ -20,6 +21,17 @@ func writeWorkflowMutationPrepareError(w http.ResponseWriter, err error) {
 	case errors.Is(err, workflowapp.ErrActorRequired):
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
 	case errors.Is(err, workflowapp.ErrMaintainerRequired):
+		writeError(w, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
+	default:
+		writeInternal(w, err)
+	}
+}
+
+func writeSprintDefinitionPrepareError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, sprintapp.ErrActorRequired):
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
+	case errors.Is(err, sprintapp.ErrMaintainerRequired):
 		writeError(w, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
 	default:
 		writeInternal(w, err)
@@ -758,14 +770,11 @@ func (s *Server) handleBoardSprintRoutes(w http.ResponseWriter, r *http.Request,
 	// POST /api/board/{slug}/sprints - create sprint (Maintainer+)
 	if len(rest) == 2 && rest[1] == "sprints" && r.Method == http.MethodPost {
 		ctx := s.requestContext(r)
-		userID, ok := store.UserIDFromContext(ctx)
-		if !ok {
-			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
-			return true
-		}
-		role, err := s.store.GetProjectRole(ctx, project.ID, userID)
-		if err != nil || !role.HasMinimumRole(store.RoleMaintainer) {
-			writeError(w, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
+		prepared, err := s.sprintDefinitions.PrepareCreate(ctx, sprintapp.ResolvedRESTProjectTarget{
+			ProjectID: project.ID,
+		})
+		if err != nil {
+			writeSprintDefinitionPrepareError(w, err)
 			return true
 		}
 		var in struct {
@@ -780,12 +789,15 @@ func (s *Server) handleBoardSprintRoutes(w http.ResponseWriter, r *http.Request,
 			writeValidationError(w, "name required", "name_required", map[string]any{"field": "name"})
 			return true
 		}
-		sprint, err := s.store.CreateSprint(ctx, project.ID, in.Name, time.UnixMilli(in.PlannedStartAt), time.UnixMilli(in.PlannedEndAt))
+		sprint, err := prepared.Create(sprintapp.CreateCommand{
+			Name:           in.Name,
+			PlannedStartAt: time.UnixMilli(in.PlannedStartAt),
+			PlannedEndAt:   time.UnixMilli(in.PlannedEndAt),
+		})
 		if err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}
-		s.emitRefreshNeeded(s.requestContext(r), project.ID, "sprint_created")
 		writeJSON(w, http.StatusCreated, sprintToJSON(sprint))
 		return true
 	}
@@ -828,14 +840,12 @@ func (s *Server) handleBoardSprintRoutes(w http.ResponseWriter, r *http.Request,
 
 		case http.MethodPatch:
 			ctx := s.requestContext(r)
-			userID, ok := store.UserIDFromContext(ctx)
-			if !ok {
-				writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
-				return true
-			}
-			role, err := s.store.GetProjectRole(ctx, project.ID, userID)
-			if err != nil || !role.HasMinimumRole(store.RoleMaintainer) {
-				writeError(w, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
+			prepared, err := s.sprintDefinitions.PrepareUpdate(ctx, sprintapp.ResolvedRESTSprintTarget{
+				ProjectID: project.ID,
+				SprintID:  sp.ID,
+			})
+			if err != nil {
+				writeSprintDefinitionPrepareError(w, err)
 				return true
 			}
 			var in struct {
@@ -846,23 +856,19 @@ func (s *Server) handleBoardSprintRoutes(w http.ResponseWriter, r *http.Request,
 			if err := readJSON(w, r, s.maxBody, &in); err != nil {
 				return true
 			}
-			opts := store.UpdateSprintInput{}
-			if in.Name != nil {
-				opts.Name = in.Name
-			}
+			command := sprintapp.UpdateCommand{Name: in.Name}
 			if in.PlannedStartAt != nil {
 				t := time.UnixMilli(*in.PlannedStartAt)
-				opts.PlannedStartAt = &t
+				command.PlannedStartAt = &t
 			}
 			if in.PlannedEndAt != nil {
 				t := time.UnixMilli(*in.PlannedEndAt)
-				opts.PlannedEndAt = &t
+				command.PlannedEndAt = &t
 			}
-			if err := s.store.UpdateSprint(ctx, sprintID, opts); err != nil {
+			if err := prepared.Update(command); err != nil {
 				writeStoreErr(w, err, true)
 				return true
 			}
-			s.emitRefreshNeeded(s.requestContext(r), project.ID, "sprint_updated")
 			w.WriteHeader(http.StatusNoContent)
 			return true
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -274,7 +274,7 @@ type storeAPI interface {
 	GetSprintByProjectNumber(ctx context.Context, projectID, number int64) (store.Sprint, error)
 	GetActiveSprintByProjectID(ctx context.Context, projectID int64) (*store.Sprint, error)
 	ActivateSprint(ctx context.Context, projectID, sprintID int64) error
-	CloseSprint(ctx context.Context, sprintID int64) error
+	CloseSprint(ctx context.Context, projectID, sprintID int64) error
 	DeleteSprint(ctx context.Context, projectID, sprintID int64) error
 	UpdateTodo(ctx context.Context, todoID int64, in store.UpdateTodoInput, mode store.Mode) (store.Todo, error)
 	DeleteTodo(ctx context.Context, todoID int64, mode store.Mode) error

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -13,6 +13,7 @@ import (
 
 	boardapp "scrumboy/internal/application/board"
 	membershipapp "scrumboy/internal/application/membership"
+	sprintapp "scrumboy/internal/application/sprint"
 	todoapp "scrumboy/internal/application/todo"
 	todolinkapp "scrumboy/internal/application/todolink"
 	workflowapp "scrumboy/internal/application/workflow"
@@ -102,6 +103,7 @@ type Server struct {
 	todoMoves           *todoapp.MoveService
 	todoUpdates         *todoapp.UpdateService
 	todoLinkMutations   *todolinkapp.RESTMutationService
+	sprintDefinitions   *sprintapp.RESTDefinitionService
 	workflowMutations   *workflowapp.RESTMutationService
 	membershipMutations *membershipapp.RESTMutationService
 
@@ -263,7 +265,7 @@ type storeAPI interface {
 	GetTagColor(ctx context.Context, userID int64, tagID int64) (*string, error)
 	DeleteTag(ctx context.Context, userID int64, tagID int64, isAnonymousBoard bool) error
 
-	CreateSprint(ctx context.Context, projectID int64, name string, plannedStartAt, plannedEndAt time.Time) (store.Sprint, error)
+	sprintapp.DefinitionStore
 	ListSprints(ctx context.Context, projectID int64) ([]store.Sprint, error)
 	HasSprints(ctx context.Context, projectID int64) (bool, error)
 	ListSprintsWithTodoCount(ctx context.Context, projectID int64) ([]store.SprintWithTodoCount, error)
@@ -273,7 +275,6 @@ type storeAPI interface {
 	GetActiveSprintByProjectID(ctx context.Context, projectID int64) (*store.Sprint, error)
 	ActivateSprint(ctx context.Context, projectID, sprintID int64) error
 	CloseSprint(ctx context.Context, sprintID int64) error
-	UpdateSprint(ctx context.Context, sprintID int64, in store.UpdateSprintInput) error
 	DeleteSprint(ctx context.Context, projectID, sprintID int64) error
 	UpdateTodo(ctx context.Context, todoID int64, in store.UpdateTodoInput, mode store.Mode) (store.Todo, error)
 	DeleteTodo(ctx context.Context, todoID int64, mode store.Mode) error
@@ -598,6 +599,11 @@ func NewServer(st storeAPI, opts Options) *Server {
 		Sources:   st,
 		Mutations: st,
 		Publisher: todoLinkMutationPublisher{server: server},
+	})
+	server.sprintDefinitions = sprintapp.NewRESTDefinitionService(sprintapp.RESTDefinitionServiceDependencies{
+		Roles:       st,
+		Definitions: st,
+		Publisher:   sprintDefinitionPublisher{server: server},
 	})
 	server.workflowMutations = workflowapp.NewRESTMutationService(workflowapp.RESTMutationServiceDependencies{
 		Roles:     st,

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -104,6 +104,8 @@ type Server struct {
 	todoUpdates         *todoapp.UpdateService
 	todoLinkMutations   *todolinkapp.RESTMutationService
 	sprintDefinitions   *sprintapp.RESTDefinitionService
+	sprintLifecycle     *sprintapp.RESTLifecycleService
+	sprintDeletions     *sprintapp.RESTDeletionService
 	workflowMutations   *workflowapp.RESTMutationService
 	membershipMutations *membershipapp.RESTMutationService
 
@@ -273,9 +275,8 @@ type storeAPI interface {
 	GetSprintByID(ctx context.Context, sprintID int64) (store.Sprint, error)
 	GetSprintByProjectNumber(ctx context.Context, projectID, number int64) (store.Sprint, error)
 	GetActiveSprintByProjectID(ctx context.Context, projectID int64) (*store.Sprint, error)
-	ActivateSprint(ctx context.Context, projectID, sprintID int64) error
-	CloseSprint(ctx context.Context, projectID, sprintID int64) error
-	DeleteSprint(ctx context.Context, projectID, sprintID int64) error
+	sprintapp.TransitionStore
+	sprintapp.DeletionStore
 	UpdateTodo(ctx context.Context, todoID int64, in store.UpdateTodoInput, mode store.Mode) (store.Todo, error)
 	DeleteTodo(ctx context.Context, todoID int64, mode store.Mode) error
 	GetProjectIDForTodo(ctx context.Context, todoID int64) (int64, error)
@@ -604,6 +605,17 @@ func NewServer(st storeAPI, opts Options) *Server {
 		Roles:       st,
 		Definitions: st,
 		Publisher:   sprintDefinitionPublisher{server: server},
+	})
+	server.sprintLifecycle = sprintapp.NewRESTLifecycleService(sprintapp.RESTLifecycleServiceDependencies{
+		Roles:       st,
+		Sprints:     st,
+		Transitions: st,
+		Publisher:   sprintTransitionPublisher{server: server},
+	})
+	server.sprintDeletions = sprintapp.NewRESTDeletionService(sprintapp.RESTDeletionServiceDependencies{
+		Roles:     st,
+		Deletions: st,
+		Publisher: sprintDeletionPublisher{server: server},
 	})
 	server.workflowMutations = workflowapp.NewRESTMutationService(workflowapp.RESTMutationServiceDependencies{
 		Roles:     st,

--- a/internal/httpapi/sprint_definition_transport_contract_test.go
+++ b/internal/httpapi/sprint_definition_transport_contract_test.go
@@ -1,0 +1,737 @@
+package httpapi
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"scrumboy/internal/db"
+	"scrumboy/internal/eventbus"
+	"scrumboy/internal/migrate"
+	"scrumboy/internal/store"
+)
+
+type sprintDefinitionRESTEventCollector struct {
+	mu     sync.Mutex
+	events []eventbus.Event
+}
+
+func (c *sprintDefinitionRESTEventCollector) OnEvent(_ context.Context, event eventbus.Event) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, event)
+}
+
+func (c *sprintDefinitionRESTEventCollector) snapshot() []eventbus.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]eventbus.Event(nil), c.events...)
+}
+
+type sprintDefinitionRESTStore struct {
+	*store.Store
+
+	mu sync.Mutex
+
+	active bool
+	trace  []string
+
+	accessErr      error
+	accessOverride *store.ProjectContext
+	roleErr        error
+	targetErr      error
+	createErr      error
+	updateErr      error
+
+	accessSlug string
+	accessMode store.Mode
+	rolePID    int64
+	roleUID    int64
+
+	targetReads int
+	targetID    int64
+
+	createCalls int
+	createPID   int64
+	createName  string
+	createStart time.Time
+	createEnd   time.Time
+
+	updateCalls int
+	updateID    int64
+	updateInput store.UpdateSprintInput
+}
+
+func (s *sprintDefinitionRESTStore) activate() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.active = true
+	s.trace = nil
+	s.targetReads = 0
+	s.createCalls = 0
+	s.updateCalls = 0
+}
+
+func (s *sprintDefinitionRESTStore) record(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.active {
+		return false
+	}
+	s.trace = append(s.trace, name)
+	return true
+}
+
+func (s *sprintDefinitionRESTStore) snapshotTrace() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.trace...)
+}
+
+func (s *sprintDefinitionRESTStore) GetProjectContextBySlug(ctx context.Context, slug string, mode store.Mode) (store.ProjectContext, error) {
+	if !s.record("access") {
+		return s.Store.GetProjectContextBySlug(ctx, slug, mode)
+	}
+	s.mu.Lock()
+	s.accessSlug = slug
+	s.accessMode = mode
+	err := s.accessErr
+	override := s.accessOverride
+	s.mu.Unlock()
+	if err != nil {
+		return store.ProjectContext{}, err
+	}
+	if override != nil {
+		return *override, nil
+	}
+	return s.Store.GetProjectContextBySlug(ctx, slug, mode)
+}
+
+func (s *sprintDefinitionRESTStore) GetProjectRole(ctx context.Context, projectID, userID int64) (store.ProjectRole, error) {
+	if !s.record("role") {
+		return s.Store.GetProjectRole(ctx, projectID, userID)
+	}
+	s.mu.Lock()
+	s.rolePID = projectID
+	s.roleUID = userID
+	err := s.roleErr
+	s.mu.Unlock()
+	if err != nil {
+		return "", err
+	}
+	return s.Store.GetProjectRole(ctx, projectID, userID)
+}
+
+func (s *sprintDefinitionRESTStore) GetSprintByID(ctx context.Context, sprintID int64) (store.Sprint, error) {
+	if !s.record("target") {
+		return s.Store.GetSprintByID(ctx, sprintID)
+	}
+	s.mu.Lock()
+	s.targetReads++
+	s.targetID = sprintID
+	err := s.targetErr
+	s.mu.Unlock()
+	if err != nil {
+		return store.Sprint{}, err
+	}
+	return s.Store.GetSprintByID(ctx, sprintID)
+}
+
+func (s *sprintDefinitionRESTStore) CreateSprint(ctx context.Context, projectID int64, name string, plannedStartAt, plannedEndAt time.Time) (store.Sprint, error) {
+	if !s.record("create") {
+		return s.Store.CreateSprint(ctx, projectID, name, plannedStartAt, plannedEndAt)
+	}
+	s.mu.Lock()
+	s.createCalls++
+	s.createPID = projectID
+	s.createName = name
+	s.createStart = plannedStartAt
+	s.createEnd = plannedEndAt
+	err := s.createErr
+	s.mu.Unlock()
+	if err != nil {
+		return store.Sprint{}, err
+	}
+	return s.Store.CreateSprint(ctx, projectID, name, plannedStartAt, plannedEndAt)
+}
+
+func (s *sprintDefinitionRESTStore) UpdateSprint(ctx context.Context, sprintID int64, in store.UpdateSprintInput) error {
+	if !s.record("update") {
+		return s.Store.UpdateSprint(ctx, sprintID, in)
+	}
+	s.mu.Lock()
+	s.updateCalls++
+	s.updateID = sprintID
+	s.updateInput = in
+	err := s.updateErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.Store.UpdateSprint(ctx, sprintID, in)
+}
+
+type sprintDefinitionRESTFixture struct {
+	ts        *httptest.Server
+	db        *sql.DB
+	st        *store.Store
+	wrapped   *sprintDefinitionRESTStore
+	client    *http.Client
+	ownerID   int64
+	ctx       context.Context
+	project   store.Project
+	projectPC store.ProjectContext
+	collector *sprintDefinitionRESTEventCollector
+}
+
+func newSprintDefinitionRESTFixture(t *testing.T, name string) *sprintDefinitionRESTFixture {
+	t.Helper()
+
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "app.db"), db.Options{
+		BusyTimeout: 5000,
+		JournalMode: "WAL",
+		Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := migrate.Apply(context.Background(), sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+	st := store.New(sqlDB, nil)
+	wrapped := &sprintDefinitionRESTStore{Store: st}
+	srv := NewServer(wrapped, Options{MaxRequestBody: 1 << 20, ScrumboyMode: "full"})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(func() {
+		ts.Close()
+		_ = sqlDB.Close()
+	})
+
+	client := newCookieClient(t)
+	owner := bootstrapUserClient(t, client, ts.URL, "Sprint Owner", name+"@example.com", "password123")
+	ownerID := int64(owner["id"].(float64))
+	ctx := store.WithUserID(context.Background(), ownerID)
+	project, err := st.CreateProject(ctx, name)
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	pc, err := st.GetProjectContextBySlug(ctx, project.Slug, store.ModeFull)
+	if err != nil {
+		t.Fatalf("GetProjectContextBySlug: %v", err)
+	}
+
+	collector := &sprintDefinitionRESTEventCollector{}
+	srv.fanout = eventbus.NewFanout(collector)
+
+	return &sprintDefinitionRESTFixture{
+		ts: ts, db: sqlDB, st: st, wrapped: wrapped, client: client,
+		ownerID: ownerID, ctx: ctx, project: project, projectPC: pc, collector: collector,
+	}
+}
+
+func (fx *sprintDefinitionRESTFixture) createURL() string {
+	return fx.ts.URL + "/api/board/" + fx.project.Slug + "/sprints"
+}
+
+func (fx *sprintDefinitionRESTFixture) updateURL(sprintID int64) string {
+	return fmt.Sprintf("%s/api/board/%s/sprints/%d", fx.ts.URL, fx.project.Slug, sprintID)
+}
+
+func createSprintDefinitionRESTSprint(t *testing.T, fx *sprintDefinitionRESTFixture, name string) store.Sprint {
+	t.Helper()
+	start := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
+	sp, err := fx.st.CreateSprint(fx.ctx, fx.project.ID, name, start, start.Add(7*24*time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSprint fixture: %v", err)
+	}
+	return sp
+}
+
+func assertSprintDefinitionRESTTrace(t *testing.T, wrapped *sprintDefinitionRESTStore, want ...string) {
+	t.Helper()
+	if got := wrapped.snapshotTrace(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("store trace=%v, want %v", got, want)
+	}
+}
+
+func assertSprintDefinitionRESTError(t *testing.T, resp *http.Response, got apiErrorEnvelope, wantStatus int, wantCode, wantMessage string, wantDetail *string) {
+	t.Helper()
+	if resp.StatusCode != wantStatus || got.Error.Code != wantCode || got.Error.Message != wantMessage {
+		t.Fatalf("error status=%d envelope=%+v, want status=%d code=%q message=%q", resp.StatusCode, got, wantStatus, wantCode, wantMessage)
+	}
+	if wantDetail == nil {
+		if got.Error.Details != nil {
+			t.Fatalf("error details=%+v, want null", got.Error.Details)
+		}
+		return
+	}
+	if got.Error.Details == nil || got.Error.Details["detail"] != *wantDetail {
+		t.Fatalf("error details=%+v, want detail=%q", got.Error.Details, *wantDetail)
+	}
+}
+
+func assertSprintDefinitionRESTRefresh(t *testing.T, fx *sprintDefinitionRESTFixture, reason string) {
+	t.Helper()
+	events := fx.collector.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("events=%+v, want one board refresh", events)
+	}
+	event := events[0]
+	if event.Type != "board.refresh_needed" || event.ProjectID != fx.project.ID {
+		t.Fatalf("event=%+v, want board.refresh_needed for project %d", event, fx.project.ID)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("decode refresh payload: %v", err)
+	}
+	if payload["reason"] != reason || int64(payload["actorUserId"].(float64)) != fx.ownerID {
+		t.Fatalf("refresh payload=%+v, want reason=%q actor=%d", payload, reason, fx.ownerID)
+	}
+}
+
+func assertSprintDefinitionRESTSilence(t *testing.T, fx *sprintDefinitionRESTFixture) {
+	t.Helper()
+	if events := fx.collector.snapshot(); len(events) != 0 {
+		t.Fatalf("unexpected sprint refresh events: %+v", events)
+	}
+}
+
+func sprintDefinitionRESTSessionClient(t *testing.T, fx *sprintDefinitionRESTFixture, userID int64) *http.Client {
+	t.Helper()
+	token, expiresAt, err := fx.st.CreateSession(context.Background(), userID, time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookie jar: %v", err)
+	}
+	base, err := url.Parse(fx.ts.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	jar.SetCookies(base, []*http.Cookie{{Name: "scrumboy_session", Value: token, Path: "/", Expires: expiresAt}})
+	return &http.Client{Transport: fx.ts.Client().Transport, Jar: jar}
+}
+
+func TestSprintDefinitionRESTCreateAndUpdateContracts(t *testing.T) {
+	t.Run("create uses Unix milliseconds and publishes once after one store call", func(t *testing.T) {
+		fx := newSprintDefinitionRESTFixture(t, "rest-sprint-definition-create")
+		start := time.Date(2026, time.August, 11, 13, 14, 15, 321000000, time.UTC)
+		end := start.Add(9 * 24 * time.Hour)
+		fx.wrapped.activate()
+
+		var got sprintJSON
+		resp, body := doJSON(t, fx.client, http.MethodPost, fx.createURL(), map[string]any{
+			"name": "  REST definition  ", "plannedStartAt": start.UnixMilli(), "plannedEndAt": end.UnixMilli(),
+		}, &got)
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("create status=%d body=%s", resp.StatusCode, body)
+		}
+		if got.ProjectID != fx.project.ID || got.Name != "REST definition" || got.PlannedStartAt != start.UnixMilli() || got.PlannedEndAt != end.UnixMilli() || got.State != store.SprintStatePlanned {
+			t.Fatalf("created sprint=%+v", got)
+		}
+		assertSprintDefinitionRESTTrace(t, fx.wrapped, "access", "role", "create")
+		if fx.wrapped.accessSlug != fx.project.Slug || fx.wrapped.accessMode != store.ModeFull {
+			t.Fatalf("access=(slug=%q mode=%q), want (%q,%q)", fx.wrapped.accessSlug, fx.wrapped.accessMode, fx.project.Slug, store.ModeFull)
+		}
+		if fx.wrapped.rolePID != fx.project.ID || fx.wrapped.roleUID != fx.ownerID {
+			t.Fatalf("role args=(%d,%d), want (%d,%d)", fx.wrapped.rolePID, fx.wrapped.roleUID, fx.project.ID, fx.ownerID)
+		}
+		if fx.wrapped.createCalls != 1 || fx.wrapped.createPID != fx.project.ID || fx.wrapped.createName != "  REST definition  " || !fx.wrapped.createStart.Equal(start) || !fx.wrapped.createEnd.Equal(end) {
+			t.Fatalf("create call=(count=%d project=%d name=%q start=%s end=%s)", fx.wrapped.createCalls, fx.wrapped.createPID, fx.wrapped.createName, fx.wrapped.createStart, fx.wrapped.createEnd)
+		}
+		assertSprintDefinitionRESTRefresh(t, fx, "sprint_created")
+	})
+
+	t.Run("non-empty update binds stored ID and performs no route post-read", func(t *testing.T) {
+		fx := newSprintDefinitionRESTFixture(t, "rest-sprint-definition-update")
+		offsetProject, err := fx.st.CreateProject(fx.ctx, "rest-sprint-definition-update-offset")
+		if err != nil {
+			t.Fatalf("CreateProject offset: %v", err)
+		}
+		offsetStart := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+		if _, err := fx.st.CreateSprint(fx.ctx, offsetProject.ID, "Offset sprint", offsetStart, offsetStart.Add(24*time.Hour)); err != nil {
+			t.Fatalf("CreateSprint offset: %v", err)
+		}
+		sp := createSprintDefinitionRESTSprint(t, fx, "Before update")
+		if sp.ID == sp.Number {
+			t.Fatalf("identity fixture requires stored ID and project-local number to differ, sprint=%+v", sp)
+		}
+		newName := "After update"
+		newStart := sp.PlannedStartAt.Add(24 * time.Hour)
+		newEnd := sp.PlannedEndAt.Add(48 * time.Hour)
+		fx.wrapped.activate()
+
+		resp, body := doJSON(t, fx.client, http.MethodPatch, fx.updateURL(sp.ID), map[string]any{
+			"name": newName, "plannedStartAt": newStart.UnixMilli(), "plannedEndAt": newEnd.UnixMilli(),
+		}, nil)
+		if resp.StatusCode != http.StatusNoContent || len(body) != 0 {
+			t.Fatalf("update status=%d body=%q", resp.StatusCode, body)
+		}
+		assertSprintDefinitionRESTTrace(t, fx.wrapped, "access", "target", "role", "update")
+		if fx.wrapped.targetReads != 1 || fx.wrapped.targetID != sp.ID || fx.wrapped.updateCalls != 1 || fx.wrapped.updateID != sp.ID {
+			t.Fatalf("target/update=(reads=%d targetID=%d calls=%d updateID=%d), want stored ID %d exactly once", fx.wrapped.targetReads, fx.wrapped.targetID, fx.wrapped.updateCalls, fx.wrapped.updateID, sp.ID)
+		}
+		in := fx.wrapped.updateInput
+		if in.Name == nil || *in.Name != newName || in.PlannedStartAt == nil || !in.PlannedStartAt.Equal(newStart) || in.PlannedEndAt == nil || !in.PlannedEndAt.Equal(newEnd) {
+			t.Fatalf("update input=%+v", in)
+		}
+		stored, err := fx.st.GetSprintByID(fx.ctx, sp.ID)
+		if err != nil {
+			t.Fatalf("GetSprintByID: %v", err)
+		}
+		if stored.Name != newName || !stored.PlannedStartAt.Equal(newStart) || !stored.PlannedEndAt.Equal(newEnd) {
+			t.Fatalf("stored sprint=%+v", stored)
+		}
+		assertSprintDefinitionRESTRefresh(t, fx, "sprint_updated")
+	})
+
+	t.Run("empty update still calls store and publishes without post-read", func(t *testing.T) {
+		fx := newSprintDefinitionRESTFixture(t, "rest-sprint-definition-empty")
+		sp := createSprintDefinitionRESTSprint(t, fx, "Empty update")
+		fx.wrapped.activate()
+
+		resp, body := doJSON(t, fx.client, http.MethodPatch, fx.updateURL(sp.ID), map[string]any{}, nil)
+		if resp.StatusCode != http.StatusNoContent || len(body) != 0 {
+			t.Fatalf("empty update status=%d body=%q", resp.StatusCode, body)
+		}
+		assertSprintDefinitionRESTTrace(t, fx.wrapped, "access", "target", "role", "update")
+		if fx.wrapped.updateCalls != 1 || fx.wrapped.targetReads != 1 {
+			t.Fatalf("empty update calls=%d targetReads=%d, want one each", fx.wrapped.updateCalls, fx.wrapped.targetReads)
+		}
+		if in := fx.wrapped.updateInput; in.Name != nil || in.PlannedStartAt != nil || in.PlannedEndAt != nil {
+			t.Fatalf("empty update input=%+v", in)
+		}
+		assertSprintDefinitionRESTRefresh(t, fx, "sprint_updated")
+	})
+}
+
+func TestSprintDefinitionRESTAuthorityAndInputContracts(t *testing.T) {
+	t.Run("signed out full-mode access hides project before actor extraction", func(t *testing.T) {
+		fx := newSprintDefinitionRESTFixture(t, "rest-sprint-definition-signed-out")
+		fx.wrapped.activate()
+		var got apiErrorEnvelope
+		resp, _ := doJSON(t, fx.ts.Client(), http.MethodPost, fx.createURL(), map[string]any{
+			"name": "Denied", "plannedStartAt": int64(1), "plannedEndAt": int64(2),
+		}, &got)
+		assertSprintDefinitionRESTError(t, resp, got, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+		assertSprintDefinitionRESTTrace(t, fx.wrapped, "access")
+		assertSprintDefinitionRESTSilence(t, fx)
+	})
+
+	t.Run("actor absence after a successful access result returns unauthorized", func(t *testing.T) {
+		fx := newSprintDefinitionRESTFixture(t, "rest-sprint-definition-actor")
+		fx.wrapped.accessOverride = &fx.projectPC
+		fx.wrapped.activate()
+		var got apiErrorEnvelope
+		resp, _ := doJSON(t, fx.ts.Client(), http.MethodPost, fx.createURL(), map[string]any{
+			"name": "Denied", "plannedStartAt": int64(1), "plannedEndAt": int64(2),
+		}, &got)
+		assertSprintDefinitionRESTError(t, resp, got, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
+		assertSprintDefinitionRESTTrace(t, fx.wrapped, "access")
+		assertSprintDefinitionRESTSilence(t, fx)
+	})
+
+	t.Run("viewer is denied by the fresh role lookup", func(t *testing.T) {
+		fx := newSprintDefinitionRESTFixture(t, "rest-sprint-definition-viewer")
+		viewer, err := fx.st.CreateUser(context.Background(), "rest-sprint-viewer@example.com", "password123", "Viewer")
+		if err != nil {
+			t.Fatalf("CreateUser: %v", err)
+		}
+		if err := fx.st.AddProjectMember(fx.ctx, fx.ownerID, fx.project.ID, viewer.ID, store.RoleViewer); err != nil {
+			t.Fatalf("AddProjectMember: %v", err)
+		}
+		client := sprintDefinitionRESTSessionClient(t, fx, viewer.ID)
+		fx.wrapped.activate()
+		var got apiErrorEnvelope
+		resp, _ := doJSON(t, client, http.MethodPost, fx.createURL(), map[string]any{
+			"name": "Denied", "plannedStartAt": int64(1), "plannedEndAt": int64(2),
+		}, &got)
+		assertSprintDefinitionRESTError(t, resp, got, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
+		assertSprintDefinitionRESTTrace(t, fx.wrapped, "access", "role")
+		if fx.wrapped.roleUID != viewer.ID {
+			t.Fatalf("role user=%d, want viewer %d", fx.wrapped.roleUID, viewer.ID)
+		}
+		assertSprintDefinitionRESTSilence(t, fx)
+	})
+
+	t.Run("cross-project target is rejected before role and body", func(t *testing.T) {
+		fx := newSprintDefinitionRESTFixture(t, "rest-sprint-definition-cross-project")
+		other, err := fx.st.CreateProject(fx.ctx, "rest-sprint-definition-other-project")
+		if err != nil {
+			t.Fatalf("CreateProject other: %v", err)
+		}
+		start := time.Date(2026, time.August, 12, 0, 0, 0, 0, time.UTC)
+		foreign, err := fx.st.CreateSprint(fx.ctx, other.ID, "Foreign", start, start.Add(24*time.Hour))
+		if err != nil {
+			t.Fatalf("CreateSprint other: %v", err)
+		}
+		fx.wrapped.activate()
+		var got apiErrorEnvelope
+		resp, _ := doJSON(t, fx.client, http.MethodPatch, fx.updateURL(foreign.ID), map[string]any{"name": "Should not decode"}, &got)
+		assertSprintDefinitionRESTError(t, resp, got, http.StatusNotFound, "NOT_FOUND", "sprint not found", nil)
+		assertSprintDefinitionRESTTrace(t, fx.wrapped, "access", "target")
+		assertSprintDefinitionRESTSilence(t, fx)
+	})
+
+	t.Run("state is not a public definition patch field", func(t *testing.T) {
+		fx := newSprintDefinitionRESTFixture(t, "rest-sprint-definition-state-field")
+		sp := createSprintDefinitionRESTSprint(t, fx, "No state patch")
+		fx.wrapped.activate()
+		var got apiErrorEnvelope
+		resp, _ := doJSON(t, fx.client, http.MethodPatch, fx.updateURL(sp.ID), map[string]any{"state": "ACTIVE"}, &got)
+		if resp.StatusCode != http.StatusBadRequest || got.Error.Code != "VALIDATION_ERROR" || got.Error.Message != "invalid json" || got.Error.Details["reason"] != "invalid_json" {
+			t.Fatalf("state patch response status=%d envelope=%+v", resp.StatusCode, got)
+		}
+		assertSprintDefinitionRESTTrace(t, fx.wrapped, "access", "target", "role")
+		if fx.wrapped.updateCalls != 0 {
+			t.Fatalf("state patch update calls=%d, want zero", fx.wrapped.updateCalls)
+		}
+		assertSprintDefinitionRESTSilence(t, fx)
+	})
+
+	t.Run("create validation ownership preserves route and store distinctions", func(t *testing.T) {
+		for _, tc := range []struct {
+			name        string
+			body        map[string]any
+			wantMessage string
+			wantReason  string
+			wantTrace   []string
+		}{
+			{name: "missing name", body: map[string]any{"plannedStartAt": int64(1), "plannedEndAt": int64(2)}, wantMessage: "name required", wantReason: "name_required", wantTrace: []string{"access", "role"}},
+			{name: "whitespace name reaches store", body: map[string]any{"name": "   ", "plannedStartAt": int64(1), "plannedEndAt": int64(2)}, wantMessage: "validation: invalid sprint name", wantReason: "invalid_sprint_name", wantTrace: []string{"access", "role", "create"}},
+			{name: "reversed dates reach store", body: map[string]any{"name": "Reverse", "plannedStartAt": int64(2), "plannedEndAt": int64(1)}, wantMessage: "validation: end_at must be >= start_at", wantReason: "sprint_end_before_start", wantTrace: []string{"access", "role", "create"}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				fx := newSprintDefinitionRESTFixture(t, "rest-sprint-definition-validation-"+strings.ReplaceAll(tc.name, " ", "-"))
+				fx.wrapped.activate()
+				var got apiErrorEnvelope
+				resp, _ := doJSON(t, fx.client, http.MethodPost, fx.createURL(), tc.body, &got)
+				if resp.StatusCode != http.StatusBadRequest || got.Error.Code != "VALIDATION_ERROR" || got.Error.Message != tc.wantMessage || got.Error.Details["reason"] != tc.wantReason {
+					t.Fatalf("validation status=%d envelope=%+v", resp.StatusCode, got)
+				}
+				assertSprintDefinitionRESTTrace(t, fx.wrapped, tc.wantTrace...)
+				assertSprintDefinitionRESTSilence(t, fx)
+			})
+		}
+	})
+}
+
+func TestSprintDefinitionRESTCancellationContract(t *testing.T) {
+	canceledText := context.Canceled.Error()
+
+	for _, operation := range []string{"create", "update"} {
+		for _, stage := range []string{"access", "role", "mutation"} {
+			t.Run(operation+"/"+stage, func(t *testing.T) {
+				fx := newSprintDefinitionRESTFixture(t, "rest-sprint-definition-cancel-"+operation+"-"+stage)
+				var sp store.Sprint
+				if operation == "update" {
+					sp = createSprintDefinitionRESTSprint(t, fx, "Before canceled update")
+				}
+				switch stage {
+				case "access":
+					fx.wrapped.accessErr = context.Canceled
+				case "role":
+					fx.wrapped.roleErr = context.Canceled
+				case "mutation":
+					if operation == "create" {
+						fx.wrapped.createErr = context.Canceled
+					} else {
+						fx.wrapped.updateErr = context.Canceled
+					}
+				}
+				fx.wrapped.activate()
+
+				var got apiErrorEnvelope
+				var resp *http.Response
+				if operation == "create" {
+					resp, _ = doJSON(t, fx.client, http.MethodPost, fx.createURL(), map[string]any{"name": "Canceled", "plannedStartAt": int64(1), "plannedEndAt": int64(2)}, &got)
+				} else {
+					resp, _ = doJSON(t, fx.client, http.MethodPatch, fx.updateURL(sp.ID), map[string]any{"name": "Canceled"}, &got)
+				}
+
+				if stage == "role" {
+					assertSprintDefinitionRESTError(t, resp, got, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
+				} else {
+					assertSprintDefinitionRESTError(t, resp, got, http.StatusInternalServerError, "INTERNAL", "internal error", &canceledText)
+				}
+
+				wantTrace := []string{"access"}
+				if operation == "update" && stage != "access" {
+					wantTrace = append(wantTrace, "target")
+				}
+				if stage == "role" || stage == "mutation" {
+					wantTrace = append(wantTrace, "role")
+				}
+				if stage == "mutation" {
+					wantTrace = append(wantTrace, operation)
+				}
+				assertSprintDefinitionRESTTrace(t, fx.wrapped, wantTrace...)
+				assertSprintDefinitionRESTSilence(t, fx)
+				if operation == "create" {
+					var count int
+					if err := fx.db.QueryRow(`SELECT COUNT(*) FROM sprints WHERE project_id = ?`, fx.project.ID).Scan(&count); err != nil {
+						t.Fatalf("count sprints: %v", err)
+					}
+					if count != 0 {
+						t.Fatalf("canceled create rows=%d, want zero", count)
+					}
+				} else if stored, err := fx.st.GetSprintByID(fx.ctx, sp.ID); err != nil || stored.Name != sp.Name {
+					t.Fatalf("canceled update stored=%+v err=%v, want unchanged", stored, err)
+				}
+			})
+		}
+	}
+
+	t.Run("update target", func(t *testing.T) {
+		fx := newSprintDefinitionRESTFixture(t, "rest-sprint-definition-cancel-target")
+		sp := createSprintDefinitionRESTSprint(t, fx, "Target canceled")
+		fx.wrapped.targetErr = context.Canceled
+		fx.wrapped.activate()
+		var got apiErrorEnvelope
+		resp, _ := doJSON(t, fx.client, http.MethodPatch, fx.updateURL(sp.ID), map[string]any{"name": "Never"}, &got)
+		assertSprintDefinitionRESTError(t, resp, got, http.StatusInternalServerError, "INTERNAL", "internal error", &canceledText)
+		assertSprintDefinitionRESTTrace(t, fx.wrapped, "access", "target")
+		assertSprintDefinitionRESTSilence(t, fx)
+	})
+}
+
+func TestSprintDefinitionRESTCommittedCreateFailureContract(t *testing.T) {
+	fx := newSprintDefinitionRESTFixture(t, "rest-sprint-definition-committed-failure")
+	const corruptValue = "rest-create-return-read-failed"
+	if _, err := fx.db.Exec(`
+		CREATE TRIGGER sprint_definition_rest_corrupt_created_row
+		AFTER INSERT ON sprints
+		BEGIN
+			UPDATE sprints SET planned_start_at = '` + corruptValue + `' WHERE id = NEW.id;
+		END
+	`); err != nil {
+		t.Fatalf("create post-insert fault trigger: %v", err)
+	}
+	fx.wrapped.activate()
+
+	var got apiErrorEnvelope
+	resp, _ := doJSON(t, fx.client, http.MethodPost, fx.createURL(), map[string]any{
+		"name": "Committed REST failure", "plannedStartAt": int64(1000), "plannedEndAt": int64(2000),
+	}, &got)
+	if resp.StatusCode != http.StatusInternalServerError || got.Error.Code != "INTERNAL" || got.Error.Message != "internal error" {
+		t.Fatalf("committed create response status=%d envelope=%+v", resp.StatusCode, got)
+	}
+	detail, _ := got.Error.Details["detail"].(string)
+	if !strings.Contains(detail, "get sprint") || !strings.Contains(detail, corruptValue) {
+		t.Fatalf("committed create public detail=%q, want current return-read diagnostic", detail)
+	}
+	assertSprintDefinitionRESTTrace(t, fx.wrapped, "access", "role", "create")
+	if fx.wrapped.createCalls != 1 {
+		t.Fatalf("create calls=%d, want one with no retry", fx.wrapped.createCalls)
+	}
+	var count int
+	if err := fx.db.QueryRow(`SELECT COUNT(*) FROM sprints WHERE project_id = ? AND name = ?`, fx.project.ID, "Committed REST failure").Scan(&count); err != nil {
+		t.Fatalf("count committed sprint: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("committed sprint rows=%d, want one", count)
+	}
+	assertSprintDefinitionRESTSilence(t, fx)
+}
+
+func TestSprintDefinitionRESTRoleCancellationMatchesInsufficientRole(t *testing.T) {
+	for _, roleResult := range []string{"canceled", "viewer"} {
+		t.Run(roleResult, func(t *testing.T) {
+			fx := newSprintDefinitionRESTFixture(t, "rest-sprint-definition-role-"+roleResult)
+			if roleResult == "canceled" {
+				fx.wrapped.roleErr = context.Canceled
+			} else {
+				viewer, err := fx.st.CreateUser(context.Background(), "rest-role-collapse-viewer@example.com", "password123", "Viewer")
+				if err != nil {
+					t.Fatalf("CreateUser: %v", err)
+				}
+				if err := fx.st.AddProjectMember(fx.ctx, fx.ownerID, fx.project.ID, viewer.ID, store.RoleViewer); err != nil {
+					t.Fatalf("AddProjectMember: %v", err)
+				}
+				fx.client = sprintDefinitionRESTSessionClient(t, fx, viewer.ID)
+			}
+			fx.wrapped.activate()
+			var got apiErrorEnvelope
+			resp, _ := doJSON(t, fx.client, http.MethodPost, fx.createURL(), map[string]any{"name": "Denied", "plannedStartAt": int64(1), "plannedEndAt": int64(2)}, &got)
+			assertSprintDefinitionRESTError(t, resp, got, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
+			assertSprintDefinitionRESTTrace(t, fx.wrapped, "access", "role")
+			assertSprintDefinitionRESTSilence(t, fx)
+		})
+	}
+}
+
+func TestSprintDefinitionRESTDefinitionFieldsRespectExistingSprintState(t *testing.T) {
+	start := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name        string
+		state       string
+		body        map[string]any
+		wantStatus  int
+		wantName    string
+		wantMessage string
+		wantReason  string
+	}{
+		{name: "planned name", state: store.SprintStatePlanned, body: map[string]any{"name": "Planned renamed"}, wantStatus: http.StatusNoContent, wantName: "Planned renamed"},
+		{name: "active end", state: store.SprintStateActive, body: map[string]any{"plannedEndAt": start.Add(9 * 24 * time.Hour).UnixMilli()}, wantStatus: http.StatusNoContent, wantName: "State fixture"},
+		{name: "active name rejected", state: store.SprintStateActive, body: map[string]any{"name": "No active rename"}, wantStatus: http.StatusBadRequest, wantName: "State fixture", wantMessage: "validation: only endAt can be updated for ACTIVE sprint", wantReason: "active_sprint_only_end_at"},
+		{name: "closed name", state: store.SprintStateClosed, body: map[string]any{"name": "Closed renamed"}, wantStatus: http.StatusNoContent, wantName: "Closed renamed"},
+		{name: "closed end rejected", state: store.SprintStateClosed, body: map[string]any{"plannedEndAt": start.Add(10 * 24 * time.Hour).UnixMilli()}, wantStatus: http.StatusBadRequest, wantName: "State fixture", wantMessage: "validation: dates cannot be updated for CLOSED sprint", wantReason: "closed_sprint_dates_locked"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newSprintDefinitionRESTFixture(t, "rest-sprint-definition-state-"+strings.ReplaceAll(tc.name, " ", "-"))
+			sp, err := fx.st.CreateSprint(fx.ctx, fx.project.ID, "State fixture", start, start.Add(7*24*time.Hour))
+			if err != nil {
+				t.Fatalf("CreateSprint: %v", err)
+			}
+			if tc.state != store.SprintStatePlanned {
+				var started any
+				var closed any
+				if tc.state == store.SprintStateActive {
+					started = start.UnixMilli()
+				} else {
+					started = start.UnixMilli()
+					closed = start.Add(24 * time.Hour).UnixMilli()
+				}
+				if _, err := fx.db.Exec(`UPDATE sprints SET state = ?, started_at = ?, closed_at = ? WHERE id = ?`, tc.state, started, closed, sp.ID); err != nil {
+					t.Fatalf("set state fixture: %v", err)
+				}
+			}
+			fx.wrapped.activate()
+			var got apiErrorEnvelope
+			resp, _ := doJSON(t, fx.client, http.MethodPatch, fx.updateURL(sp.ID), tc.body, &got)
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("state update status=%d envelope=%+v, want %d", resp.StatusCode, got, tc.wantStatus)
+			}
+			stored, err := fx.st.GetSprintByID(fx.ctx, sp.ID)
+			if err != nil {
+				t.Fatalf("GetSprintByID: %v", err)
+			}
+			if stored.Name != tc.wantName || stored.State != tc.state {
+				t.Fatalf("stored sprint=%+v, want name=%q state=%q", stored, tc.wantName, tc.state)
+			}
+			if tc.wantStatus == http.StatusNoContent {
+				assertSprintDefinitionRESTRefresh(t, fx, "sprint_updated")
+			} else {
+				if got.Error.Code != "VALIDATION_ERROR" || got.Error.Message != tc.wantMessage || got.Error.Details["reason"] != tc.wantReason {
+					t.Fatalf("state validation envelope=%+v, want message=%q reason=%q", got, tc.wantMessage, tc.wantReason)
+				}
+				assertSprintDefinitionRESTSilence(t, fx)
+			}
+			assertSprintDefinitionRESTTrace(t, fx.wrapped, "access", "target", "role", "update")
+		})
+	}
+}

--- a/internal/httpapi/sprint_lifecycle_transport_contract_test.go
+++ b/internal/httpapi/sprint_lifecycle_transport_contract_test.go
@@ -68,6 +68,7 @@ type sprintLifecycleRESTStore struct {
 	activatePID   int64
 	activateID    int64
 	closeCalls    int
+	closePID      int64
 	closeID       int64
 	deleteCalls   int
 	deletePID     int64
@@ -171,19 +172,20 @@ func (s *sprintLifecycleRESTStore) ActivateSprint(ctx context.Context, projectID
 	return s.Store.ActivateSprint(ctx, projectID, sprintID)
 }
 
-func (s *sprintLifecycleRESTStore) CloseSprint(ctx context.Context, sprintID int64) error {
+func (s *sprintLifecycleRESTStore) CloseSprint(ctx context.Context, projectID, sprintID int64) error {
 	if !s.record("close") {
-		return s.Store.CloseSprint(ctx, sprintID)
+		return s.Store.CloseSprint(ctx, projectID, sprintID)
 	}
 	s.mu.Lock()
 	s.closeCalls++
+	s.closePID = projectID
 	s.closeID = sprintID
 	err := s.closeErr
 	s.mu.Unlock()
 	if err != nil {
 		return err
 	}
-	return s.Store.CloseSprint(ctx, sprintID)
+	return s.Store.CloseSprint(ctx, projectID, sprintID)
 }
 
 func (s *sprintLifecycleRESTStore) DeleteSprint(ctx context.Context, projectID, sprintID int64) error {
@@ -326,7 +328,7 @@ func createSprintLifecycleRESTSprint(t *testing.T, fx *sprintLifecycleRESTFixtur
 		}
 	}
 	if state == store.SprintStateClosed {
-		if err := fx.st.CloseSprint(fx.ownerCtx, sp.ID); err != nil {
+		if err := fx.st.CloseSprint(fx.ownerCtx, fx.project.ID, sp.ID); err != nil {
 			t.Fatalf("CloseSprint setup: %v", err)
 		}
 	}
@@ -542,9 +544,9 @@ func TestSprintLifecycleRESTCloseContract(t *testing.T) {
 		if resp.StatusCode != http.StatusNoContent || len(body) != 0 {
 			t.Fatalf("close status=%d body=%q", resp.StatusCode, body)
 		}
-		assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "close")
-		if fx.wrapped.targetReads != 0 || fx.wrapped.closeCalls != 1 || fx.wrapped.closeID != sp.ID {
-			t.Fatalf("close observations=(targetReads=%d calls=%d id=%d)", fx.wrapped.targetReads, fx.wrapped.closeCalls, fx.wrapped.closeID)
+		assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "target", "close")
+		if fx.wrapped.targetReads != 1 || !reflect.DeepEqual(fx.wrapped.targetIDs, []int64{sp.ID}) || fx.wrapped.closeCalls != 1 || fx.wrapped.closePID != fx.project.ID || fx.wrapped.closeID != sp.ID {
+			t.Fatalf("close observations=(targetReads=%d ids=%v calls=%d project=%d sprint=%d)", fx.wrapped.targetReads, fx.wrapped.targetIDs, fx.wrapped.closeCalls, fx.wrapped.closePID, fx.wrapped.closeID)
 		}
 		after := getSprintLifecycleRESTSprint(t, fx, sp.ID)
 		if after.State != store.SprintStateClosed || after.ClosedAt == nil || before.StartedAt == nil || after.StartedAt == nil || !after.StartedAt.Equal(*before.StartedAt) {
@@ -563,9 +565,9 @@ func TestSprintLifecycleRESTCloseContract(t *testing.T) {
 			var got apiErrorEnvelope
 			resp, _ := doJSON(t, fx.client, http.MethodPost, fx.actionURL(sp.ID, "close"), map[string]any{}, &got)
 			assertSprintLifecycleRESTError(t, resp, got, http.StatusNotFound, "NOT_FOUND", "not found", nil)
-			assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "close")
-			if fx.wrapped.closeCalls != 1 || !reflect.DeepEqual(getSprintLifecycleRESTSprint(t, fx, sp.ID), before) {
-				t.Fatalf("failed close calls=%d or changed state", fx.wrapped.closeCalls)
+			assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "target", "close")
+			if fx.wrapped.targetReads != 1 || !reflect.DeepEqual(fx.wrapped.targetIDs, []int64{sp.ID}) || fx.wrapped.closeCalls != 1 || fx.wrapped.closePID != fx.project.ID || fx.wrapped.closeID != sp.ID || !reflect.DeepEqual(getSprintLifecycleRESTSprint(t, fx, sp.ID), before) {
+				t.Fatalf("failed close observations=(reads=%d ids=%v calls=%d project=%d sprint=%d) or changed state", fx.wrapped.targetReads, fx.wrapped.targetIDs, fx.wrapped.closeCalls, fx.wrapped.closePID, fx.wrapped.closeID)
 			}
 			assertSprintLifecycleRESTSilence(t, fx)
 		})
@@ -577,17 +579,17 @@ func TestSprintLifecycleRESTCloseContract(t *testing.T) {
 		var got apiErrorEnvelope
 		resp, _ := doJSON(t, fx.client, http.MethodPost, fx.actionURL(900002, "close"), map[string]any{}, &got)
 		assertSprintLifecycleRESTError(t, resp, got, http.StatusNotFound, "NOT_FOUND", "not found", nil)
-		assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "close")
-		if fx.wrapped.closeCalls != 1 {
-			t.Fatalf("missing close calls=%d, want one", fx.wrapped.closeCalls)
+		assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "target")
+		if fx.wrapped.targetReads != 1 || !reflect.DeepEqual(fx.wrapped.targetIDs, []int64{900002}) || fx.wrapped.closeCalls != 0 {
+			t.Fatalf("missing close observations=(reads=%d ids=%v calls=%d)", fx.wrapped.targetReads, fx.wrapped.targetIDs, fx.wrapped.closeCalls)
 		}
 		assertSprintLifecycleRESTSilence(t, fx)
 	})
 }
 
-func TestSprintLifecycleRESTCloseCrossProjectExploitCurrentBehavior(t *testing.T) {
-	fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-close-exploit-route-a")
-	projectB, err := fx.st.CreateProject(fx.ownerCtx, "rest-lifecycle-close-exploit-project-b")
+func TestSprintLifecycleRESTCloseRejectsForeignProjectTarget(t *testing.T) {
+	fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-close-foreign-route-a")
+	projectB, err := fx.st.CreateProject(fx.ownerCtx, "rest-lifecycle-close-foreign-project-b")
 	if err != nil {
 		t.Fatalf("CreateProject B: %v", err)
 	}
@@ -612,21 +614,20 @@ func TestSprintLifecycleRESTCloseCrossProjectExploitCurrentBehavior(t *testing.T
 	}
 	fx.wrapped.activateTrace()
 
-	resp, body := doJSON(t, fx.client, http.MethodPost, fx.actionURL(foreign.ID, "close"), map[string]any{}, nil)
-	if resp.StatusCode != http.StatusNoContent || len(body) != 0 {
-		t.Fatalf("cross-project close status=%d body=%q, want current 204 empty behavior", resp.StatusCode, body)
+	var got apiErrorEnvelope
+	resp, _ := doJSON(t, fx.client, http.MethodPost, fx.actionURL(foreign.ID, "close"), map[string]any{}, &got)
+	assertSprintLifecycleRESTError(t, resp, got, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+	assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "target")
+	if fx.wrapped.rolePID != fx.project.ID || fx.wrapped.roleUID != fx.actorID || fx.wrapped.targetReads != 1 || !reflect.DeepEqual(fx.wrapped.targetIDs, []int64{foreign.ID}) || fx.wrapped.closeCalls != 0 {
+		t.Fatalf("cross-project observations=(roleProject=%d actor=%d reads=%d ids=%v calls=%d)", fx.wrapped.rolePID, fx.wrapped.roleUID, fx.wrapped.targetReads, fx.wrapped.targetIDs, fx.wrapped.closeCalls)
 	}
-	assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "close")
-	if fx.wrapped.rolePID != fx.project.ID || fx.wrapped.roleUID != fx.actorID || fx.wrapped.closeCalls != 1 || fx.wrapped.closeID != foreign.ID {
-		t.Fatalf("cross-project observations=(roleProject=%d actor=%d calls=%d sprint=%d)", fx.wrapped.rolePID, fx.wrapped.roleUID, fx.wrapped.closeCalls, fx.wrapped.closeID)
+	if after := getSprintLifecycleRESTSprint(t, fx, foreign.ID); after.ProjectID != projectB.ID || after.State != store.SprintStateActive || after.ClosedAt != nil {
+		t.Fatalf("foreign sprint changed after rejection=%+v", after)
 	}
-	if after := getSprintLifecycleRESTSprint(t, fx, foreign.ID); after.ProjectID != projectB.ID || after.State != store.SprintStateClosed || after.ClosedAt == nil {
-		t.Fatalf("foreign sprint after current exploit=%+v", after)
-	}
-	assertSprintLifecycleRESTRefresh(t, fx, fx.project.ID, "sprint_closed")
+	assertSprintLifecycleRESTSilence(t, fx)
 	for _, event := range fx.collector.snapshot() {
-		if event.ProjectID == projectB.ID {
-			t.Fatalf("unexpected refresh attributed to mutated project B: %+v", event)
+		if event.ProjectID == fx.project.ID || event.ProjectID == projectB.ID {
+			t.Fatalf("unexpected refresh after foreign close rejection: %+v", event)
 		}
 	}
 }
@@ -875,7 +876,8 @@ func TestSprintLifecycleRESTDependencyFailureContract(t *testing.T) {
 		{operation: "activate", stage: "mutation", wantTrace: []string{"access", "role", "activate"}, wantStatus: 500, wantCode: "INTERNAL", wantMessage: "internal error", wantDetails: map[string]any{"detail": sentinel.Error()}},
 		{operation: "close", stage: "access", wantTrace: []string{"access"}, wantStatus: 500, wantCode: "INTERNAL", wantMessage: "internal error", wantDetails: map[string]any{"detail": sentinel.Error()}},
 		{operation: "close", stage: "role", wantTrace: []string{"access", "role"}, wantStatus: 403, wantCode: "FORBIDDEN", wantMessage: "maintainer or higher required"},
-		{operation: "close", stage: "mutation", wantTrace: []string{"access", "role", "close"}, wantStatus: 500, wantCode: "INTERNAL", wantMessage: "internal error", wantDetails: map[string]any{"detail": sentinel.Error()}},
+		{operation: "close", stage: "target", wantTrace: []string{"access", "role", "target"}, wantStatus: 500, wantCode: "INTERNAL", wantMessage: "internal error", wantDetails: map[string]any{"detail": sentinel.Error()}},
+		{operation: "close", stage: "mutation", wantTrace: []string{"access", "role", "target", "close"}, wantStatus: 500, wantCode: "INTERNAL", wantMessage: "internal error", wantDetails: map[string]any{"detail": sentinel.Error()}},
 		{operation: "delete", stage: "access", wantTrace: []string{"access"}, wantStatus: 500, wantCode: "INTERNAL", wantMessage: "internal error", wantDetails: map[string]any{"detail": sentinel.Error()}},
 		{operation: "delete", stage: "target", wantTrace: []string{"access", "target"}, wantStatus: 500, wantCode: "INTERNAL", wantMessage: "internal error", wantDetails: map[string]any{"detail": sentinel.Error()}},
 		{operation: "delete", stage: "role", wantTrace: []string{"access", "target", "role"}, wantStatus: 403, wantCode: "FORBIDDEN", wantMessage: "maintainer or higher required"},
@@ -942,7 +944,8 @@ func TestSprintLifecycleRESTCancellationContract(t *testing.T) {
 		{operation: "activate", stage: "mutation", wantTrace: []string{"access", "role", "activate"}},
 		{operation: "close", stage: "access", wantTrace: []string{"access"}},
 		{operation: "close", stage: "role", wantTrace: []string{"access", "role"}},
-		{operation: "close", stage: "mutation", wantTrace: []string{"access", "role", "close"}},
+		{operation: "close", stage: "target", wantTrace: []string{"access", "role", "target"}},
+		{operation: "close", stage: "mutation", wantTrace: []string{"access", "role", "target", "close"}},
 		{operation: "delete", stage: "access", wantTrace: []string{"access"}},
 		{operation: "delete", stage: "target", wantTrace: []string{"access", "target"}},
 		{operation: "delete", stage: "role", wantTrace: []string{"access", "target", "role"}},
@@ -1040,7 +1043,9 @@ func TestSprintLifecycleRESTMutationErrorMappingContract(t *testing.T) {
 				resp, _ := doJSON(t, fx.client, method, path, map[string]any{}, &got)
 				assertSprintLifecycleRESTError(t, resp, got, tc.wantStatus, tc.wantCode, tc.wantMessage, nil)
 				wantTrace := []string{"access", "role", operation}
-				if operation == "delete" {
+				if operation == "close" {
+					wantTrace = []string{"access", "role", "target", "close"}
+				} else if operation == "delete" {
 					wantTrace = []string{"access", "target", "role", "delete"}
 				}
 				assertSprintLifecycleRESTTrace(t, fx.wrapped, wantTrace...)

--- a/internal/httpapi/sprint_lifecycle_transport_contract_test.go
+++ b/internal/httpapi/sprint_lifecycle_transport_contract_test.go
@@ -1,0 +1,1054 @@
+package httpapi
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"scrumboy/internal/db"
+	"scrumboy/internal/eventbus"
+	"scrumboy/internal/migrate"
+	"scrumboy/internal/store"
+)
+
+type sprintLifecycleRESTEventCollector struct {
+	mu     sync.Mutex
+	events []eventbus.Event
+}
+
+func (c *sprintLifecycleRESTEventCollector) OnEvent(_ context.Context, event eventbus.Event) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, event)
+}
+
+func (c *sprintLifecycleRESTEventCollector) snapshot() []eventbus.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]eventbus.Event(nil), c.events...)
+}
+
+type sprintLifecycleRESTStore struct {
+	*store.Store
+
+	mu     sync.Mutex
+	active bool
+	trace  []string
+
+	accessErr      error
+	accessOverride *store.ProjectContext
+	roleErr        error
+	roleOverride   *store.ProjectRole
+	targetErr      error
+	activateErr    error
+	closeErr       error
+	deleteErr      error
+
+	accessSlug string
+	accessMode store.Mode
+	rolePID    int64
+	roleUID    int64
+
+	targetReads int
+	targetIDs   []int64
+
+	activateCalls int
+	activatePID   int64
+	activateID    int64
+	closeCalls    int
+	closeID       int64
+	deleteCalls   int
+	deletePID     int64
+	deleteID      int64
+}
+
+func (s *sprintLifecycleRESTStore) activateTrace() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.active = true
+	s.trace = nil
+	s.targetReads = 0
+	s.targetIDs = nil
+	s.activateCalls = 0
+	s.closeCalls = 0
+	s.deleteCalls = 0
+}
+
+func (s *sprintLifecycleRESTStore) record(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.active {
+		return false
+	}
+	s.trace = append(s.trace, name)
+	return true
+}
+
+func (s *sprintLifecycleRESTStore) snapshotTrace() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.trace...)
+}
+
+func (s *sprintLifecycleRESTStore) GetProjectContextBySlug(ctx context.Context, slug string, mode store.Mode) (store.ProjectContext, error) {
+	if !s.record("access") {
+		return s.Store.GetProjectContextBySlug(ctx, slug, mode)
+	}
+	s.mu.Lock()
+	s.accessSlug = slug
+	s.accessMode = mode
+	err := s.accessErr
+	override := s.accessOverride
+	s.mu.Unlock()
+	if err != nil {
+		return store.ProjectContext{}, err
+	}
+	if override != nil {
+		return *override, nil
+	}
+	return s.Store.GetProjectContextBySlug(ctx, slug, mode)
+}
+
+func (s *sprintLifecycleRESTStore) GetProjectRole(ctx context.Context, projectID, userID int64) (store.ProjectRole, error) {
+	if !s.record("role") {
+		return s.Store.GetProjectRole(ctx, projectID, userID)
+	}
+	s.mu.Lock()
+	s.rolePID = projectID
+	s.roleUID = userID
+	err := s.roleErr
+	override := s.roleOverride
+	s.mu.Unlock()
+	if err != nil {
+		return "", err
+	}
+	if override != nil {
+		return *override, nil
+	}
+	return s.Store.GetProjectRole(ctx, projectID, userID)
+}
+
+func (s *sprintLifecycleRESTStore) GetSprintByID(ctx context.Context, sprintID int64) (store.Sprint, error) {
+	if !s.record("target") {
+		return s.Store.GetSprintByID(ctx, sprintID)
+	}
+	s.mu.Lock()
+	s.targetReads++
+	s.targetIDs = append(s.targetIDs, sprintID)
+	err := s.targetErr
+	s.mu.Unlock()
+	if err != nil {
+		return store.Sprint{}, err
+	}
+	return s.Store.GetSprintByID(ctx, sprintID)
+}
+
+func (s *sprintLifecycleRESTStore) ActivateSprint(ctx context.Context, projectID, sprintID int64) error {
+	if !s.record("activate") {
+		return s.Store.ActivateSprint(ctx, projectID, sprintID)
+	}
+	s.mu.Lock()
+	s.activateCalls++
+	s.activatePID = projectID
+	s.activateID = sprintID
+	err := s.activateErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.Store.ActivateSprint(ctx, projectID, sprintID)
+}
+
+func (s *sprintLifecycleRESTStore) CloseSprint(ctx context.Context, sprintID int64) error {
+	if !s.record("close") {
+		return s.Store.CloseSprint(ctx, sprintID)
+	}
+	s.mu.Lock()
+	s.closeCalls++
+	s.closeID = sprintID
+	err := s.closeErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.Store.CloseSprint(ctx, sprintID)
+}
+
+func (s *sprintLifecycleRESTStore) DeleteSprint(ctx context.Context, projectID, sprintID int64) error {
+	if !s.record("delete") {
+		return s.Store.DeleteSprint(ctx, projectID, sprintID)
+	}
+	s.mu.Lock()
+	s.deleteCalls++
+	s.deletePID = projectID
+	s.deleteID = sprintID
+	err := s.deleteErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.Store.DeleteSprint(ctx, projectID, sprintID)
+}
+
+type sprintLifecycleRESTFixture struct {
+	ts          *httptest.Server
+	db          *sql.DB
+	st          *store.Store
+	wrapped     *sprintLifecycleRESTStore
+	client      *http.Client
+	ownerClient *http.Client
+	ownerID     int64
+	actorID     int64
+	ownerCtx    context.Context
+	actorCtx    context.Context
+	project     store.Project
+	projectPC   store.ProjectContext
+	collector   *sprintLifecycleRESTEventCollector
+}
+
+func newSprintLifecycleRESTFixture(t *testing.T, name string) *sprintLifecycleRESTFixture {
+	t.Helper()
+
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "app.db"), db.Options{
+		BusyTimeout: 5000,
+		JournalMode: "WAL",
+		Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := migrate.Apply(context.Background(), sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+	st := store.New(sqlDB, nil)
+	wrapped := &sprintLifecycleRESTStore{Store: st}
+	srv := NewServer(wrapped, Options{MaxRequestBody: 1 << 20, ScrumboyMode: "full"})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(func() {
+		ts.Close()
+		_ = sqlDB.Close()
+	})
+
+	ownerClient := newCookieClient(t)
+	owner := bootstrapUserClient(t, ownerClient, ts.URL, "Lifecycle Owner", name+"-owner@example.com", "password123")
+	ownerID := int64(owner["id"].(float64))
+	ownerCtx := store.WithUserID(context.Background(), ownerID)
+	actor, err := st.CreateUser(context.Background(), name+"-actor@example.com", "password123", "Lifecycle Maintainer")
+	if err != nil {
+		t.Fatalf("CreateUser actor: %v", err)
+	}
+
+	offsetOne, err := st.CreateProject(ownerCtx, name+"-offset-one")
+	if err != nil {
+		t.Fatalf("CreateProject offset one: %v", err)
+	}
+	if _, err := st.CreateProject(ownerCtx, name+"-offset-two"); err != nil {
+		t.Fatalf("CreateProject offset two: %v", err)
+	}
+	now := time.Now().UTC()
+	for i := 0; i < 4; i++ {
+		if _, err := st.CreateSprint(ownerCtx, offsetOne.ID, fmt.Sprintf("Offset %d", i+1), now.Add(-time.Hour), now.Add(time.Duration(48+i)*time.Hour)); err != nil {
+			t.Fatalf("CreateSprint offset %d: %v", i+1, err)
+		}
+	}
+	project, err := st.CreateProject(ownerCtx, name)
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	if err := st.AddProjectMember(ownerCtx, ownerID, project.ID, actor.ID, store.RoleMaintainer); err != nil {
+		t.Fatalf("AddProjectMember actor: %v", err)
+	}
+	actorCtx := store.WithUserID(context.Background(), actor.ID)
+	pc, err := st.GetProjectContextBySlug(actorCtx, project.Slug, store.ModeFull)
+	if err != nil {
+		t.Fatalf("GetProjectContextBySlug: %v", err)
+	}
+	client := sprintLifecycleRESTSessionClient(t, ts, st, actor.ID)
+	collector := &sprintLifecycleRESTEventCollector{}
+	srv.fanout = eventbus.NewFanout(collector)
+
+	return &sprintLifecycleRESTFixture{
+		ts: ts, db: sqlDB, st: st, wrapped: wrapped, client: client, ownerClient: ownerClient,
+		ownerID: ownerID, actorID: actor.ID, ownerCtx: ownerCtx, actorCtx: actorCtx,
+		project: project, projectPC: pc, collector: collector,
+	}
+}
+
+func sprintLifecycleRESTSessionClient(t *testing.T, ts *httptest.Server, st *store.Store, userID int64) *http.Client {
+	t.Helper()
+	token, expiresAt, err := st.CreateSession(context.Background(), userID, time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookie jar: %v", err)
+	}
+	base, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	jar.SetCookies(base, []*http.Cookie{{Name: "scrumboy_session", Value: token, Path: "/", Expires: expiresAt}})
+	return &http.Client{Transport: ts.Client().Transport, Jar: jar}
+}
+
+func (fx *sprintLifecycleRESTFixture) actionURL(sprintID int64, action string) string {
+	return fmt.Sprintf("%s/api/board/%s/sprints/%d/%s", fx.ts.URL, fx.project.Slug, sprintID, action)
+}
+
+func (fx *sprintLifecycleRESTFixture) deleteURL(sprintID int64) string {
+	return fmt.Sprintf("%s/api/board/%s/sprints/%d", fx.ts.URL, fx.project.Slug, sprintID)
+}
+
+func createSprintLifecycleRESTSprint(t *testing.T, fx *sprintLifecycleRESTFixture, name, state string) store.Sprint {
+	t.Helper()
+	now := time.Now().UTC()
+	sp, err := fx.st.CreateSprint(fx.ownerCtx, fx.project.ID, name, now.Add(-time.Hour), now.Add(72*time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSprint %s: %v", state, err)
+	}
+	if state == store.SprintStateActive || state == store.SprintStateClosed {
+		if err := fx.st.ActivateSprint(fx.ownerCtx, fx.project.ID, sp.ID); err != nil {
+			t.Fatalf("ActivateSprint setup: %v", err)
+		}
+	}
+	if state == store.SprintStateClosed {
+		if err := fx.st.CloseSprint(fx.ownerCtx, sp.ID); err != nil {
+			t.Fatalf("CloseSprint setup: %v", err)
+		}
+	}
+	return sp
+}
+
+func assertSprintLifecycleRESTTrace(t *testing.T, wrapped *sprintLifecycleRESTStore, want ...string) {
+	t.Helper()
+	if got := wrapped.snapshotTrace(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("store trace=%v, want %v", got, want)
+	}
+}
+
+func assertSprintLifecycleRESTError(t *testing.T, resp *http.Response, got apiErrorEnvelope, wantStatus int, wantCode, wantMessage string, wantDetails map[string]any) {
+	t.Helper()
+	if resp.StatusCode != wantStatus || got.Error.Code != wantCode || got.Error.Message != wantMessage {
+		t.Fatalf("error status=%d envelope=%+v, want status=%d code=%q message=%q", resp.StatusCode, got, wantStatus, wantCode, wantMessage)
+	}
+	if !reflect.DeepEqual(got.Error.Details, wantDetails) {
+		t.Fatalf("error details=%+v, want %+v", got.Error.Details, wantDetails)
+	}
+}
+
+func assertSprintLifecycleRESTRefresh(t *testing.T, fx *sprintLifecycleRESTFixture, projectID int64, reason string) {
+	t.Helper()
+	events := fx.collector.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("events=%+v, want exactly one refresh", events)
+	}
+	event := events[0]
+	if event.Type != "board.refresh_needed" || event.ProjectID != projectID {
+		t.Fatalf("event=%+v, want board.refresh_needed for project %d", event, projectID)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("decode refresh payload: %v", err)
+	}
+	if payload["reason"] != reason || int64(payload["actorUserId"].(float64)) != fx.actorID {
+		t.Fatalf("refresh payload=%+v, want reason=%q actor=%d", payload, reason, fx.actorID)
+	}
+}
+
+func assertSprintLifecycleRESTSilence(t *testing.T, fx *sprintLifecycleRESTFixture) {
+	t.Helper()
+	if events := fx.collector.snapshot(); len(events) != 0 {
+		t.Fatalf("unexpected lifecycle refresh events: %+v", events)
+	}
+}
+
+func getSprintLifecycleRESTSprint(t *testing.T, fx *sprintLifecycleRESTFixture, sprintID int64) store.Sprint {
+	t.Helper()
+	sp, err := fx.st.GetSprintByID(fx.ownerCtx, sprintID)
+	if err != nil {
+		t.Fatalf("GetSprintByID(%d): %v", sprintID, err)
+	}
+	return sp
+}
+
+func TestSprintLifecycleRESTActivateContract(t *testing.T) {
+	t.Run("planned future success", func(t *testing.T) {
+		fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-activate")
+		sp := createSprintLifecycleRESTSprint(t, fx, "Target", store.SprintStatePlanned)
+		if sp.ID == sp.Number || sp.ID == fx.project.ID || fx.project.ID == fx.actorID {
+			t.Fatalf("identity fixture is not distinct: actor=%d project=%d sprint=%d number=%d", fx.actorID, fx.project.ID, sp.ID, sp.Number)
+		}
+		fx.wrapped.activateTrace()
+
+		resp, body := doJSON(t, fx.client, http.MethodPost, fx.actionURL(sp.ID, "activate"), map[string]any{}, nil)
+		if resp.StatusCode != http.StatusNoContent || len(body) != 0 {
+			t.Fatalf("activate status=%d body=%q, want 204 empty", resp.StatusCode, body)
+		}
+		assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "activate")
+		if fx.wrapped.accessSlug != fx.project.Slug || fx.wrapped.accessMode != store.ModeFull || fx.wrapped.rolePID != fx.project.ID || fx.wrapped.roleUID != fx.actorID {
+			t.Fatalf("access/role args=(slug=%q mode=%q project=%d actor=%d)", fx.wrapped.accessSlug, fx.wrapped.accessMode, fx.wrapped.rolePID, fx.wrapped.roleUID)
+		}
+		if fx.wrapped.targetReads != 0 || fx.wrapped.activateCalls != 1 || fx.wrapped.activatePID != fx.project.ID || fx.wrapped.activateID != sp.ID {
+			t.Fatalf("activate observations=(targetReads=%d calls=%d project=%d sprint=%d)", fx.wrapped.targetReads, fx.wrapped.activateCalls, fx.wrapped.activatePID, fx.wrapped.activateID)
+		}
+		stored := getSprintLifecycleRESTSprint(t, fx, sp.ID)
+		if stored.State != store.SprintStateActive || stored.StartedAt == nil || stored.ClosedAt != nil {
+			t.Fatalf("activated sprint=%+v", stored)
+		}
+		assertSprintLifecycleRESTRefresh(t, fx, fx.project.ID, "sprint_activated")
+	})
+
+	t.Run("replacement closes prior active and publishes only activation", func(t *testing.T) {
+		fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-activate-replacement")
+		prior := createSprintLifecycleRESTSprint(t, fx, "Prior", store.SprintStateActive)
+		target := createSprintLifecycleRESTSprint(t, fx, "Replacement", store.SprintStatePlanned)
+		fx.wrapped.activateTrace()
+
+		resp, body := doJSON(t, fx.client, http.MethodPost, fx.actionURL(target.ID, "activate"), map[string]any{}, nil)
+		if resp.StatusCode != http.StatusNoContent || len(body) != 0 {
+			t.Fatalf("replacement status=%d body=%q", resp.StatusCode, body)
+		}
+		assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "activate")
+		if fx.wrapped.activateCalls != 1 || fx.wrapped.closeCalls != 0 {
+			t.Fatalf("replacement activateCalls=%d closeCalls=%d", fx.wrapped.activateCalls, fx.wrapped.closeCalls)
+		}
+		priorAfter := getSprintLifecycleRESTSprint(t, fx, prior.ID)
+		targetAfter := getSprintLifecycleRESTSprint(t, fx, target.ID)
+		if priorAfter.State != store.SprintStateClosed || priorAfter.ClosedAt == nil || targetAfter.State != store.SprintStateActive || targetAfter.StartedAt == nil {
+			t.Fatalf("replacement prior=%+v target=%+v", priorAfter, targetAfter)
+		}
+		active, err := fx.st.GetActiveSprintByProjectID(fx.ownerCtx, fx.project.ID)
+		if err != nil || active == nil || active.ID != target.ID {
+			t.Fatalf("active sprint=%+v err=%v, want target %d", active, err, target.ID)
+		}
+		assertSprintLifecycleRESTRefresh(t, fx, fx.project.ID, "sprint_activated")
+	})
+
+	t.Run("repeated activation remains idempotent success with another refresh", func(t *testing.T) {
+		fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-activate-repeat")
+		sp := createSprintLifecycleRESTSprint(t, fx, "Already active", store.SprintStateActive)
+		before := getSprintLifecycleRESTSprint(t, fx, sp.ID)
+		fx.wrapped.activateTrace()
+
+		resp, body := doJSON(t, fx.client, http.MethodPost, fx.actionURL(sp.ID, "activate"), map[string]any{}, nil)
+		if resp.StatusCode != http.StatusNoContent || len(body) != 0 {
+			t.Fatalf("repeated activate status=%d body=%q", resp.StatusCode, body)
+		}
+		assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "activate")
+		if fx.wrapped.targetReads != 0 || fx.wrapped.activateCalls != 1 {
+			t.Fatalf("repeated activate targetReads=%d calls=%d", fx.wrapped.targetReads, fx.wrapped.activateCalls)
+		}
+		after := getSprintLifecycleRESTSprint(t, fx, sp.ID)
+		if before.StartedAt == nil || after.StartedAt == nil || !after.StartedAt.Equal(*before.StartedAt) || !after.UpdatedAt.Equal(before.UpdatedAt) {
+			t.Fatalf("repeated activation changed timestamps before=%+v after=%+v", before, after)
+		}
+		assertSprintLifecycleRESTRefresh(t, fx, fx.project.ID, "sprint_activated")
+	})
+
+	for _, tc := range []struct {
+		name        string
+		prepare     func(*testing.T, *sprintLifecycleRESTFixture) int64
+		wantStatus  int
+		wantCode    string
+		wantMessage string
+		wantDetails map[string]any
+	}{
+		{
+			name: "closed target",
+			prepare: func(t *testing.T, fx *sprintLifecycleRESTFixture) int64 {
+				return createSprintLifecycleRESTSprint(t, fx, "Closed", store.SprintStateClosed).ID
+			},
+			wantStatus: http.StatusBadRequest, wantCode: "VALIDATION_ERROR", wantMessage: "validation: sprint must be PLANNED to activate", wantDetails: map[string]any{"reason": "sprint_activate_requires_planned"},
+		},
+		{
+			name:       "missing target",
+			prepare:    func(_ *testing.T, _ *sprintLifecycleRESTFixture) int64 { return 900001 },
+			wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND", wantMessage: "not found",
+		},
+		{
+			name: "foreign target exposes store validation",
+			prepare: func(t *testing.T, fx *sprintLifecycleRESTFixture) int64 {
+				other, err := fx.st.CreateProject(fx.ownerCtx, "rest-lifecycle-activate-foreign")
+				if err != nil {
+					t.Fatalf("CreateProject foreign: %v", err)
+				}
+				now := time.Now().UTC()
+				sp, err := fx.st.CreateSprint(fx.ownerCtx, other.ID, "Foreign", now.Add(-time.Hour), now.Add(48*time.Hour))
+				if err != nil {
+					t.Fatalf("CreateSprint foreign: %v", err)
+				}
+				return sp.ID
+			},
+			wantStatus: http.StatusBadRequest, wantCode: "VALIDATION_ERROR", wantMessage: "validation: sprint does not belong to project", wantDetails: map[string]any{"reason": "sprint_not_in_project"},
+		},
+		{
+			name: "safely expired planned end",
+			prepare: func(t *testing.T, fx *sprintLifecycleRESTFixture) int64 {
+				now := time.Now().UTC()
+				sp, err := fx.st.CreateSprint(fx.ownerCtx, fx.project.ID, "Past", now.Add(-48*time.Hour), now.Add(-24*time.Hour))
+				if err != nil {
+					t.Fatalf("CreateSprint past: %v", err)
+				}
+				return sp.ID
+			},
+			wantStatus: http.StatusBadRequest, wantCode: "VALIDATION_ERROR", wantMessage: "validation: sprint end date is on or before now; cannot activate", wantDetails: map[string]any{"reason": "sprint_end_in_past"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-activate-reject-"+strings.ReplaceAll(tc.name, " ", "-"))
+			sprintID := tc.prepare(t, fx)
+			before, beforeErr := fx.st.GetSprintByID(fx.ownerCtx, sprintID)
+			fx.wrapped.activateTrace()
+			var got apiErrorEnvelope
+			resp, _ := doJSON(t, fx.client, http.MethodPost, fx.actionURL(sprintID, "activate"), map[string]any{}, &got)
+			assertSprintLifecycleRESTError(t, resp, got, tc.wantStatus, tc.wantCode, tc.wantMessage, tc.wantDetails)
+			assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "activate")
+			if fx.wrapped.activateCalls != 1 || fx.wrapped.targetReads != 0 {
+				t.Fatalf("rejection activateCalls=%d targetReads=%d", fx.wrapped.activateCalls, fx.wrapped.targetReads)
+			}
+			if beforeErr == nil {
+				after := getSprintLifecycleRESTSprint(t, fx, sprintID)
+				if !reflect.DeepEqual(after, before) {
+					t.Fatalf("rejected activation changed sprint before=%+v after=%+v", before, after)
+				}
+			}
+			assertSprintLifecycleRESTSilence(t, fx)
+		})
+	}
+}
+
+func TestSprintLifecycleRESTCloseContract(t *testing.T) {
+	t.Run("same-project active success", func(t *testing.T) {
+		fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-close")
+		sp := createSprintLifecycleRESTSprint(t, fx, "Active", store.SprintStateActive)
+		before := getSprintLifecycleRESTSprint(t, fx, sp.ID)
+		fx.wrapped.activateTrace()
+
+		resp, body := doJSON(t, fx.client, http.MethodPost, fx.actionURL(sp.ID, "close"), map[string]any{}, nil)
+		if resp.StatusCode != http.StatusNoContent || len(body) != 0 {
+			t.Fatalf("close status=%d body=%q", resp.StatusCode, body)
+		}
+		assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "close")
+		if fx.wrapped.targetReads != 0 || fx.wrapped.closeCalls != 1 || fx.wrapped.closeID != sp.ID {
+			t.Fatalf("close observations=(targetReads=%d calls=%d id=%d)", fx.wrapped.targetReads, fx.wrapped.closeCalls, fx.wrapped.closeID)
+		}
+		after := getSprintLifecycleRESTSprint(t, fx, sp.ID)
+		if after.State != store.SprintStateClosed || after.ClosedAt == nil || before.StartedAt == nil || after.StartedAt == nil || !after.StartedAt.Equal(*before.StartedAt) {
+			t.Fatalf("closed sprint before=%+v after=%+v", before, after)
+		}
+		assertSprintLifecycleRESTRefresh(t, fx, fx.project.ID, "sprint_closed")
+	})
+
+	for _, state := range []string{store.SprintStatePlanned, store.SprintStateClosed} {
+		state := state
+		t.Run(strings.ToLower(state), func(t *testing.T) {
+			fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-close-"+strings.ToLower(state))
+			sp := createSprintLifecycleRESTSprint(t, fx, state, state)
+			before := getSprintLifecycleRESTSprint(t, fx, sp.ID)
+			fx.wrapped.activateTrace()
+			var got apiErrorEnvelope
+			resp, _ := doJSON(t, fx.client, http.MethodPost, fx.actionURL(sp.ID, "close"), map[string]any{}, &got)
+			assertSprintLifecycleRESTError(t, resp, got, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+			assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "close")
+			if fx.wrapped.closeCalls != 1 || !reflect.DeepEqual(getSprintLifecycleRESTSprint(t, fx, sp.ID), before) {
+				t.Fatalf("failed close calls=%d or changed state", fx.wrapped.closeCalls)
+			}
+			assertSprintLifecycleRESTSilence(t, fx)
+		})
+	}
+
+	t.Run("missing", func(t *testing.T) {
+		fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-close-missing")
+		fx.wrapped.activateTrace()
+		var got apiErrorEnvelope
+		resp, _ := doJSON(t, fx.client, http.MethodPost, fx.actionURL(900002, "close"), map[string]any{}, &got)
+		assertSprintLifecycleRESTError(t, resp, got, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+		assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "close")
+		if fx.wrapped.closeCalls != 1 {
+			t.Fatalf("missing close calls=%d, want one", fx.wrapped.closeCalls)
+		}
+		assertSprintLifecycleRESTSilence(t, fx)
+	})
+}
+
+func TestSprintLifecycleRESTCloseCrossProjectExploitCurrentBehavior(t *testing.T) {
+	fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-close-exploit-route-a")
+	projectB, err := fx.st.CreateProject(fx.ownerCtx, "rest-lifecycle-close-exploit-project-b")
+	if err != nil {
+		t.Fatalf("CreateProject B: %v", err)
+	}
+	now := time.Now().UTC()
+	foreign, err := fx.st.CreateSprint(fx.ownerCtx, projectB.ID, "Foreign active", now.Add(-time.Hour), now.Add(48*time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSprint B: %v", err)
+	}
+	if err := fx.st.ActivateSprint(fx.ownerCtx, projectB.ID, foreign.ID); err != nil {
+		t.Fatalf("ActivateSprint B: %v", err)
+	}
+	if role, err := fx.st.GetProjectRole(fx.actorCtx, projectB.ID, fx.actorID); err != nil || role.HasMinimumRole(store.RoleMaintainer) {
+		t.Fatalf("actor unexpectedly authorized for project B: role=%q err=%v", role, err)
+	}
+	identities := []int64{fx.project.ID, projectB.ID, foreign.ID, foreign.Number, fx.actorID}
+	seen := map[int64]bool{}
+	for _, identity := range identities {
+		if seen[identity] {
+			t.Fatalf("exploit fixture identities not distinct: routeProject=%d foreignProject=%d sprintID=%d sprintNumber=%d actor=%d", fx.project.ID, projectB.ID, foreign.ID, foreign.Number, fx.actorID)
+		}
+		seen[identity] = true
+	}
+	fx.wrapped.activateTrace()
+
+	resp, body := doJSON(t, fx.client, http.MethodPost, fx.actionURL(foreign.ID, "close"), map[string]any{}, nil)
+	if resp.StatusCode != http.StatusNoContent || len(body) != 0 {
+		t.Fatalf("cross-project close status=%d body=%q, want current 204 empty behavior", resp.StatusCode, body)
+	}
+	assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "role", "close")
+	if fx.wrapped.rolePID != fx.project.ID || fx.wrapped.roleUID != fx.actorID || fx.wrapped.closeCalls != 1 || fx.wrapped.closeID != foreign.ID {
+		t.Fatalf("cross-project observations=(roleProject=%d actor=%d calls=%d sprint=%d)", fx.wrapped.rolePID, fx.wrapped.roleUID, fx.wrapped.closeCalls, fx.wrapped.closeID)
+	}
+	if after := getSprintLifecycleRESTSprint(t, fx, foreign.ID); after.ProjectID != projectB.ID || after.State != store.SprintStateClosed || after.ClosedAt == nil {
+		t.Fatalf("foreign sprint after current exploit=%+v", after)
+	}
+	assertSprintLifecycleRESTRefresh(t, fx, fx.project.ID, "sprint_closed")
+	for _, event := range fx.collector.snapshot() {
+		if event.ProjectID == projectB.ID {
+			t.Fatalf("unexpected refresh attributed to mutated project B: %+v", event)
+		}
+	}
+}
+
+func TestSprintLifecycleRESTDeleteContract(t *testing.T) {
+	for _, state := range []string{store.SprintStatePlanned, store.SprintStateActive, store.SprintStateClosed} {
+		state := state
+		t.Run(strings.ToLower(state), func(t *testing.T) {
+			fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-delete-"+strings.ToLower(state))
+			sp := createSprintLifecycleRESTSprint(t, fx, state, state)
+			fx.wrapped.activateTrace()
+
+			resp, body := doJSON(t, fx.client, http.MethodDelete, fx.deleteURL(sp.ID), map[string]any{}, nil)
+			if resp.StatusCode != http.StatusNoContent || len(body) != 0 {
+				t.Fatalf("delete %s status=%d body=%q", state, resp.StatusCode, body)
+			}
+			assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "target", "role", "delete")
+			if fx.wrapped.targetReads != 1 || !reflect.DeepEqual(fx.wrapped.targetIDs, []int64{sp.ID}) || fx.wrapped.deleteCalls != 1 || fx.wrapped.deletePID != fx.project.ID || fx.wrapped.deleteID != sp.ID {
+				t.Fatalf("delete observations=(reads=%d ids=%v calls=%d project=%d sprint=%d)", fx.wrapped.targetReads, fx.wrapped.targetIDs, fx.wrapped.deleteCalls, fx.wrapped.deletePID, fx.wrapped.deleteID)
+			}
+			if _, err := fx.st.GetSprintByID(fx.ownerCtx, sp.ID); !errors.Is(err, store.ErrNotFound) {
+				t.Fatalf("GetSprintByID after delete error=%v, want not found", err)
+			}
+			if state == store.SprintStateActive {
+				active, err := fx.st.GetActiveSprintByProjectID(fx.ownerCtx, fx.project.ID)
+				if err != nil || active != nil {
+					t.Fatalf("active sprint after active delete=%+v err=%v, want nil", active, err)
+				}
+			}
+			assertSprintLifecycleRESTRefresh(t, fx, fx.project.ID, "sprint_deleted")
+		})
+	}
+}
+
+func TestSprintLifecycleRESTDeleteDetachesTodos(t *testing.T) {
+	fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-delete-detach")
+	target := createSprintLifecycleRESTSprint(t, fx, "Target", store.SprintStateActive)
+	controlSprint := createSprintLifecycleRESTSprint(t, fx, "Control", store.SprintStatePlanned)
+	points := int64(8)
+	assignedOne, err := fx.st.CreateTodo(fx.ownerCtx, fx.project.ID, store.CreateTodoInput{
+		Title: "Assigned one", Body: "body one", Tags: []string{"contract", "phase20"}, ColumnKey: store.DefaultColumnDoing,
+		EstimationPoints: &points, AssigneeUserID: &fx.actorID, SprintID: &target.ID,
+	}, store.ModeFull)
+	if err != nil {
+		t.Fatalf("CreateTodo assigned one: %v", err)
+	}
+	assignedTwo, err := fx.st.CreateTodo(fx.ownerCtx, fx.project.ID, store.CreateTodoInput{
+		Title: "Assigned two", Body: "body two", ColumnKey: store.DefaultColumnBacklog, SprintID: &target.ID,
+	}, store.ModeFull)
+	if err != nil {
+		t.Fatalf("CreateTodo assigned two: %v", err)
+	}
+	controlAssigned, err := fx.st.CreateTodo(fx.ownerCtx, fx.project.ID, store.CreateTodoInput{
+		Title: "Control scheduled", Body: "control", ColumnKey: store.DefaultColumnBacklog, SprintID: &controlSprint.ID,
+	}, store.ModeFull)
+	if err != nil {
+		t.Fatalf("CreateTodo control scheduled: %v", err)
+	}
+	controlBacklog, err := fx.st.CreateTodo(fx.ownerCtx, fx.project.ID, store.CreateTodoInput{
+		Title: "Control backlog", Body: "backlog", ColumnKey: store.DefaultColumnBacklog,
+	}, store.ModeFull)
+	if err != nil {
+		t.Fatalf("CreateTodo control backlog: %v", err)
+	}
+	fx.wrapped.activateTrace()
+
+	resp, body := doJSON(t, fx.client, http.MethodDelete, fx.deleteURL(target.ID), map[string]any{}, nil)
+	if resp.StatusCode != http.StatusNoContent || len(body) != 0 {
+		t.Fatalf("delete with todos status=%d body=%q", resp.StatusCode, body)
+	}
+	assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "target", "role", "delete")
+	if fx.wrapped.targetReads != 1 || fx.wrapped.deleteCalls != 1 {
+		t.Fatalf("delete with todos reads=%d calls=%d", fx.wrapped.targetReads, fx.wrapped.deleteCalls)
+	}
+	for _, before := range []store.Todo{assignedOne, assignedTwo} {
+		after, err := fx.st.GetTodoByLocalID(fx.ownerCtx, fx.project.ID, before.LocalID, store.ModeFull)
+		if err != nil {
+			t.Fatalf("GetTodoByLocalID(%d): %v", before.LocalID, err)
+		}
+		want := before
+		want.SprintID = nil
+		want.AssignmentChanged = false
+		if !reflect.DeepEqual(after, want) {
+			t.Fatalf("todo changed beyond sprint detachment before=%+v after=%+v", before, after)
+		}
+	}
+	for _, before := range []store.Todo{controlAssigned, controlBacklog} {
+		after, err := fx.st.GetTodoByLocalID(fx.ownerCtx, fx.project.ID, before.LocalID, store.ModeFull)
+		if err != nil {
+			t.Fatalf("GetTodoByLocalID control %d: %v", before.LocalID, err)
+		}
+		want := before
+		want.AssignmentChanged = false
+		if !reflect.DeepEqual(after, want) {
+			t.Fatalf("control todo changed before=%+v after=%+v", before, after)
+		}
+	}
+	assertSprintLifecycleRESTRefresh(t, fx, fx.project.ID, "sprint_deleted")
+}
+
+func TestSprintLifecycleRESTAuthorityAndInputContract(t *testing.T) {
+	operationSetup := func(t *testing.T, fx *sprintLifecycleRESTFixture, operation string) (string, string) {
+		t.Helper()
+		switch operation {
+		case "activate":
+			sp := createSprintLifecycleRESTSprint(t, fx, "Authority activate", store.SprintStatePlanned)
+			return http.MethodPost, fx.actionURL(sp.ID, operation)
+		case "close":
+			sp := createSprintLifecycleRESTSprint(t, fx, "Authority close", store.SprintStateActive)
+			return http.MethodPost, fx.actionURL(sp.ID, operation)
+		case "delete":
+			sp := createSprintLifecycleRESTSprint(t, fx, "Authority delete", store.SprintStatePlanned)
+			return http.MethodDelete, fx.deleteURL(sp.ID)
+		default:
+			t.Fatalf("unknown operation %q", operation)
+			return "", ""
+		}
+	}
+
+	for _, operation := range []string{"activate", "close", "delete"} {
+		operation := operation
+		t.Run(operation+"/invalid sprint id", func(t *testing.T) {
+			fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-invalid-id-"+operation)
+			method := http.MethodPost
+			path := fx.ts.URL + "/api/board/" + fx.project.Slug + "/sprints/not-a-number/" + operation
+			if operation == "delete" {
+				method = http.MethodDelete
+				path = fx.ts.URL + "/api/board/" + fx.project.Slug + "/sprints/not-a-number"
+			}
+			fx.wrapped.activateTrace()
+			var got apiErrorEnvelope
+			resp, _ := doJSON(t, fx.client, method, path, map[string]any{}, &got)
+			assertSprintLifecycleRESTError(t, resp, got, http.StatusBadRequest, "VALIDATION_ERROR", "invalid sprintId", map[string]any{"field": "sprintId", "reason": "invalid_sprint_id"})
+			assertSprintLifecycleRESTTrace(t, fx.wrapped, "access")
+			assertSprintLifecycleRESTSilence(t, fx)
+		})
+
+		t.Run(operation+"/signed out access hides project", func(t *testing.T) {
+			fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-signed-out-"+operation)
+			method, path := operationSetup(t, fx, operation)
+			fx.wrapped.activateTrace()
+			var got apiErrorEnvelope
+			resp, _ := doJSON(t, fx.ts.Client(), method, path, map[string]any{}, &got)
+			assertSprintLifecycleRESTError(t, resp, got, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+			assertSprintLifecycleRESTTrace(t, fx.wrapped, "access")
+			assertSprintLifecycleRESTSilence(t, fx)
+		})
+
+		t.Run(operation+"/actor absence after forced access", func(t *testing.T) {
+			fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-actor-absent-"+operation)
+			method, path := operationSetup(t, fx, operation)
+			pc := fx.projectPC
+			fx.wrapped.accessOverride = &pc
+			fx.wrapped.activateTrace()
+			var got apiErrorEnvelope
+			resp, _ := doJSON(t, fx.ts.Client(), method, path, map[string]any{}, &got)
+			assertSprintLifecycleRESTError(t, resp, got, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
+			wantTrace := []string{"access"}
+			if operation == "delete" {
+				wantTrace = append(wantTrace, "target")
+			}
+			assertSprintLifecycleRESTTrace(t, fx.wrapped, wantTrace...)
+			assertSprintLifecycleRESTSilence(t, fx)
+		})
+
+		t.Run(operation+"/fresh viewer role overrides access context", func(t *testing.T) {
+			fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-fresh-role-"+operation)
+			method, path := operationSetup(t, fx, operation)
+			pc := fx.projectPC
+			pc.Role = store.RoleOwner
+			viewer := store.RoleViewer
+			fx.wrapped.accessOverride = &pc
+			fx.wrapped.roleOverride = &viewer
+			fx.wrapped.activateTrace()
+			var got apiErrorEnvelope
+			resp, _ := doJSON(t, fx.client, method, path, map[string]any{}, &got)
+			assertSprintLifecycleRESTError(t, resp, got, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
+			wantTrace := []string{"access"}
+			if operation == "delete" {
+				wantTrace = append(wantTrace, "target")
+			}
+			wantTrace = append(wantTrace, "role")
+			assertSprintLifecycleRESTTrace(t, fx.wrapped, wantTrace...)
+			if fx.wrapped.roleUID != fx.actorID || fx.wrapped.rolePID != fx.project.ID || fx.wrapped.activateCalls+fx.wrapped.closeCalls+fx.wrapped.deleteCalls != 0 {
+				t.Fatalf("authority observations=(project=%d actor=%d mutations=%d)", fx.wrapped.rolePID, fx.wrapped.roleUID, fx.wrapped.activateCalls+fx.wrapped.closeCalls+fx.wrapped.deleteCalls)
+			}
+			assertSprintLifecycleRESTSilence(t, fx)
+		})
+	}
+}
+
+func TestSprintLifecycleRESTDeleteFailurePrecedenceContract(t *testing.T) {
+	t.Run("missing target stops before role", func(t *testing.T) {
+		fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-delete-missing")
+		fx.wrapped.activateTrace()
+		var got apiErrorEnvelope
+		resp, _ := doJSON(t, fx.client, http.MethodDelete, fx.deleteURL(900003), map[string]any{}, &got)
+		assertSprintLifecycleRESTError(t, resp, got, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+		assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "target")
+		if fx.wrapped.deleteCalls != 0 {
+			t.Fatalf("missing target delete calls=%d", fx.wrapped.deleteCalls)
+		}
+		assertSprintLifecycleRESTSilence(t, fx)
+	})
+
+	t.Run("foreign target is hidden before role", func(t *testing.T) {
+		fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-delete-foreign")
+		other, err := fx.st.CreateProject(fx.ownerCtx, "rest-lifecycle-delete-foreign-project")
+		if err != nil {
+			t.Fatalf("CreateProject foreign: %v", err)
+		}
+		now := time.Now().UTC()
+		sp, err := fx.st.CreateSprint(fx.ownerCtx, other.ID, "Foreign", now.Add(-time.Hour), now.Add(48*time.Hour))
+		if err != nil {
+			t.Fatalf("CreateSprint foreign: %v", err)
+		}
+		fx.wrapped.activateTrace()
+		var got apiErrorEnvelope
+		resp, _ := doJSON(t, fx.client, http.MethodDelete, fx.deleteURL(sp.ID), map[string]any{}, &got)
+		assertSprintLifecycleRESTError(t, resp, got, http.StatusNotFound, "NOT_FOUND", "sprint not found", nil)
+		assertSprintLifecycleRESTTrace(t, fx.wrapped, "access", "target")
+		if fx.wrapped.deleteCalls != 0 {
+			t.Fatalf("foreign target delete calls=%d", fx.wrapped.deleteCalls)
+		}
+		if stored := getSprintLifecycleRESTSprint(t, fx, sp.ID); stored.ProjectID != other.ID {
+			t.Fatalf("foreign target changed=%+v", stored)
+		}
+		assertSprintLifecycleRESTSilence(t, fx)
+	})
+}
+
+func TestSprintLifecycleRESTDependencyFailureContract(t *testing.T) {
+	type testCase struct {
+		operation   string
+		stage       string
+		wantTrace   []string
+		wantStatus  int
+		wantCode    string
+		wantMessage string
+		wantDetails map[string]any
+	}
+	sentinel := errors.New("sprint lifecycle REST injected failure")
+	cases := []testCase{
+		{operation: "activate", stage: "access", wantTrace: []string{"access"}, wantStatus: 500, wantCode: "INTERNAL", wantMessage: "internal error", wantDetails: map[string]any{"detail": sentinel.Error()}},
+		{operation: "activate", stage: "role", wantTrace: []string{"access", "role"}, wantStatus: 403, wantCode: "FORBIDDEN", wantMessage: "maintainer or higher required"},
+		{operation: "activate", stage: "mutation", wantTrace: []string{"access", "role", "activate"}, wantStatus: 500, wantCode: "INTERNAL", wantMessage: "internal error", wantDetails: map[string]any{"detail": sentinel.Error()}},
+		{operation: "close", stage: "access", wantTrace: []string{"access"}, wantStatus: 500, wantCode: "INTERNAL", wantMessage: "internal error", wantDetails: map[string]any{"detail": sentinel.Error()}},
+		{operation: "close", stage: "role", wantTrace: []string{"access", "role"}, wantStatus: 403, wantCode: "FORBIDDEN", wantMessage: "maintainer or higher required"},
+		{operation: "close", stage: "mutation", wantTrace: []string{"access", "role", "close"}, wantStatus: 500, wantCode: "INTERNAL", wantMessage: "internal error", wantDetails: map[string]any{"detail": sentinel.Error()}},
+		{operation: "delete", stage: "access", wantTrace: []string{"access"}, wantStatus: 500, wantCode: "INTERNAL", wantMessage: "internal error", wantDetails: map[string]any{"detail": sentinel.Error()}},
+		{operation: "delete", stage: "target", wantTrace: []string{"access", "target"}, wantStatus: 500, wantCode: "INTERNAL", wantMessage: "internal error", wantDetails: map[string]any{"detail": sentinel.Error()}},
+		{operation: "delete", stage: "role", wantTrace: []string{"access", "target", "role"}, wantStatus: 403, wantCode: "FORBIDDEN", wantMessage: "maintainer or higher required"},
+		{operation: "delete", stage: "mutation", wantTrace: []string{"access", "target", "role", "delete"}, wantStatus: 500, wantCode: "INTERNAL", wantMessage: "internal error", wantDetails: map[string]any{"detail": sentinel.Error()}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.operation+"/"+tc.stage, func(t *testing.T) {
+			fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-failure-"+tc.operation+"-"+tc.stage)
+			var method, path string
+			var before store.Sprint
+			switch tc.operation {
+			case "activate":
+				sp := createSprintLifecycleRESTSprint(t, fx, "Failure activate", store.SprintStatePlanned)
+				before = getSprintLifecycleRESTSprint(t, fx, sp.ID)
+				method, path = http.MethodPost, fx.actionURL(sp.ID, "activate")
+			case "close":
+				sp := createSprintLifecycleRESTSprint(t, fx, "Failure close", store.SprintStateActive)
+				before = getSprintLifecycleRESTSprint(t, fx, sp.ID)
+				method, path = http.MethodPost, fx.actionURL(sp.ID, "close")
+			case "delete":
+				sp := createSprintLifecycleRESTSprint(t, fx, "Failure delete", store.SprintStatePlanned)
+				before = getSprintLifecycleRESTSprint(t, fx, sp.ID)
+				method, path = http.MethodDelete, fx.deleteURL(sp.ID)
+			}
+			switch tc.stage {
+			case "access":
+				fx.wrapped.accessErr = sentinel
+			case "role":
+				fx.wrapped.roleErr = sentinel
+			case "target":
+				fx.wrapped.targetErr = sentinel
+			case "mutation":
+				switch tc.operation {
+				case "activate":
+					fx.wrapped.activateErr = sentinel
+				case "close":
+					fx.wrapped.closeErr = sentinel
+				case "delete":
+					fx.wrapped.deleteErr = sentinel
+				}
+			}
+			fx.wrapped.activateTrace()
+			var got apiErrorEnvelope
+			resp, _ := doJSON(t, fx.client, method, path, map[string]any{}, &got)
+			assertSprintLifecycleRESTError(t, resp, got, tc.wantStatus, tc.wantCode, tc.wantMessage, tc.wantDetails)
+			assertSprintLifecycleRESTTrace(t, fx.wrapped, tc.wantTrace...)
+			if after := getSprintLifecycleRESTSprint(t, fx, before.ID); !reflect.DeepEqual(after, before) {
+				t.Fatalf("dependency failure changed sprint before=%+v after=%+v", before, after)
+			}
+			assertSprintLifecycleRESTSilence(t, fx)
+		})
+	}
+}
+
+func TestSprintLifecycleRESTCancellationContract(t *testing.T) {
+	type testCase struct {
+		operation string
+		stage     string
+		wantTrace []string
+	}
+	cases := []testCase{
+		{operation: "activate", stage: "access", wantTrace: []string{"access"}},
+		{operation: "activate", stage: "role", wantTrace: []string{"access", "role"}},
+		{operation: "activate", stage: "mutation", wantTrace: []string{"access", "role", "activate"}},
+		{operation: "close", stage: "access", wantTrace: []string{"access"}},
+		{operation: "close", stage: "role", wantTrace: []string{"access", "role"}},
+		{operation: "close", stage: "mutation", wantTrace: []string{"access", "role", "close"}},
+		{operation: "delete", stage: "access", wantTrace: []string{"access"}},
+		{operation: "delete", stage: "target", wantTrace: []string{"access", "target"}},
+		{operation: "delete", stage: "role", wantTrace: []string{"access", "target", "role"}},
+		{operation: "delete", stage: "mutation", wantTrace: []string{"access", "target", "role", "delete"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.operation+"/"+tc.stage, func(t *testing.T) {
+			fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-cancel-"+tc.operation+"-"+tc.stage)
+			var method, path string
+			var before store.Sprint
+			switch tc.operation {
+			case "activate":
+				sp := createSprintLifecycleRESTSprint(t, fx, "Canceled activate", store.SprintStatePlanned)
+				before = getSprintLifecycleRESTSprint(t, fx, sp.ID)
+				method, path = http.MethodPost, fx.actionURL(sp.ID, "activate")
+			case "close":
+				sp := createSprintLifecycleRESTSprint(t, fx, "Canceled close", store.SprintStateActive)
+				before = getSprintLifecycleRESTSprint(t, fx, sp.ID)
+				method, path = http.MethodPost, fx.actionURL(sp.ID, "close")
+			case "delete":
+				sp := createSprintLifecycleRESTSprint(t, fx, "Canceled delete", store.SprintStatePlanned)
+				before = getSprintLifecycleRESTSprint(t, fx, sp.ID)
+				method, path = http.MethodDelete, fx.deleteURL(sp.ID)
+			}
+			switch tc.stage {
+			case "access":
+				fx.wrapped.accessErr = context.Canceled
+			case "role":
+				fx.wrapped.roleErr = context.Canceled
+			case "target":
+				fx.wrapped.targetErr = context.Canceled
+			case "mutation":
+				switch tc.operation {
+				case "activate":
+					fx.wrapped.activateErr = context.Canceled
+				case "close":
+					fx.wrapped.closeErr = context.Canceled
+				case "delete":
+					fx.wrapped.deleteErr = context.Canceled
+				}
+			}
+			fx.wrapped.activateTrace()
+			var got apiErrorEnvelope
+			resp, _ := doJSON(t, fx.client, method, path, map[string]any{}, &got)
+			if tc.stage == "role" {
+				assertSprintLifecycleRESTError(t, resp, got, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
+			} else {
+				assertSprintLifecycleRESTError(t, resp, got, http.StatusInternalServerError, "INTERNAL", "internal error", map[string]any{"detail": context.Canceled.Error()})
+			}
+			assertSprintLifecycleRESTTrace(t, fx.wrapped, tc.wantTrace...)
+			if after := getSprintLifecycleRESTSprint(t, fx, before.ID); !reflect.DeepEqual(after, before) {
+				t.Fatalf("cancellation changed sprint before=%+v after=%+v", before, after)
+			}
+			assertSprintLifecycleRESTSilence(t, fx)
+		})
+	}
+}
+
+func TestSprintLifecycleRESTMutationErrorMappingContract(t *testing.T) {
+	validationErr := fmt.Errorf("%w: lifecycle mutation rejected", store.ErrValidation)
+	for _, operation := range []string{"activate", "close", "delete"} {
+		for _, tc := range []struct {
+			name        string
+			err         error
+			wantStatus  int
+			wantCode    string
+			wantMessage string
+		}{
+			{name: "validation", err: validationErr, wantStatus: http.StatusBadRequest, wantCode: "VALIDATION_ERROR", wantMessage: validationErr.Error()},
+			{name: "not found", err: store.ErrNotFound, wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND", wantMessage: "not found"},
+		} {
+			operation, tc := operation, tc
+			t.Run(operation+"/"+tc.name, func(t *testing.T) {
+				fx := newSprintLifecycleRESTFixture(t, "rest-lifecycle-mutation-mapping-"+operation+"-"+strings.ReplaceAll(tc.name, " ", "-"))
+				state := store.SprintStatePlanned
+				if operation == "close" {
+					state = store.SprintStateActive
+				}
+				target := createSprintLifecycleRESTSprint(t, fx, "Mutation mapping", state)
+				before := getSprintLifecycleRESTSprint(t, fx, target.ID)
+				method := http.MethodPost
+				path := fx.actionURL(target.ID, operation)
+				switch operation {
+				case "activate":
+					fx.wrapped.activateErr = tc.err
+				case "close":
+					fx.wrapped.closeErr = tc.err
+				case "delete":
+					method = http.MethodDelete
+					path = fx.deleteURL(target.ID)
+					fx.wrapped.deleteErr = tc.err
+				}
+				fx.wrapped.activateTrace()
+				var got apiErrorEnvelope
+				resp, _ := doJSON(t, fx.client, method, path, map[string]any{}, &got)
+				assertSprintLifecycleRESTError(t, resp, got, tc.wantStatus, tc.wantCode, tc.wantMessage, nil)
+				wantTrace := []string{"access", "role", operation}
+				if operation == "delete" {
+					wantTrace = []string{"access", "target", "role", "delete"}
+				}
+				assertSprintLifecycleRESTTrace(t, fx.wrapped, wantTrace...)
+				if after := getSprintLifecycleRESTSprint(t, fx, target.ID); !reflect.DeepEqual(after, before) {
+					t.Fatalf("mapped mutation failure changed sprint before=%+v after=%+v", before, after)
+				}
+				assertSprintLifecycleRESTSilence(t, fx)
+			})
+		}
+	}
+}

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -9,10 +9,10 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	"time"
 
 	boardapp "scrumboy/internal/application/board"
 	membershipapp "scrumboy/internal/application/membership"
+	sprintapp "scrumboy/internal/application/sprint"
 	todoapp "scrumboy/internal/application/todo"
 	todolinkapp "scrumboy/internal/application/todolink"
 	workflowapp "scrumboy/internal/application/workflow"
@@ -38,13 +38,12 @@ type storeAPI interface {
 	todoapp.MCPMoveLaneStore
 	ListSprintsWithTodoCount(ctx context.Context, projectID int64) ([]store.SprintWithTodoCount, error)
 	CountUnscheduledTodos(ctx context.Context, projectID int64) (int64, error)
+	sprintapp.DefinitionStore
 	GetSprintByID(ctx context.Context, sprintID int64) (store.Sprint, error)
 	GetActiveSprintByProjectID(ctx context.Context, projectID int64) (*store.Sprint, error)
-	CreateSprint(ctx context.Context, projectID int64, name string, plannedStartAt, plannedEndAt time.Time) (store.Sprint, error)
 	GetProjectRole(ctx context.Context, projectID int64, userID int64) (store.ProjectRole, error)
 	ActivateSprint(ctx context.Context, projectID, sprintID int64) error
 	CloseSprint(ctx context.Context, sprintID int64) error
-	UpdateSprint(ctx context.Context, sprintID int64, in store.UpdateSprintInput) error
 	DeleteSprint(ctx context.Context, projectID, sprintID int64) error
 	ListTagCounts(ctx context.Context, pc *store.ProjectContext) ([]store.TagCount, error)
 	ListUserTags(ctx context.Context, userID int64) ([]store.TagWithColor, error)
@@ -94,6 +93,7 @@ type Adapter struct {
 	todoLinkMutations   *todolinkapp.MCPMutationService
 	workflowMutations   *workflowapp.MCPMutationService
 	membershipMutations *membershipapp.MCPMutationService
+	sprintDefinitions   *sprintapp.MCPDefinitionService
 	mode                string
 	tools               toolRegistry
 	publicOrigin        *publicorigin.Resolver
@@ -157,6 +157,12 @@ func New(st storeAPI, opts Options) *Adapter {
 			Access:    st,
 			Mutations: st,
 			Members:   st,
+		}),
+		sprintDefinitions: sprintapp.NewMCPDefinitionService(sprintapp.MCPDefinitionServiceDependencies{
+			Access:      st,
+			Roles:       st,
+			Definitions: st,
+			Sprints:     st,
 		}),
 		mode:         mode,
 		tools:        make(toolRegistry),

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -39,12 +39,11 @@ type storeAPI interface {
 	ListSprintsWithTodoCount(ctx context.Context, projectID int64) ([]store.SprintWithTodoCount, error)
 	CountUnscheduledTodos(ctx context.Context, projectID int64) (int64, error)
 	sprintapp.DefinitionStore
+	sprintapp.TransitionStore
+	sprintapp.DeletionStore
 	GetSprintByID(ctx context.Context, sprintID int64) (store.Sprint, error)
 	GetActiveSprintByProjectID(ctx context.Context, projectID int64) (*store.Sprint, error)
 	GetProjectRole(ctx context.Context, projectID int64, userID int64) (store.ProjectRole, error)
-	ActivateSprint(ctx context.Context, projectID, sprintID int64) error
-	CloseSprint(ctx context.Context, projectID, sprintID int64) error
-	DeleteSprint(ctx context.Context, projectID, sprintID int64) error
 	ListTagCounts(ctx context.Context, pc *store.ProjectContext) ([]store.TagCount, error)
 	ListUserTags(ctx context.Context, userID int64) ([]store.TagWithColor, error)
 	UpdateTagColor(ctx context.Context, viewerUserID *int64, tagID int64, color *string) error
@@ -94,6 +93,8 @@ type Adapter struct {
 	workflowMutations   *workflowapp.MCPMutationService
 	membershipMutations *membershipapp.MCPMutationService
 	sprintDefinitions   *sprintapp.MCPDefinitionService
+	sprintLifecycle     *sprintapp.MCPLifecycleService
+	sprintDeletions     *sprintapp.MCPDeletionService
 	mode                string
 	tools               toolRegistry
 	publicOrigin        *publicorigin.Resolver
@@ -163,6 +164,18 @@ func New(st storeAPI, opts Options) *Adapter {
 			Roles:       st,
 			Definitions: st,
 			Sprints:     st,
+		}),
+		sprintLifecycle: sprintapp.NewMCPLifecycleService(sprintapp.MCPLifecycleServiceDependencies{
+			Access:      st,
+			Roles:       st,
+			Sprints:     st,
+			Transitions: st,
+		}),
+		sprintDeletions: sprintapp.NewMCPDeletionService(sprintapp.MCPDeletionServiceDependencies{
+			Access:    st,
+			Roles:     st,
+			Sprints:   st,
+			Deletions: st,
 		}),
 		mode:         mode,
 		tools:        make(toolRegistry),

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -43,7 +43,7 @@ type storeAPI interface {
 	GetActiveSprintByProjectID(ctx context.Context, projectID int64) (*store.Sprint, error)
 	GetProjectRole(ctx context.Context, projectID int64, userID int64) (store.ProjectRole, error)
 	ActivateSprint(ctx context.Context, projectID, sprintID int64) error
-	CloseSprint(ctx context.Context, sprintID int64) error
+	CloseSprint(ctx context.Context, projectID, sprintID int64) error
 	DeleteSprint(ctx context.Context, projectID, sprintID int64) error
 	ListTagCounts(ctx context.Context, pc *store.ProjectContext) ([]store.TagCount, error)
 	ListUserTags(ctx context.Context, userID int64) ([]store.TagWithColor, error)

--- a/internal/mcp/sprint_definition_error_mapping_test.go
+++ b/internal/mcp/sprint_definition_error_mapping_test.go
@@ -1,0 +1,118 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	sprintapp "scrumboy/internal/application/sprint"
+	"scrumboy/internal/store"
+)
+
+func TestMapSprintDefinitionPrepareErrorSentinels(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		status  int
+		code    string
+		message string
+	}{
+		{
+			name:    "actor",
+			err:     sprintapp.ErrActorRequired,
+			status:  http.StatusUnauthorized,
+			code:    CodeAuthRequired,
+			message: "Sign-in required for this tool",
+		},
+		{
+			name:    "maintainer",
+			err:     sprintapp.ErrMaintainerRequired,
+			status:  http.StatusForbidden,
+			code:    CodeForbidden,
+			message: "maintainer or higher required",
+		},
+		{
+			name:    "project mismatch",
+			err:     sprintapp.ErrSprintNotInProject,
+			status:  http.StatusNotFound,
+			code:    CodeNotFound,
+			message: "not found",
+		},
+		{
+			name:    "wrapped actor",
+			err:     fmt.Errorf("outer diagnostic: %w", sprintapp.ErrActorRequired),
+			status:  http.StatusUnauthorized,
+			code:    CodeAuthRequired,
+			message: "Sign-in required for this tool",
+		},
+		{
+			name:    "wrapped maintainer",
+			err:     fmt.Errorf("outer diagnostic: %w", sprintapp.ErrMaintainerRequired),
+			status:  http.StatusForbidden,
+			code:    CodeForbidden,
+			message: "maintainer or higher required",
+		},
+		{
+			name:    "wrapped project mismatch",
+			err:     fmt.Errorf("outer diagnostic: %w", sprintapp.ErrSprintNotInProject),
+			status:  http.StatusNotFound,
+			code:    CodeNotFound,
+			message: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapSprintDefinitionPrepareError(tt.err)
+			if got.Status != tt.status || got.Code != tt.code || got.Message != tt.message {
+				t.Fatalf("mapped = status %d code %q message %q", got.Status, got.Code, got.Message)
+			}
+			if got.Details != nil || got.Cause != nil {
+				t.Fatalf("mapped details/cause = %#v/%v, want nil/nil", got.Details, got.Cause)
+			}
+			if details := clientErrorDetails(got); len(details) != 0 {
+				t.Fatalf("public details = %#v, want empty", details)
+			}
+		})
+	}
+}
+
+func TestMapSprintDefinitionPrepareErrorDelegatesRawErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "unauthorized", err: store.ErrUnauthorized},
+		{name: "forbidden", err: store.ErrForbidden},
+		{name: "not found", err: store.ErrNotFound},
+		{name: "validation", err: fmt.Errorf("%w: invalid sprint", store.ErrValidation)},
+		{name: "conflict", err: fmt.Errorf("%w: duplicate sprint", store.ErrConflict)},
+		{name: "private", err: errors.New("private sprint dependency failure")},
+		{name: "cancellation", err: context.Canceled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapSprintDefinitionPrepareError(tt.err)
+			want := mapStoreError(tt.err)
+			if got.Status != want.Status || got.Code != want.Code || got.Message != want.Message ||
+				!reflect.DeepEqual(got.Details, want.Details) {
+				t.Fatalf("mapped = %#v, want mapStoreError result %#v", got, want)
+			}
+			switch {
+			case got.Cause == nil && want.Cause == nil:
+			case got.Cause != nil && want.Cause != nil && got.Cause.Error() == want.Cause.Error():
+			default:
+				t.Fatalf("mapped cause = %v, want %v", got.Cause, want.Cause)
+			}
+			if got.Code == CodeInternal {
+				if details := clientErrorDetails(got); len(details) != 0 {
+					t.Fatalf("internal public details = %#v, want empty", details)
+				}
+			}
+		})
+	}
+}

--- a/internal/mcp/sprint_definition_transport_contract_test.go
+++ b/internal/mcp/sprint_definition_transport_contract_test.go
@@ -1,0 +1,855 @@
+package mcp_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"scrumboy/internal/db"
+	"scrumboy/internal/httpapi"
+	"scrumboy/internal/mcp"
+	"scrumboy/internal/migrate"
+	"scrumboy/internal/store"
+)
+
+type sprintDefinitionMCPStore struct {
+	*store.Store
+
+	mu sync.Mutex
+
+	active bool
+	trace  []string
+
+	accessErr     error
+	roleErr       error
+	roleOverride  *store.ProjectRole
+	targetErr     error
+	projectionErr error
+	createErr     error
+	updateErr     error
+
+	accessSlug string
+	accessMode store.Mode
+	rolePID    int64
+	roleUID    int64
+
+	readCalls int
+	readIDs   []int64
+
+	createCalls int
+	createPID   int64
+	createName  string
+	createStart time.Time
+	createEnd   time.Time
+
+	updateCalls int
+	updateID    int64
+	updateInput store.UpdateSprintInput
+}
+
+func (s *sprintDefinitionMCPStore) activate() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.active = true
+	s.trace = nil
+	s.readCalls = 0
+	s.readIDs = nil
+	s.createCalls = 0
+	s.updateCalls = 0
+}
+
+func (s *sprintDefinitionMCPStore) record(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.active {
+		return false
+	}
+	s.trace = append(s.trace, name)
+	return true
+}
+
+func (s *sprintDefinitionMCPStore) snapshotTrace() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.trace...)
+}
+
+func (s *sprintDefinitionMCPStore) GetProjectContextBySlug(ctx context.Context, slug string, mode store.Mode) (store.ProjectContext, error) {
+	if !s.record("access") {
+		return s.Store.GetProjectContextBySlug(ctx, slug, mode)
+	}
+	s.mu.Lock()
+	s.accessSlug = slug
+	s.accessMode = mode
+	err := s.accessErr
+	s.mu.Unlock()
+	if err != nil {
+		return store.ProjectContext{}, err
+	}
+	return s.Store.GetProjectContextBySlug(ctx, slug, mode)
+}
+
+func (s *sprintDefinitionMCPStore) GetProjectRole(ctx context.Context, projectID, userID int64) (store.ProjectRole, error) {
+	if !s.record("role") {
+		return s.Store.GetProjectRole(ctx, projectID, userID)
+	}
+	s.mu.Lock()
+	s.rolePID = projectID
+	s.roleUID = userID
+	err := s.roleErr
+	override := s.roleOverride
+	s.mu.Unlock()
+	if err != nil {
+		return "", err
+	}
+	if override != nil {
+		return *override, nil
+	}
+	return s.Store.GetProjectRole(ctx, projectID, userID)
+}
+
+func (s *sprintDefinitionMCPStore) GetSprintByID(ctx context.Context, sprintID int64) (store.Sprint, error) {
+	s.mu.Lock()
+	if !s.active {
+		s.mu.Unlock()
+		return s.Store.GetSprintByID(ctx, sprintID)
+	}
+	s.readCalls++
+	readNumber := s.readCalls
+	s.readIDs = append(s.readIDs, sprintID)
+	stage := "target"
+	err := s.targetErr
+	if readNumber > 1 {
+		stage = "projection"
+		err = s.projectionErr
+	}
+	s.trace = append(s.trace, stage)
+	s.mu.Unlock()
+	if err != nil {
+		return store.Sprint{}, err
+	}
+	return s.Store.GetSprintByID(ctx, sprintID)
+}
+
+func (s *sprintDefinitionMCPStore) CreateSprint(ctx context.Context, projectID int64, name string, plannedStartAt, plannedEndAt time.Time) (store.Sprint, error) {
+	if !s.record("create") {
+		return s.Store.CreateSprint(ctx, projectID, name, plannedStartAt, plannedEndAt)
+	}
+	s.mu.Lock()
+	s.createCalls++
+	s.createPID = projectID
+	s.createName = name
+	s.createStart = plannedStartAt
+	s.createEnd = plannedEndAt
+	err := s.createErr
+	s.mu.Unlock()
+	if err != nil {
+		return store.Sprint{}, err
+	}
+	return s.Store.CreateSprint(ctx, projectID, name, plannedStartAt, plannedEndAt)
+}
+
+func (s *sprintDefinitionMCPStore) UpdateSprint(ctx context.Context, sprintID int64, in store.UpdateSprintInput) error {
+	if !s.record("update") {
+		return s.Store.UpdateSprint(ctx, sprintID, in)
+	}
+	s.mu.Lock()
+	s.updateCalls++
+	s.updateID = sprintID
+	s.updateInput = in
+	err := s.updateErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.Store.UpdateSprint(ctx, sprintID, in)
+}
+
+type sprintDefinitionMCPFixture struct {
+	ts      *httptest.Server
+	db      *sql.DB
+	st      *store.Store
+	wrapped *sprintDefinitionMCPStore
+	client  *http.Client
+	ownerID int64
+	ctx     context.Context
+	project store.Project
+}
+
+func newSprintDefinitionMCPFixture(t *testing.T, name string) *sprintDefinitionMCPFixture {
+	t.Helper()
+
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "app.db"), db.Options{
+		BusyTimeout: 5000,
+		JournalMode: "WAL",
+		Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := migrate.Apply(context.Background(), sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+	st := store.New(sqlDB, nil)
+	wrapped := &sprintDefinitionMCPStore{Store: st}
+	srv := httpapi.NewServer(wrapped, httpapi.Options{
+		MaxRequestBody: 1 << 20,
+		ScrumboyMode:   "full",
+		MCPHandler:     mcp.New(wrapped, mcp.Options{Mode: "full"}),
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(func() {
+		ts.Close()
+		_ = sqlDB.Close()
+	})
+
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	ownerID := firstUserID(t, sqlDB)
+	ctx := store.WithUserID(context.Background(), ownerID)
+	project, err := st.CreateProject(ctx, name)
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	return &sprintDefinitionMCPFixture{
+		ts: ts, db: sqlDB, st: st, wrapped: wrapped, client: client,
+		ownerID: ownerID, ctx: ctx, project: project,
+	}
+}
+
+func createSprintDefinitionMCPSprint(t *testing.T, fx *sprintDefinitionMCPFixture, name string) store.Sprint {
+	t.Helper()
+	start := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
+	sp, err := fx.st.CreateSprint(fx.ctx, fx.project.ID, name, start, start.Add(7*24*time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSprint fixture: %v", err)
+	}
+	return sp
+}
+
+func subscribeSprintDefinitionMCPEvents(t *testing.T, fx *sprintDefinitionMCPFixture) *todoUpdateMCPEventStream {
+	t.Helper()
+	return subscribeTodoUpdateMCPEvents(t, fx.client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+}
+
+func assertSprintDefinitionMCPTrace(t *testing.T, wrapped *sprintDefinitionMCPStore, want ...string) {
+	t.Helper()
+	if got := wrapped.snapshotTrace(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("store trace=%v, want %v", got, want)
+	}
+}
+
+func assertSprintDefinitionMCPSilence(t *testing.T, stream *todoUpdateMCPEventStream) {
+	t.Helper()
+	if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+		t.Fatalf("MCP sprint mutation emitted realtime events: %+v", events)
+	}
+}
+
+func sprintDefinitionMCPData(t *testing.T, transport string, response map[string]any) map[string]any {
+	t.Helper()
+	return todoLinkMCPData(t, transport, response)
+}
+
+func assertSprintDefinitionMCPItem(t *testing.T, data map[string]any, projectSlug string, sprintID, number int64, name string, start, end time.Time) map[string]any {
+	t.Helper()
+	if got, want := sortedMapKeys(data), []string{"sprint"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("data keys=%v, want %v; data=%+v", got, want, data)
+	}
+	item, ok := data["sprint"].(map[string]any)
+	if !ok {
+		t.Fatalf("sprint projection type=%T data=%+v", data["sprint"], data)
+	}
+	if got, want := sortedMapKeys(item), []string{"closedAt", "name", "number", "plannedEndAt", "plannedStartAt", "projectSlug", "sprintId", "startedAt", "state", "todoCount"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("sprint keys=%v, want %v; sprint=%+v", got, want, item)
+	}
+	if item["projectSlug"] != projectSlug || int64(item["sprintId"].(float64)) != sprintID || int64(item["number"].(float64)) != number || item["name"] != name || int64(item["plannedStartAt"].(float64)) != start.UnixMilli() || int64(item["plannedEndAt"].(float64)) != end.UnixMilli() || item["state"] != store.SprintStatePlanned || item["startedAt"] != nil || item["closedAt"] != nil || item["todoCount"] != nil {
+		t.Fatalf("sprint projection=%+v", item)
+	}
+	return item
+}
+
+func callSprintDefinitionMCP(t *testing.T, fx *sprintDefinitionMCPFixture, transport, tool string, args map[string]any) (*http.Response, map[string]any) {
+	t.Helper()
+	return callTodoUpdateMCP(t, fx.client, fx.ts.URL, transport, tool, args)
+}
+
+func callSprintDefinitionJSONRPCWithoutRetry(t *testing.T, client *http.Client, baseURL string, body any) (*http.Response, map[string]any) {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(body); err != nil {
+		t.Fatalf("encode JSON-RPC: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/mcp/rpc", &buf)
+	if err != nil {
+		t.Fatalf("new JSON-RPC request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("MCP-Protocol-Version", "2025-11-25")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do JSON-RPC request: %v", err)
+	}
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read JSON-RPC response: %v", err)
+	}
+	if len(bodyBytes) == 0 {
+		return resp, nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(bodyBytes, &out); err != nil {
+		t.Fatalf("decode JSON-RPC response: %v body=%s", err, bodyBytes)
+	}
+	return resp, out
+}
+
+func TestSprintDefinitionMCPTransportAndDefinitionContracts(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		t.Run(transport+"/create", func(t *testing.T) {
+			fx := newSprintDefinitionMCPFixture(t, "mcp-sprint-definition-create-"+transport)
+			stream := subscribeSprintDefinitionMCPEvents(t, fx)
+			defer stream.close()
+			start := time.Date(2026, time.August, 11, 13, 14, 15, 456000000, time.FixedZone("plus-two", 2*60*60))
+			end := start.Add(9 * 24 * time.Hour)
+			fx.wrapped.activate()
+
+			resp, out := callSprintDefinitionMCP(t, fx, transport, "sprints_create", map[string]any{
+				"projectSlug":    fx.project.Slug,
+				"name":           "  MCP definition  ",
+				"plannedStartAt": start.Format(time.RFC3339Nano),
+				"plannedEndAt":   end.Format(time.RFC3339Nano),
+			})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("create status=%d response=%+v", resp.StatusCode, out)
+			}
+			var stored store.Sprint
+			if err := fx.db.QueryRow(`SELECT id FROM sprints WHERE project_id = ? AND name = ?`, fx.project.ID, "MCP definition").Scan(&stored.ID); err != nil {
+				t.Fatalf("query created sprint ID: %v", err)
+			}
+			stored, err := fx.st.GetSprintByID(fx.ctx, stored.ID)
+			if err != nil {
+				t.Fatalf("GetSprintByID: %v", err)
+			}
+			assertSprintDefinitionMCPItem(t, sprintDefinitionMCPData(t, transport, out), fx.project.Slug, stored.ID, stored.Number, "MCP definition", stored.PlannedStartAt, stored.PlannedEndAt)
+			assertSprintDefinitionMCPTrace(t, fx.wrapped, "access", "role", "create")
+			if fx.wrapped.accessSlug != fx.project.Slug || fx.wrapped.accessMode != store.ModeFull || fx.wrapped.rolePID != fx.project.ID || fx.wrapped.roleUID != fx.ownerID {
+				t.Fatalf("access/role args=(slug=%q mode=%q project=%d user=%d)", fx.wrapped.accessSlug, fx.wrapped.accessMode, fx.wrapped.rolePID, fx.wrapped.roleUID)
+			}
+			if fx.wrapped.createCalls != 1 || fx.wrapped.createPID != fx.project.ID || fx.wrapped.createName != "  MCP definition  " || !fx.wrapped.createStart.Equal(start) || !fx.wrapped.createEnd.Equal(end) {
+				t.Fatalf("create call=(count=%d project=%d name=%q start=%s end=%s)", fx.wrapped.createCalls, fx.wrapped.createPID, fx.wrapped.createName, fx.wrapped.createStart, fx.wrapped.createEnd)
+			}
+			assertSprintDefinitionMCPSilence(t, stream)
+		})
+
+		t.Run(transport+"/update", func(t *testing.T) {
+			fx := newSprintDefinitionMCPFixture(t, "mcp-sprint-definition-update-"+transport)
+			offsetProject, err := fx.st.CreateProject(fx.ctx, "mcp-sprint-definition-offset-"+transport)
+			if err != nil {
+				t.Fatalf("CreateProject offset: %v", err)
+			}
+			offsetStart := time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC)
+			if _, err := fx.st.CreateSprint(fx.ctx, offsetProject.ID, "Offset", offsetStart, offsetStart.Add(24*time.Hour)); err != nil {
+				t.Fatalf("CreateSprint offset: %v", err)
+			}
+			sp := createSprintDefinitionMCPSprint(t, fx, "Before MCP update")
+			if sp.ID == sp.Number {
+				t.Fatalf("identity fixture requires stored ID and local number to differ, sprint=%+v", sp)
+			}
+			stream := subscribeSprintDefinitionMCPEvents(t, fx)
+			defer stream.close()
+			newStart := sp.PlannedStartAt.Add(24 * time.Hour)
+			newEnd := sp.PlannedEndAt.Add(48 * time.Hour)
+			fx.wrapped.activate()
+
+			resp, out := callSprintDefinitionMCP(t, fx, transport, "sprints_update", map[string]any{
+				"projectSlug": fx.project.Slug,
+				"sprintId":    sp.ID,
+				"patch":       map[string]any{"name": "After MCP update", "plannedStartAt": newStart.UnixMilli(), "plannedEndAt": newEnd.UnixMilli()},
+			})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("update status=%d response=%+v", resp.StatusCode, out)
+			}
+			assertSprintDefinitionMCPItem(t, sprintDefinitionMCPData(t, transport, out), fx.project.Slug, sp.ID, sp.Number, "After MCP update", newStart, newEnd)
+			assertSprintDefinitionMCPTrace(t, fx.wrapped, "access", "role", "target", "update", "projection")
+			if fx.wrapped.readCalls != 2 || !reflect.DeepEqual(fx.wrapped.readIDs, []int64{sp.ID, sp.ID}) || fx.wrapped.updateCalls != 1 || fx.wrapped.updateID != sp.ID {
+				t.Fatalf("read/update=(reads=%d ids=%v calls=%d id=%d), want verified stored ID %d", fx.wrapped.readCalls, fx.wrapped.readIDs, fx.wrapped.updateCalls, fx.wrapped.updateID, sp.ID)
+			}
+			in := fx.wrapped.updateInput
+			if in.Name == nil || *in.Name != "After MCP update" || in.PlannedStartAt == nil || !in.PlannedStartAt.Equal(newStart) || in.PlannedEndAt == nil || !in.PlannedEndAt.Equal(newEnd) {
+				t.Fatalf("update input=%+v", in)
+			}
+			assertSprintDefinitionMCPSilence(t, stream)
+		})
+	}
+}
+
+func TestSprintDefinitionMCPEmptyPatchContract(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		t.Run(transport, func(t *testing.T) {
+			fx := newSprintDefinitionMCPFixture(t, "mcp-sprint-definition-empty-"+transport)
+			sp := createSprintDefinitionMCPSprint(t, fx, "Empty MCP patch")
+			stream := subscribeSprintDefinitionMCPEvents(t, fx)
+			defer stream.close()
+			fx.wrapped.activate()
+
+			resp, out := callSprintDefinitionMCP(t, fx, transport, "sprints_update", map[string]any{
+				"projectSlug": fx.project.Slug, "sprintId": sp.ID, "patch": map[string]any{},
+			})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("empty patch status=%d response=%+v", resp.StatusCode, out)
+			}
+			assertSprintDefinitionMCPItem(t, sprintDefinitionMCPData(t, transport, out), fx.project.Slug, sp.ID, sp.Number, sp.Name, sp.PlannedStartAt, sp.PlannedEndAt)
+			assertSprintDefinitionMCPTrace(t, fx.wrapped, "access", "role", "target")
+			if fx.wrapped.readCalls != 1 || fx.wrapped.updateCalls != 0 {
+				t.Fatalf("empty patch reads=%d updates=%d, want one preparation read and no mutation/post-read", fx.wrapped.readCalls, fx.wrapped.updateCalls)
+			}
+			assertSprintDefinitionMCPSilence(t, stream)
+		})
+	}
+}
+
+func TestSprintDefinitionMCPCancellationContract(t *testing.T) {
+	type testCase struct {
+		operation string
+		stage     string
+		wantTrace []string
+	}
+	cases := []testCase{
+		{operation: "create", stage: "access", wantTrace: []string{"access"}},
+		{operation: "create", stage: "role", wantTrace: []string{"access", "role"}},
+		{operation: "create", stage: "mutation", wantTrace: []string{"access", "role", "create"}},
+		{operation: "update", stage: "access", wantTrace: []string{"access"}},
+		{operation: "update", stage: "role", wantTrace: []string{"access", "role"}},
+		{operation: "update", stage: "target", wantTrace: []string{"access", "role", "target"}},
+		{operation: "update", stage: "mutation", wantTrace: []string{"access", "role", "target", "update"}},
+		{operation: "update", stage: "projection", wantTrace: []string{"access", "role", "target", "update", "projection"}},
+	}
+
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		for _, tc := range cases {
+			t.Run(transport+"/"+tc.operation+"/"+tc.stage, func(t *testing.T) {
+				fx := newSprintDefinitionMCPFixture(t, "mcp-sprint-definition-cancel-"+transport+"-"+tc.operation+"-"+tc.stage)
+				var sp store.Sprint
+				if tc.operation == "update" {
+					sp = createSprintDefinitionMCPSprint(t, fx, "Before canceled MCP update")
+				}
+				stream := subscribeSprintDefinitionMCPEvents(t, fx)
+				defer stream.close()
+				switch tc.stage {
+				case "access":
+					fx.wrapped.accessErr = context.Canceled
+				case "role":
+					fx.wrapped.roleErr = context.Canceled
+				case "target":
+					fx.wrapped.targetErr = context.Canceled
+				case "mutation":
+					if tc.operation == "create" {
+						fx.wrapped.createErr = context.Canceled
+					} else {
+						fx.wrapped.updateErr = context.Canceled
+					}
+				case "projection":
+					fx.wrapped.projectionErr = context.Canceled
+				}
+				fx.wrapped.activate()
+
+				tool := "sprints_create"
+				args := map[string]any{
+					"projectSlug": fx.project.Slug, "name": "Canceled MCP create",
+					"plannedStartAt": "2026-08-10T12:00:00Z", "plannedEndAt": "2026-08-17T12:00:00Z",
+				}
+				if tc.operation == "update" {
+					tool = "sprints_update"
+					args = map[string]any{"projectSlug": fx.project.Slug, "sprintId": sp.ID, "patch": map[string]any{"name": "Canceled MCP update"}}
+				}
+				resp, out := callSprintDefinitionMCP(t, fx, transport, tool, args)
+				publicErr := assertTodoLinkMCPError(t, transport, resp, out, http.StatusInternalServerError, "INTERNAL", "internal error")
+				assertEmptyTodoLinkMCPDetails(t, publicErr)
+				assertSprintDefinitionMCPTrace(t, fx.wrapped, tc.wantTrace...)
+				assertSprintDefinitionMCPSilence(t, stream)
+
+				if tc.operation == "create" {
+					var count int
+					if err := fx.db.QueryRow(`SELECT COUNT(*) FROM sprints WHERE project_id = ?`, fx.project.ID).Scan(&count); err != nil {
+						t.Fatalf("count sprints: %v", err)
+					}
+					if count != 0 {
+						t.Fatalf("canceled create rows=%d, want zero", count)
+					}
+					return
+				}
+				stored, err := fx.st.GetSprintByID(fx.ctx, sp.ID)
+				if err != nil {
+					t.Fatalf("GetSprintByID: %v", err)
+				}
+				if tc.stage == "projection" {
+					if stored.Name != "Canceled MCP update" || fx.wrapped.updateCalls != 1 {
+						t.Fatalf("projection cancellation stored=%+v updateCalls=%d, want committed update", stored, fx.wrapped.updateCalls)
+					}
+				} else if stored.Name != sp.Name {
+					t.Fatalf("pre-commit cancellation stored=%+v, want unchanged name %q", stored, sp.Name)
+				}
+			})
+		}
+	}
+}
+
+func TestSprintDefinitionMCPCommittedCreateFailureContract(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		t.Run(transport, func(t *testing.T) {
+			fx := newSprintDefinitionMCPFixture(t, "mcp-sprint-definition-committed-create-"+transport)
+			const corruptValue = "mcp-create-return-read-failed"
+			if _, err := fx.db.Exec(`
+				CREATE TRIGGER sprint_definition_mcp_corrupt_created_row
+				AFTER INSERT ON sprints
+				BEGIN
+					UPDATE sprints SET planned_start_at = '` + corruptValue + `' WHERE id = NEW.id;
+				END
+			`); err != nil {
+				t.Fatalf("create post-insert fault trigger: %v", err)
+			}
+			stream := subscribeSprintDefinitionMCPEvents(t, fx)
+			defer stream.close()
+			fx.wrapped.activate()
+
+			resp, out := callSprintDefinitionMCP(t, fx, transport, "sprints_create", map[string]any{
+				"projectSlug":    fx.project.Slug,
+				"name":           "Committed MCP failure",
+				"plannedStartAt": "2026-08-10T12:00:00Z",
+				"plannedEndAt":   "2026-08-17T12:00:00Z",
+			})
+			publicErr := assertTodoLinkMCPError(t, transport, resp, out, http.StatusInternalServerError, "INTERNAL", "internal error")
+			assertEmptyTodoLinkMCPDetails(t, publicErr)
+			assertSprintDefinitionMCPTrace(t, fx.wrapped, "access", "role", "create")
+			if fx.wrapped.createCalls != 1 {
+				t.Fatalf("create calls=%d, want one with no retry", fx.wrapped.createCalls)
+			}
+			var (
+				count int
+				raw   string
+			)
+			if err := fx.db.QueryRow(`SELECT COUNT(*), MIN(CAST(planned_start_at AS TEXT)) FROM sprints WHERE project_id = ? AND name = ?`, fx.project.ID, "Committed MCP failure").Scan(&count, &raw); err != nil {
+				t.Fatalf("query committed sprint: %v", err)
+			}
+			if count != 1 || raw != corruptValue {
+				t.Fatalf("committed sprint=(count=%d raw=%q), want one unreadable row", count, raw)
+			}
+			assertSprintDefinitionMCPSilence(t, stream)
+		})
+	}
+}
+
+func TestSprintDefinitionMCPAuthorityAndBoundaryContracts(t *testing.T) {
+	t.Run("fresh role lookup is authoritative over access context", func(t *testing.T) {
+		for _, transport := range []string{"legacy", "jsonrpc"} {
+			t.Run(transport, func(t *testing.T) {
+				fx := newSprintDefinitionMCPFixture(t, "mcp-sprint-definition-fresh-role-"+transport)
+				viewer := store.RoleViewer
+				fx.wrapped.roleOverride = &viewer
+				stream := subscribeSprintDefinitionMCPEvents(t, fx)
+				defer stream.close()
+				fx.wrapped.activate()
+				resp, out := callSprintDefinitionMCP(t, fx, transport, "sprints_create", map[string]any{
+					"projectSlug": fx.project.Slug, "name": "Denied by fresh role",
+					"plannedStartAt": "2026-08-10T12:00:00Z", "plannedEndAt": "2026-08-17T12:00:00Z",
+				})
+				publicErr := assertTodoLinkMCPError(t, transport, resp, out, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required")
+				assertEmptyTodoLinkMCPDetails(t, publicErr)
+				assertSprintDefinitionMCPTrace(t, fx.wrapped, "access", "role")
+				if fx.wrapped.roleUID != fx.ownerID || fx.wrapped.createCalls != 0 {
+					t.Fatalf("role user=%d createCalls=%d, want authenticated actor at role lookup and no mutation", fx.wrapped.roleUID, fx.wrapped.createCalls)
+				}
+				assertSprintDefinitionMCPSilence(t, stream)
+			})
+		}
+	})
+
+	t.Run("cross-project target is hidden before patch parsing", func(t *testing.T) {
+		for _, transport := range []string{"legacy", "jsonrpc"} {
+			t.Run(transport, func(t *testing.T) {
+				fx := newSprintDefinitionMCPFixture(t, "mcp-sprint-definition-cross-project-"+transport)
+				other, err := fx.st.CreateProject(fx.ctx, "mcp-sprint-definition-other-"+transport)
+				if err != nil {
+					t.Fatalf("CreateProject other: %v", err)
+				}
+				start := time.Date(2026, time.August, 12, 0, 0, 0, 0, time.UTC)
+				foreign, err := fx.st.CreateSprint(fx.ctx, other.ID, "Foreign", start, start.Add(24*time.Hour))
+				if err != nil {
+					t.Fatalf("CreateSprint other: %v", err)
+				}
+				stream := subscribeSprintDefinitionMCPEvents(t, fx)
+				defer stream.close()
+				fx.wrapped.activate()
+				resp, out := callSprintDefinitionMCP(t, fx, transport, "sprints_update", map[string]any{
+					"projectSlug": fx.project.Slug, "sprintId": foreign.ID, "patch": map[string]any{"state": "ACTIVE"},
+				})
+				publicErr := assertTodoLinkMCPError(t, transport, resp, out, http.StatusNotFound, "NOT_FOUND", "not found")
+				assertEmptyTodoLinkMCPDetails(t, publicErr)
+				assertSprintDefinitionMCPTrace(t, fx.wrapped, "access", "role", "target")
+				if fx.wrapped.updateCalls != 0 {
+					t.Fatalf("cross-project update calls=%d", fx.wrapped.updateCalls)
+				}
+				assertSprintDefinitionMCPSilence(t, stream)
+			})
+		}
+	})
+
+	t.Run("state is not a public definition patch field", func(t *testing.T) {
+		for _, transport := range []string{"legacy", "jsonrpc"} {
+			t.Run(transport, func(t *testing.T) {
+				fx := newSprintDefinitionMCPFixture(t, "mcp-sprint-definition-state-field-"+transport)
+				sp := createSprintDefinitionMCPSprint(t, fx, "No MCP state patch")
+				stream := subscribeSprintDefinitionMCPEvents(t, fx)
+				defer stream.close()
+				fx.wrapped.activate()
+				resp, out := callSprintDefinitionMCP(t, fx, transport, "sprints_update", map[string]any{
+					"projectSlug": fx.project.Slug, "sprintId": sp.ID, "patch": map[string]any{"state": "ACTIVE"},
+				})
+				publicErr := assertTodoLinkMCPError(t, transport, resp, out, http.StatusBadRequest, "VALIDATION_ERROR", "unsupported patch field")
+				details, ok := publicErr["details"].(map[string]any)
+				if !ok || details["field"] != "state" {
+					t.Fatalf("state patch details=%+v", publicErr)
+				}
+				assertSprintDefinitionMCPTrace(t, fx.wrapped, "access", "role", "target")
+				assertSprintDefinitionMCPSilence(t, stream)
+			})
+		}
+	})
+
+	t.Run("create requires RFC3339 strings before access", func(t *testing.T) {
+		for _, transport := range []string{"legacy", "jsonrpc"} {
+			t.Run(transport, func(t *testing.T) {
+				fx := newSprintDefinitionMCPFixture(t, "mcp-sprint-definition-time-format-"+transport)
+				stream := subscribeSprintDefinitionMCPEvents(t, fx)
+				defer stream.close()
+				fx.wrapped.activate()
+				resp, out := callSprintDefinitionMCP(t, fx, transport, "sprints_create", map[string]any{
+					"projectSlug": fx.project.Slug, "name": "Numeric MCP dates", "plannedStartAt": int64(1000), "plannedEndAt": int64(2000),
+				})
+				assertTodoLinkMCPError(t, transport, resp, out, http.StatusBadRequest, "VALIDATION_ERROR", "invalid input")
+				assertSprintDefinitionMCPTrace(t, fx.wrapped)
+				assertSprintDefinitionMCPSilence(t, stream)
+			})
+		}
+	})
+}
+
+func TestSprintDefinitionMCPAuthenticationAndCapabilityContracts(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		for _, operation := range []string{"create", "update"} {
+			t.Run("signed-out/"+transport+"/"+operation, func(t *testing.T) {
+				fx := newSprintDefinitionMCPFixture(t, "mcp-sprint-definition-signed-out-"+transport+"-"+operation)
+				tool := "sprints_create"
+				args := map[string]any{}
+				if operation == "update" {
+					tool = "sprints_update"
+				}
+				client := newStatelessClient(fx.ts)
+				var resp *http.Response
+				var out map[string]any
+				if transport == "legacy" {
+					resp, out = doMCP(t, client, fx.ts.URL+"/mcp", map[string]any{"tool": tool, "input": args})
+				} else {
+					resp, out = callSprintDefinitionJSONRPCWithoutRetry(t, client, fx.ts.URL, map[string]any{
+						"jsonrpc": "2.0", "id": 71, "method": "tools/call", "params": map[string]any{"name": tool, "arguments": args},
+					})
+				}
+				if resp.StatusCode != http.StatusUnauthorized {
+					t.Fatalf("signed-out status=%d response=%+v", resp.StatusCode, out)
+				}
+				if transport == "jsonrpc" {
+					if out != nil {
+						t.Fatalf("signed-out JSON-RPC response=%+v, want bare 401 before tool serialization", out)
+					}
+					assertSprintDefinitionMCPTrace(t, fx.wrapped)
+					return
+				}
+				errBody, ok := out["error"].(map[string]any)
+				if !ok || errBody["code"] != "AUTH_REQUIRED" || errBody["message"] != "Sign-in required for this tool" {
+					t.Fatalf("signed-out response=%+v", out)
+				}
+				assertSprintDefinitionMCPTrace(t, fx.wrapped)
+			})
+		}
+	}
+
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		for _, operation := range []string{"create", "update"} {
+			t.Run("anonymous/"+transport+"/"+operation, func(t *testing.T) {
+				ts, _, cleanup := newTestServer(t, "anonymous")
+				defer cleanup()
+				tool := "sprints_create"
+				wantMessage := "sprints_create is unavailable in anonymous mode"
+				args := map[string]any{
+					"projectSlug": "anonymous-project", "name": "Anonymous sprint",
+					"plannedStartAt": "2026-08-10T12:00:00Z", "plannedEndAt": "2026-08-17T12:00:00Z",
+				}
+				if operation == "update" {
+					tool = "sprints_update"
+					wantMessage = "sprints_update is unavailable in anonymous mode"
+					args = map[string]any{"projectSlug": "anonymous-project", "sprintId": int64(1), "patch": map[string]any{}}
+				}
+				client := ts.Client()
+				var resp *http.Response
+				var out map[string]any
+				if transport == "legacy" {
+					resp, out = doMCP(t, client, ts.URL+"/mcp", map[string]any{"tool": tool, "input": args})
+				} else {
+					resp, out = doJSONRPC(t, client, ts.URL, map[string]any{
+						"jsonrpc": "2.0", "id": 72, "method": "tools/call", "params": map[string]any{"name": tool, "arguments": args},
+					})
+				}
+				publicErr := assertTodoLinkMCPError(t, transport, resp, out, http.StatusForbidden, "CAPABILITY_UNAVAILABLE", wantMessage)
+				assertEmptyTodoLinkMCPDetails(t, publicErr)
+			})
+		}
+	}
+}
+
+func TestSprintDefinitionMCPAliasesRemainDispatchOnly(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		t.Run(transport, func(t *testing.T) {
+			fx := newSprintDefinitionMCPFixture(t, "mcp-sprint-definition-alias-"+transport)
+			stream := subscribeSprintDefinitionMCPEvents(t, fx)
+			defer stream.close()
+			fx.wrapped.activate()
+			resp, out := callSprintDefinitionMCP(t, fx, transport, "sprints.create", map[string]any{
+				"projectSlug": fx.project.Slug, "name": "Alias sprint",
+				"plannedStartAt": "2026-08-10T12:00:00Z", "plannedEndAt": "2026-08-17T12:00:00Z",
+			})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("create alias status=%d response=%+v", resp.StatusCode, out)
+			}
+			data := sprintDefinitionMCPData(t, transport, out)
+			item := data["sprint"].(map[string]any)
+			sprintID := int64(item["sprintId"].(float64))
+			assertSprintDefinitionMCPTrace(t, fx.wrapped, "access", "role", "create")
+
+			fx.wrapped.activate()
+			resp, out = callSprintDefinitionMCP(t, fx, transport, "sprints.update", map[string]any{
+				"projectSlug": fx.project.Slug, "sprintId": sprintID, "patch": map[string]any{},
+			})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("update alias status=%d response=%+v", resp.StatusCode, out)
+			}
+			assertSprintDefinitionMCPTrace(t, fx.wrapped, "access", "role", "target")
+			assertSprintDefinitionMCPSilence(t, stream)
+		})
+	}
+
+	fx := newSprintDefinitionMCPFixture(t, "mcp-sprint-definition-advertisement")
+	resp, out := doJSONRPC(t, fx.client, fx.ts.URL, map[string]any{"jsonrpc": "2.0", "id": 73, "method": "tools/list", "params": map[string]any{}})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("tools/list status=%d response=%+v", resp.StatusCode, out)
+	}
+	result := out["result"].(map[string]any)
+	tools := result["tools"].([]any)
+	seen := map[string]bool{}
+	for _, raw := range tools {
+		seen[raw.(map[string]any)["name"].(string)] = true
+	}
+	if !seen["sprints_create"] || !seen["sprints_update"] || seen["sprints.create"] || seen["sprints.update"] {
+		t.Fatalf("tool advertisement create/update aliases=%+v", seen)
+	}
+}
+
+func TestSprintDefinitionMCPDefinitionFieldsRespectExistingSprintState(t *testing.T) {
+	start := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name        string
+		state       string
+		patch       map[string]any
+		wantSuccess bool
+		wantName    string
+		wantMessage string
+	}{
+		{name: "planned name", state: store.SprintStatePlanned, patch: map[string]any{"name": "Planned renamed"}, wantSuccess: true, wantName: "Planned renamed"},
+		{name: "active end", state: store.SprintStateActive, patch: map[string]any{"plannedEndAt": start.Add(9 * 24 * time.Hour).UnixMilli()}, wantSuccess: true, wantName: "State fixture"},
+		{name: "active name rejected", state: store.SprintStateActive, patch: map[string]any{"name": "No active rename"}, wantName: "State fixture", wantMessage: "validation: only endAt can be updated for ACTIVE sprint"},
+		{name: "closed name", state: store.SprintStateClosed, patch: map[string]any{"name": "Closed renamed"}, wantSuccess: true, wantName: "Closed renamed"},
+		{name: "closed end rejected", state: store.SprintStateClosed, patch: map[string]any{"plannedEndAt": start.Add(10 * 24 * time.Hour).UnixMilli()}, wantName: "State fixture", wantMessage: "validation: dates cannot be updated for CLOSED sprint"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newSprintDefinitionMCPFixture(t, "mcp-sprint-definition-state-"+strings.ReplaceAll(tc.name, " ", "-"))
+			sp, err := fx.st.CreateSprint(fx.ctx, fx.project.ID, "State fixture", start, start.Add(7*24*time.Hour))
+			if err != nil {
+				t.Fatalf("CreateSprint: %v", err)
+			}
+			if tc.state != store.SprintStatePlanned {
+				var closed any
+				if tc.state == store.SprintStateClosed {
+					closed = start.Add(24 * time.Hour).UnixMilli()
+				}
+				if _, err := fx.db.Exec(`UPDATE sprints SET state = ?, started_at = ?, closed_at = ? WHERE id = ?`, tc.state, start.UnixMilli(), closed, sp.ID); err != nil {
+					t.Fatalf("set state fixture: %v", err)
+				}
+			}
+			stream := subscribeSprintDefinitionMCPEvents(t, fx)
+			defer stream.close()
+			fx.wrapped.activate()
+			resp, out := callSprintDefinitionMCP(t, fx, "legacy", "sprints_update", map[string]any{
+				"projectSlug": fx.project.Slug, "sprintId": sp.ID, "patch": tc.patch,
+			})
+			if tc.wantSuccess {
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("state update status=%d response=%+v", resp.StatusCode, out)
+				}
+				assertSprintDefinitionMCPTrace(t, fx.wrapped, "access", "role", "target", "update", "projection")
+			} else {
+				assertTodoLinkMCPError(t, "legacy", resp, out, http.StatusBadRequest, "VALIDATION_ERROR", tc.wantMessage)
+				assertSprintDefinitionMCPTrace(t, fx.wrapped, "access", "role", "target", "update")
+			}
+			stored, err := fx.st.GetSprintByID(fx.ctx, sp.ID)
+			if err != nil {
+				t.Fatalf("GetSprintByID: %v", err)
+			}
+			if stored.Name != tc.wantName || stored.State != tc.state {
+				t.Fatalf("stored sprint=%+v, want name=%q state=%q", stored, tc.wantName, tc.state)
+			}
+			assertSprintDefinitionMCPSilence(t, stream)
+		})
+	}
+}
+
+func TestSprintDefinitionMCPCreateReturnFailureDoesNotLeakCause(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		t.Run(transport, func(t *testing.T) {
+			fx := newSprintDefinitionMCPFixture(t, "mcp-sprint-definition-private-cause-"+transport)
+			privateCause := fmt.Errorf("private sprint diagnostic %s", transport)
+			fx.wrapped.createErr = privateCause
+			stream := subscribeSprintDefinitionMCPEvents(t, fx)
+			defer stream.close()
+			fx.wrapped.activate()
+			resp, out := callSprintDefinitionMCP(t, fx, transport, "sprints_create", map[string]any{
+				"projectSlug": fx.project.Slug, "name": "Private failure",
+				"plannedStartAt": "2026-08-10T12:00:00Z", "plannedEndAt": "2026-08-17T12:00:00Z",
+			})
+			publicErr := assertTodoLinkMCPError(t, transport, resp, out, http.StatusInternalServerError, "INTERNAL", "internal error")
+			assertEmptyTodoLinkMCPDetails(t, publicErr)
+			encoded, err := json.Marshal(out)
+			if err != nil {
+				t.Fatalf("marshal response: %v", err)
+			}
+			if bytes.Contains(encoded, []byte(privateCause.Error())) {
+				t.Fatalf("public response leaked private cause: %s", encoded)
+			}
+			assertSprintDefinitionMCPTrace(t, fx.wrapped, "access", "role", "create")
+			assertSprintDefinitionMCPSilence(t, stream)
+		})
+	}
+}

--- a/internal/mcp/sprint_lifecycle_error_mapping_test.go
+++ b/internal/mcp/sprint_lifecycle_error_mapping_test.go
@@ -1,0 +1,119 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	sprintapp "scrumboy/internal/application/sprint"
+	"scrumboy/internal/store"
+)
+
+func TestMapSprintLifecyclePrepareErrorSentinels(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		message string
+		field   string
+	}{
+		{
+			name:    "activation state",
+			err:     sprintapp.ErrSprintMustBePlanned,
+			message: "sprint must be PLANNED to activate",
+			field:   "sprintId",
+		},
+		{
+			name:    "activation schedule",
+			err:     sprintapp.ErrSprintEndNotAfterNow,
+			message: "sprint end date is on or before now; cannot activate",
+			field:   "plannedEndAt",
+		},
+		{
+			name:    "close state",
+			err:     sprintapp.ErrSprintMustBeActive,
+			message: "sprint must be ACTIVE to close",
+			field:   "sprintId",
+		},
+		{
+			name:    "wrapped activation state",
+			err:     fmt.Errorf("outer diagnostic: %w", sprintapp.ErrSprintMustBePlanned),
+			message: "sprint must be PLANNED to activate",
+			field:   "sprintId",
+		},
+		{
+			name:    "wrapped activation schedule",
+			err:     fmt.Errorf("outer diagnostic: %w", sprintapp.ErrSprintEndNotAfterNow),
+			message: "sprint end date is on or before now; cannot activate",
+			field:   "plannedEndAt",
+		},
+		{
+			name:    "wrapped close state",
+			err:     fmt.Errorf("outer diagnostic: %w", sprintapp.ErrSprintMustBeActive),
+			message: "sprint must be ACTIVE to close",
+			field:   "sprintId",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapSprintLifecyclePrepareError(tt.err)
+			if got.Status != http.StatusBadRequest || got.Code != CodeValidationError || got.Message != tt.message {
+				t.Fatalf("mapped = status %d code %q message %q", got.Status, got.Code, got.Message)
+			}
+			wantDetails := map[string]any{"field": tt.field}
+			if !reflect.DeepEqual(got.Details, wantDetails) {
+				t.Fatalf("mapped details = %#v, want %#v", got.Details, wantDetails)
+			}
+			if got.Cause != nil {
+				t.Fatalf("mapped cause = %v, want nil", got.Cause)
+			}
+			if details := clientErrorDetails(got); !reflect.DeepEqual(details, wantDetails) {
+				t.Fatalf("public details = %#v, want %#v", details, wantDetails)
+			}
+		})
+	}
+}
+
+func TestMapSprintLifecyclePrepareErrorDelegatesSharedAndRawErrors(t *testing.T) {
+	mutationValidationErr := fmt.Errorf("%w: lifecycle mutation rejected", store.ErrValidation)
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "actor", err: sprintapp.ErrActorRequired},
+		{name: "maintainer", err: sprintapp.ErrMaintainerRequired},
+		{name: "project mismatch", err: sprintapp.ErrSprintNotInProject},
+		{name: "unauthorized store error", err: store.ErrUnauthorized},
+		{name: "forbidden store error", err: store.ErrForbidden},
+		{name: "not found store error", err: store.ErrNotFound},
+		{name: "mutation-time validation", err: mutationValidationErr},
+		{name: "conflict store error", err: fmt.Errorf("%w: lifecycle conflict", store.ErrConflict)},
+		{name: "private dependency error", err: errors.New("private sprint dependency failure")},
+		{name: "cancellation", err: context.Canceled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapSprintLifecyclePrepareError(tt.err)
+			want := mapSprintDefinitionPrepareError(tt.err)
+			if got.Status != want.Status || got.Code != want.Code || got.Message != want.Message ||
+				!reflect.DeepEqual(got.Details, want.Details) {
+				t.Fatalf("mapped = %#v, want definition-prepare result %#v", got, want)
+			}
+			switch {
+			case got.Cause == nil && want.Cause == nil:
+			case got.Cause != nil && want.Cause != nil && got.Cause.Error() == want.Cause.Error():
+			default:
+				t.Fatalf("mapped cause = %v, want %v", got.Cause, want.Cause)
+			}
+		})
+	}
+
+	got := mapSprintLifecyclePrepareError(mutationValidationErr)
+	if got.Message != mutationValidationErr.Error() {
+		t.Fatalf("mutation-time validation message = %q, want raw store mapping %q", got.Message, mutationValidationErr.Error())
+	}
+}

--- a/internal/mcp/sprint_lifecycle_transport_contract_test.go
+++ b/internal/mcp/sprint_lifecycle_transport_contract_test.go
@@ -1,0 +1,1240 @@
+package mcp_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"scrumboy/internal/db"
+	"scrumboy/internal/httpapi"
+	"scrumboy/internal/mcp"
+	"scrumboy/internal/migrate"
+	"scrumboy/internal/store"
+)
+
+type sprintLifecycleMCPStore struct {
+	*store.Store
+
+	mu     sync.Mutex
+	active bool
+	trace  []string
+
+	accessErr      error
+	accessOverride *store.ProjectContext
+	roleErr        error
+	roleOverride   *store.ProjectRole
+	targetErr      error
+	projectionErr  error
+	activateErr    error
+	closeErr       error
+	deleteErr      error
+
+	accessSlug string
+	accessMode store.Mode
+	rolePID    int64
+	roleUID    int64
+
+	readCalls int
+	readIDs   []int64
+
+	activateCalls     int
+	activatePID       int64
+	activateID        int64
+	activateCommitted bool
+	closeCalls        int
+	closeID           int64
+	closeCommitted    bool
+	deleteCalls       int
+	deletePID         int64
+	deleteID          int64
+	deleteCommitted   bool
+}
+
+func (s *sprintLifecycleMCPStore) activateTrace() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.active = true
+	s.trace = nil
+	s.readCalls = 0
+	s.readIDs = nil
+	s.activateCalls = 0
+	s.activateCommitted = false
+	s.closeCalls = 0
+	s.closeCommitted = false
+	s.deleteCalls = 0
+	s.deleteCommitted = false
+}
+
+func (s *sprintLifecycleMCPStore) record(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.active {
+		return false
+	}
+	s.trace = append(s.trace, name)
+	return true
+}
+
+func (s *sprintLifecycleMCPStore) snapshotTrace() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.trace...)
+}
+
+func (s *sprintLifecycleMCPStore) GetProjectContextBySlug(ctx context.Context, slug string, mode store.Mode) (store.ProjectContext, error) {
+	if !s.record("access") {
+		return s.Store.GetProjectContextBySlug(ctx, slug, mode)
+	}
+	s.mu.Lock()
+	s.accessSlug = slug
+	s.accessMode = mode
+	err := s.accessErr
+	override := s.accessOverride
+	s.mu.Unlock()
+	if err != nil {
+		return store.ProjectContext{}, err
+	}
+	if override != nil {
+		return *override, nil
+	}
+	return s.Store.GetProjectContextBySlug(ctx, slug, mode)
+}
+
+func (s *sprintLifecycleMCPStore) GetProjectRole(ctx context.Context, projectID, userID int64) (store.ProjectRole, error) {
+	if !s.record("role") {
+		return s.Store.GetProjectRole(ctx, projectID, userID)
+	}
+	s.mu.Lock()
+	s.rolePID = projectID
+	s.roleUID = userID
+	err := s.roleErr
+	override := s.roleOverride
+	s.mu.Unlock()
+	if err != nil {
+		return "", err
+	}
+	if override != nil {
+		return *override, nil
+	}
+	return s.Store.GetProjectRole(ctx, projectID, userID)
+}
+
+func (s *sprintLifecycleMCPStore) GetSprintByID(ctx context.Context, sprintID int64) (store.Sprint, error) {
+	s.mu.Lock()
+	if !s.active {
+		s.mu.Unlock()
+		return s.Store.GetSprintByID(ctx, sprintID)
+	}
+	s.readCalls++
+	readNumber := s.readCalls
+	s.readIDs = append(s.readIDs, sprintID)
+	stage := "target"
+	err := s.targetErr
+	if readNumber > 1 {
+		stage = "projection"
+		err = s.projectionErr
+	}
+	s.trace = append(s.trace, stage)
+	s.mu.Unlock()
+	if err != nil {
+		return store.Sprint{}, err
+	}
+	return s.Store.GetSprintByID(ctx, sprintID)
+}
+
+func (s *sprintLifecycleMCPStore) ActivateSprint(ctx context.Context, projectID, sprintID int64) error {
+	if !s.record("activate") {
+		return s.Store.ActivateSprint(ctx, projectID, sprintID)
+	}
+	s.mu.Lock()
+	s.activateCalls++
+	s.activatePID = projectID
+	s.activateID = sprintID
+	err := s.activateErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	if err := s.Store.ActivateSprint(ctx, projectID, sprintID); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.activateCommitted = true
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *sprintLifecycleMCPStore) CloseSprint(ctx context.Context, sprintID int64) error {
+	if !s.record("close") {
+		return s.Store.CloseSprint(ctx, sprintID)
+	}
+	s.mu.Lock()
+	s.closeCalls++
+	s.closeID = sprintID
+	err := s.closeErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	if err := s.Store.CloseSprint(ctx, sprintID); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.closeCommitted = true
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *sprintLifecycleMCPStore) DeleteSprint(ctx context.Context, projectID, sprintID int64) error {
+	if !s.record("delete") {
+		return s.Store.DeleteSprint(ctx, projectID, sprintID)
+	}
+	s.mu.Lock()
+	s.deleteCalls++
+	s.deletePID = projectID
+	s.deleteID = sprintID
+	err := s.deleteErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	if err := s.Store.DeleteSprint(ctx, projectID, sprintID); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.deleteCommitted = true
+	s.mu.Unlock()
+	return nil
+}
+
+type sprintLifecycleMCPFixture struct {
+	ts          *httptest.Server
+	db          *sql.DB
+	st          *store.Store
+	wrapped     *sprintLifecycleMCPStore
+	client      *http.Client
+	ownerClient *http.Client
+	ownerID     int64
+	actorID     int64
+	ownerCtx    context.Context
+	actorCtx    context.Context
+	project     store.Project
+	projectPC   store.ProjectContext
+}
+
+func newSprintLifecycleMCPFixture(t *testing.T, name string) *sprintLifecycleMCPFixture {
+	t.Helper()
+
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "app.db"), db.Options{
+		BusyTimeout: 5000,
+		JournalMode: "WAL",
+		Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := migrate.Apply(context.Background(), sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+	st := store.New(sqlDB, nil)
+	wrapped := &sprintLifecycleMCPStore{Store: st}
+	srv := httpapi.NewServer(wrapped, httpapi.Options{
+		MaxRequestBody: 1 << 20,
+		ScrumboyMode:   "full",
+		MCPHandler:     mcp.New(wrapped, mcp.Options{Mode: "full"}),
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(func() {
+		ts.Close()
+		_ = sqlDB.Close()
+	})
+
+	ownerClient := newCookieClient(t, ts)
+	bootstrapUser(t, ownerClient, ts.URL)
+	ownerID := firstUserID(t, sqlDB)
+	ownerCtx := store.WithUserID(context.Background(), ownerID)
+	actorEmail := name + "-actor@example.com"
+	actor, err := st.CreateUser(context.Background(), actorEmail, "password123", "Lifecycle Maintainer")
+	if err != nil {
+		t.Fatalf("CreateUser actor: %v", err)
+	}
+
+	offsetOne, err := st.CreateProject(ownerCtx, name+"-offset-one")
+	if err != nil {
+		t.Fatalf("CreateProject offset one: %v", err)
+	}
+	if _, err := st.CreateProject(ownerCtx, name+"-offset-two"); err != nil {
+		t.Fatalf("CreateProject offset two: %v", err)
+	}
+	now := time.Now().UTC()
+	for i := 0; i < 4; i++ {
+		if _, err := st.CreateSprint(ownerCtx, offsetOne.ID, fmt.Sprintf("Offset %d", i+1), now.Add(-time.Hour), now.Add(time.Duration(48+i)*time.Hour)); err != nil {
+			t.Fatalf("CreateSprint offset %d: %v", i+1, err)
+		}
+	}
+	project, err := st.CreateProject(ownerCtx, name)
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	if err := st.AddProjectMember(ownerCtx, ownerID, project.ID, actor.ID, store.RoleMaintainer); err != nil {
+		t.Fatalf("AddProjectMember actor: %v", err)
+	}
+	actorCtx := store.WithUserID(context.Background(), actor.ID)
+	pc, err := st.GetProjectContextBySlug(actorCtx, project.Slug, store.ModeFull)
+	if err != nil {
+		t.Fatalf("GetProjectContextBySlug: %v", err)
+	}
+	client := loginTodoUpdateMCPUser(t, ts, actorEmail, "password123")
+
+	return &sprintLifecycleMCPFixture{
+		ts: ts, db: sqlDB, st: st, wrapped: wrapped, client: client, ownerClient: ownerClient,
+		ownerID: ownerID, actorID: actor.ID, ownerCtx: ownerCtx, actorCtx: actorCtx,
+		project: project, projectPC: pc,
+	}
+}
+
+func createSprintLifecycleMCPSprint(t *testing.T, fx *sprintLifecycleMCPFixture, name, state string) store.Sprint {
+	t.Helper()
+	now := time.Now().UTC()
+	sp, err := fx.st.CreateSprint(fx.ownerCtx, fx.project.ID, name, now.Add(-time.Hour), now.Add(72*time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSprint %s: %v", state, err)
+	}
+	if state == store.SprintStateActive || state == store.SprintStateClosed {
+		if err := fx.st.ActivateSprint(fx.ownerCtx, fx.project.ID, sp.ID); err != nil {
+			t.Fatalf("ActivateSprint setup: %v", err)
+		}
+	}
+	if state == store.SprintStateClosed {
+		if err := fx.st.CloseSprint(fx.ownerCtx, sp.ID); err != nil {
+			t.Fatalf("CloseSprint setup: %v", err)
+		}
+	}
+	return sp
+}
+
+func callSprintLifecycleMCP(t *testing.T, fx *sprintLifecycleMCPFixture, client *http.Client, transport, tool string, args map[string]any) (*http.Response, map[string]any) {
+	t.Helper()
+	return callTodoUpdateMCP(t, client, fx.ts.URL, transport, tool, args)
+}
+
+func subscribeSprintLifecycleMCPEvents(t *testing.T, fx *sprintLifecycleMCPFixture, client *http.Client) *todoUpdateMCPEventStream {
+	t.Helper()
+	return subscribeTodoUpdateMCPEvents(t, client, fx.ts.URL+"/api/board/"+fx.project.Slug+"/events")
+}
+
+func assertSprintLifecycleMCPSilence(t *testing.T, stream *todoUpdateMCPEventStream) {
+	t.Helper()
+	if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+		t.Fatalf("MCP lifecycle operation emitted realtime events: %+v", events)
+	}
+}
+
+func assertSprintLifecycleMCPTrace(t *testing.T, wrapped *sprintLifecycleMCPStore, want ...string) {
+	t.Helper()
+	if got := wrapped.snapshotTrace(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("store trace=%v, want %v", got, want)
+	}
+}
+
+func assertSprintLifecycleMCPError(t *testing.T, transport string, resp *http.Response, out map[string]any, wantStatus int, wantCode, wantMessage string, wantDetails map[string]any) map[string]any {
+	t.Helper()
+	publicErr := assertTodoLinkMCPError(t, transport, resp, out, wantStatus, wantCode, wantMessage)
+	if transport == "legacy" {
+		if got, want := sortedMapKeys(out), []string{"error", "ok"}; !reflect.DeepEqual(got, want) || out["ok"] != false {
+			t.Fatalf("legacy error envelope=%+v keys=%v want=%v", out, got, want)
+		}
+		if got, want := sortedMapKeys(publicErr), []string{"code", "details", "message"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("legacy public error keys=%v want=%v error=%+v", got, want, publicErr)
+		}
+	} else {
+		if got, want := sortedMapKeys(out), []string{"id", "jsonrpc", "result"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("JSON-RPC error envelope=%+v keys=%v want=%v", out, got, want)
+		}
+		result := out["result"].(map[string]any)
+		if got, want := sortedMapKeys(result), []string{"content", "isError", "structuredContent"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("JSON-RPC error result=%+v keys=%v want=%v", result, got, want)
+		}
+		if got, want := sortedMapKeys(publicErr), []string{"code", "details", "message"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("JSON-RPC structured error keys=%v want=%v error=%+v", got, want, publicErr)
+		}
+	}
+	if wantDetails == nil {
+		wantDetails = map[string]any{}
+	}
+	if details, ok := publicErr["details"].(map[string]any); !ok || !reflect.DeepEqual(details, wantDetails) {
+		t.Fatalf("public error details=%+v, want %+v", publicErr["details"], wantDetails)
+	}
+	return publicErr
+}
+
+func sprintLifecycleMCPData(t *testing.T, transport string, response map[string]any) map[string]any {
+	t.Helper()
+	return todoLinkMCPData(t, transport, response)
+}
+
+func assertSprintLifecycleMCPItem(t *testing.T, data map[string]any, projectSlug string, expected store.Sprint) {
+	t.Helper()
+	if got, want := sortedMapKeys(data), []string{"sprint"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("data keys=%v, want %v; data=%+v", got, want, data)
+	}
+	item, ok := data["sprint"].(map[string]any)
+	if !ok {
+		t.Fatalf("sprint projection type=%T data=%+v", data["sprint"], data)
+	}
+	if got, want := sortedMapKeys(item), []string{"closedAt", "name", "number", "plannedEndAt", "plannedStartAt", "projectSlug", "sprintId", "startedAt", "state", "todoCount"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("sprint keys=%v, want %v; sprint=%+v", got, want, item)
+	}
+	if item["projectSlug"] != projectSlug || int64(item["sprintId"].(float64)) != expected.ID || int64(item["number"].(float64)) != expected.Number || item["name"] != expected.Name || int64(item["plannedStartAt"].(float64)) != expected.PlannedStartAt.UnixMilli() || int64(item["plannedEndAt"].(float64)) != expected.PlannedEndAt.UnixMilli() || item["state"] != expected.State || item["todoCount"] != nil {
+		t.Fatalf("sprint projection=%+v expected=%+v", item, expected)
+	}
+	assertTime := func(field string, expectedTime *time.Time) {
+		if expectedTime == nil {
+			if item[field] != nil {
+				t.Fatalf("sprint %s=%v, want null", field, item[field])
+			}
+			return
+		}
+		if raw, ok := item[field].(float64); !ok || int64(raw) != expectedTime.UnixMilli() {
+			t.Fatalf("sprint %s=%v, want %d", field, item[field], expectedTime.UnixMilli())
+		}
+	}
+	assertTime("startedAt", expected.StartedAt)
+	assertTime("closedAt", expected.ClosedAt)
+}
+
+func getSprintLifecycleMCPSprint(t *testing.T, fx *sprintLifecycleMCPFixture, sprintID int64) store.Sprint {
+	t.Helper()
+	sp, err := fx.st.GetSprintByID(fx.ownerCtx, sprintID)
+	if err != nil {
+		t.Fatalf("GetSprintByID(%d): %v", sprintID, err)
+	}
+	return sp
+}
+
+func TestSprintLifecycleMCPActivateContract(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		transport := transport
+		t.Run(transport+"/planned success", func(t *testing.T) {
+			fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-activate-"+transport)
+			sp := createSprintLifecycleMCPSprint(t, fx, "Target", store.SprintStatePlanned)
+			if sp.ID == sp.Number || sp.ID == fx.project.ID || fx.project.ID == fx.actorID {
+				t.Fatalf("identity fixture is not distinct: actor=%d project=%d sprint=%d number=%d", fx.actorID, fx.project.ID, sp.ID, sp.Number)
+			}
+			stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+			defer stream.close()
+			fx.wrapped.activateTrace()
+
+			resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, "sprints_activate", map[string]any{"projectSlug": fx.project.Slug, "sprintId": sp.ID})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("activate status=%d response=%+v", resp.StatusCode, out)
+			}
+			stored := getSprintLifecycleMCPSprint(t, fx, sp.ID)
+			if stored.State != store.SprintStateActive || stored.StartedAt == nil || stored.ClosedAt != nil {
+				t.Fatalf("activated sprint=%+v", stored)
+			}
+			assertSprintLifecycleMCPItem(t, sprintLifecycleMCPData(t, transport, out), fx.project.Slug, stored)
+			assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role", "target", "activate", "projection")
+			if fx.wrapped.accessSlug != fx.project.Slug || fx.wrapped.accessMode != store.ModeFull || fx.wrapped.rolePID != fx.project.ID || fx.wrapped.roleUID != fx.actorID {
+				t.Fatalf("access/role args=(slug=%q mode=%q project=%d actor=%d)", fx.wrapped.accessSlug, fx.wrapped.accessMode, fx.wrapped.rolePID, fx.wrapped.roleUID)
+			}
+			if fx.wrapped.readCalls != 2 || !reflect.DeepEqual(fx.wrapped.readIDs, []int64{sp.ID, sp.ID}) || fx.wrapped.activateCalls != 1 || fx.wrapped.activatePID != fx.project.ID || fx.wrapped.activateID != sp.ID || !fx.wrapped.activateCommitted {
+				t.Fatalf("activate observations=(reads=%d ids=%v calls=%d project=%d sprint=%d committed=%v)", fx.wrapped.readCalls, fx.wrapped.readIDs, fx.wrapped.activateCalls, fx.wrapped.activatePID, fx.wrapped.activateID, fx.wrapped.activateCommitted)
+			}
+			if fx.wrapped.activateID == sp.Number {
+				t.Fatalf("Sprint.Number %d was used as persistence identity", sp.Number)
+			}
+			assertSprintLifecycleMCPSilence(t, stream)
+		})
+
+		t.Run(transport+"/replacement", func(t *testing.T) {
+			fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-activate-replacement-"+transport)
+			prior := createSprintLifecycleMCPSprint(t, fx, "Prior", store.SprintStateActive)
+			target := createSprintLifecycleMCPSprint(t, fx, "Replacement", store.SprintStatePlanned)
+			stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+			defer stream.close()
+			fx.wrapped.activateTrace()
+
+			resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, "sprints_activate", map[string]any{"projectSlug": fx.project.Slug, "sprintId": target.ID})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("replacement status=%d response=%+v", resp.StatusCode, out)
+			}
+			priorAfter := getSprintLifecycleMCPSprint(t, fx, prior.ID)
+			targetAfter := getSprintLifecycleMCPSprint(t, fx, target.ID)
+			if priorAfter.State != store.SprintStateClosed || priorAfter.ClosedAt == nil || targetAfter.State != store.SprintStateActive || targetAfter.StartedAt == nil {
+				t.Fatalf("replacement prior=%+v target=%+v", priorAfter, targetAfter)
+			}
+			assertSprintLifecycleMCPItem(t, sprintLifecycleMCPData(t, transport, out), fx.project.Slug, targetAfter)
+			assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role", "target", "activate", "projection")
+			if fx.wrapped.activateCalls != 1 || fx.wrapped.closeCalls != 0 {
+				t.Fatalf("replacement activateCalls=%d closeCalls=%d", fx.wrapped.activateCalls, fx.wrapped.closeCalls)
+			}
+			assertSprintLifecycleMCPSilence(t, stream)
+		})
+	}
+}
+
+func TestSprintLifecycleMCPCloseContract(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		transport := transport
+		t.Run(transport, func(t *testing.T) {
+			fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-close-"+transport)
+			sp := createSprintLifecycleMCPSprint(t, fx, "Active", store.SprintStateActive)
+			before := getSprintLifecycleMCPSprint(t, fx, sp.ID)
+			stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+			defer stream.close()
+			fx.wrapped.activateTrace()
+
+			resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, "sprints_close", map[string]any{"projectSlug": fx.project.Slug, "sprintId": sp.ID})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("close status=%d response=%+v", resp.StatusCode, out)
+			}
+			stored := getSprintLifecycleMCPSprint(t, fx, sp.ID)
+			if stored.State != store.SprintStateClosed || stored.ClosedAt == nil || before.StartedAt == nil || stored.StartedAt == nil || !stored.StartedAt.Equal(*before.StartedAt) {
+				t.Fatalf("closed sprint before=%+v after=%+v", before, stored)
+			}
+			assertSprintLifecycleMCPItem(t, sprintLifecycleMCPData(t, transport, out), fx.project.Slug, stored)
+			assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role", "target", "close", "projection")
+			if fx.wrapped.readCalls != 2 || !reflect.DeepEqual(fx.wrapped.readIDs, []int64{sp.ID, sp.ID}) || fx.wrapped.closeCalls != 1 || fx.wrapped.closeID != sp.ID || !fx.wrapped.closeCommitted {
+				t.Fatalf("close observations=(reads=%d ids=%v calls=%d sprint=%d committed=%v)", fx.wrapped.readCalls, fx.wrapped.readIDs, fx.wrapped.closeCalls, fx.wrapped.closeID, fx.wrapped.closeCommitted)
+			}
+			if fx.wrapped.closeID == sp.Number {
+				t.Fatalf("Sprint.Number %d was used as close persistence identity", sp.Number)
+			}
+			assertSprintLifecycleMCPSilence(t, stream)
+		})
+	}
+}
+
+func TestSprintLifecycleMCPDeleteContract(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		for _, state := range []string{store.SprintStatePlanned, store.SprintStateActive, store.SprintStateClosed} {
+			transport, state := transport, state
+			t.Run(transport+"/"+strings.ToLower(state), func(t *testing.T) {
+				fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-delete-"+transport+"-"+strings.ToLower(state))
+				sp := createSprintLifecycleMCPSprint(t, fx, state, state)
+				stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+				defer stream.close()
+				fx.wrapped.activateTrace()
+
+				resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, "sprints_delete", map[string]any{"projectSlug": fx.project.Slug, "sprintId": sp.ID})
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("delete %s status=%d response=%+v", state, resp.StatusCode, out)
+				}
+				data := sprintLifecycleMCPData(t, transport, out)
+				if got, want := sortedMapKeys(data), []string{"projectSlug", "sprintId", "status"}; !reflect.DeepEqual(got, want) || data["status"] != "deleted" || data["projectSlug"] != fx.project.Slug || int64(data["sprintId"].(float64)) != sp.ID {
+					t.Fatalf("delete identity echo=%+v keys=%v want=%v", data, got, want)
+				}
+				assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role", "target", "delete")
+				if fx.wrapped.readCalls != 1 || !reflect.DeepEqual(fx.wrapped.readIDs, []int64{sp.ID}) || fx.wrapped.deleteCalls != 1 || fx.wrapped.deletePID != fx.project.ID || fx.wrapped.deleteID != sp.ID || !fx.wrapped.deleteCommitted {
+					t.Fatalf("delete observations=(reads=%d ids=%v calls=%d project=%d sprint=%d committed=%v)", fx.wrapped.readCalls, fx.wrapped.readIDs, fx.wrapped.deleteCalls, fx.wrapped.deletePID, fx.wrapped.deleteID, fx.wrapped.deleteCommitted)
+				}
+				if _, err := fx.st.GetSprintByID(fx.ownerCtx, sp.ID); !errors.Is(err, store.ErrNotFound) {
+					t.Fatalf("GetSprintByID after delete error=%v, want not found", err)
+				}
+				if state == store.SprintStateActive {
+					active, err := fx.st.GetActiveSprintByProjectID(fx.ownerCtx, fx.project.ID)
+					if err != nil || active != nil {
+						t.Fatalf("active sprint after active delete=%+v err=%v", active, err)
+					}
+				}
+				assertSprintLifecycleMCPSilence(t, stream)
+			})
+		}
+	}
+}
+
+func TestSprintLifecycleMCPActivateRejectionContract(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		for _, tc := range []struct {
+			name        string
+			prepare     func(*testing.T, *sprintLifecycleMCPFixture) int64
+			wantStatus  int
+			wantCode    string
+			wantMessage string
+			wantDetails map[string]any
+		}{
+			{
+				name: "already active",
+				prepare: func(t *testing.T, fx *sprintLifecycleMCPFixture) int64 {
+					return createSprintLifecycleMCPSprint(t, fx, "Already active", store.SprintStateActive).ID
+				},
+				wantStatus: http.StatusBadRequest, wantCode: "VALIDATION_ERROR", wantMessage: "sprint must be PLANNED to activate", wantDetails: map[string]any{"field": "sprintId"},
+			},
+			{
+				name: "closed",
+				prepare: func(t *testing.T, fx *sprintLifecycleMCPFixture) int64 {
+					return createSprintLifecycleMCPSprint(t, fx, "Closed", store.SprintStateClosed).ID
+				},
+				wantStatus: http.StatusBadRequest, wantCode: "VALIDATION_ERROR", wantMessage: "sprint must be PLANNED to activate", wantDetails: map[string]any{"field": "sprintId"},
+			},
+			{
+				name: "safely expired planned end",
+				prepare: func(t *testing.T, fx *sprintLifecycleMCPFixture) int64 {
+					now := time.Now().UTC()
+					sp, err := fx.st.CreateSprint(fx.ownerCtx, fx.project.ID, "Past", now.Add(-48*time.Hour), now.Add(-24*time.Hour))
+					if err != nil {
+						t.Fatalf("CreateSprint past: %v", err)
+					}
+					return sp.ID
+				},
+				wantStatus: http.StatusBadRequest, wantCode: "VALIDATION_ERROR", wantMessage: "sprint end date is on or before now; cannot activate", wantDetails: map[string]any{"field": "plannedEndAt"},
+			},
+			{
+				name:       "missing",
+				prepare:    func(_ *testing.T, _ *sprintLifecycleMCPFixture) int64 { return 910001 },
+				wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND", wantMessage: "not found",
+			},
+			{
+				name: "foreign",
+				prepare: func(t *testing.T, fx *sprintLifecycleMCPFixture) int64 {
+					other, err := fx.st.CreateProject(fx.ownerCtx, "mcp-lifecycle-activate-foreign-"+transport)
+					if err != nil {
+						t.Fatalf("CreateProject foreign: %v", err)
+					}
+					now := time.Now().UTC()
+					sp, err := fx.st.CreateSprint(fx.ownerCtx, other.ID, "Foreign", now.Add(-time.Hour), now.Add(48*time.Hour))
+					if err != nil {
+						t.Fatalf("CreateSprint foreign: %v", err)
+					}
+					return sp.ID
+				},
+				wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND", wantMessage: "not found",
+			},
+		} {
+			transport, tc := transport, tc
+			t.Run(transport+"/"+tc.name, func(t *testing.T) {
+				fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-activate-reject-"+transport+"-"+strings.ReplaceAll(tc.name, " ", "-"))
+				sprintID := tc.prepare(t, fx)
+				stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+				defer stream.close()
+				fx.wrapped.activateTrace()
+
+				resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, "sprints_activate", map[string]any{"projectSlug": fx.project.Slug, "sprintId": sprintID})
+				assertSprintLifecycleMCPError(t, transport, resp, out, tc.wantStatus, tc.wantCode, tc.wantMessage, tc.wantDetails)
+				assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role", "target")
+				if fx.wrapped.readCalls != 1 || !reflect.DeepEqual(fx.wrapped.readIDs, []int64{sprintID}) || fx.wrapped.activateCalls != 0 {
+					t.Fatalf("activate rejection observations=(reads=%d ids=%v calls=%d)", fx.wrapped.readCalls, fx.wrapped.readIDs, fx.wrapped.activateCalls)
+				}
+				assertSprintLifecycleMCPSilence(t, stream)
+			})
+		}
+	}
+}
+
+func TestSprintLifecycleMCPCloseRejectionContract(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		for _, tc := range []struct {
+			name    string
+			prepare func(*testing.T, *sprintLifecycleMCPFixture) int64
+		}{
+			{
+				name: "planned",
+				prepare: func(t *testing.T, fx *sprintLifecycleMCPFixture) int64 {
+					return createSprintLifecycleMCPSprint(t, fx, "Planned", store.SprintStatePlanned).ID
+				},
+			},
+			{
+				name: "already closed",
+				prepare: func(t *testing.T, fx *sprintLifecycleMCPFixture) int64 {
+					return createSprintLifecycleMCPSprint(t, fx, "Closed", store.SprintStateClosed).ID
+				},
+			},
+		} {
+			transport, tc := transport, tc
+			t.Run(transport+"/"+tc.name, func(t *testing.T) {
+				fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-close-reject-"+transport+"-"+strings.ReplaceAll(tc.name, " ", "-"))
+				sprintID := tc.prepare(t, fx)
+				stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+				defer stream.close()
+				fx.wrapped.activateTrace()
+				resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, "sprints_close", map[string]any{"projectSlug": fx.project.Slug, "sprintId": sprintID})
+				assertSprintLifecycleMCPError(t, transport, resp, out, http.StatusBadRequest, "VALIDATION_ERROR", "sprint must be ACTIVE to close", map[string]any{"field": "sprintId"})
+				assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role", "target")
+				if fx.wrapped.readCalls != 1 || fx.wrapped.closeCalls != 0 {
+					t.Fatalf("close rejection reads=%d calls=%d", fx.wrapped.readCalls, fx.wrapped.closeCalls)
+				}
+				assertSprintLifecycleMCPSilence(t, stream)
+			})
+		}
+
+		for _, targetKind := range []string{"missing", "foreign"} {
+			transport, targetKind := transport, targetKind
+			t.Run(transport+"/"+targetKind, func(t *testing.T) {
+				fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-close-"+targetKind+"-"+transport)
+				sprintID := int64(910002)
+				if targetKind == "foreign" {
+					other, err := fx.st.CreateProject(fx.ownerCtx, "mcp-lifecycle-close-foreign-project-"+transport)
+					if err != nil {
+						t.Fatalf("CreateProject foreign: %v", err)
+					}
+					now := time.Now().UTC()
+					sp, err := fx.st.CreateSprint(fx.ownerCtx, other.ID, "Foreign active", now.Add(-time.Hour), now.Add(48*time.Hour))
+					if err != nil {
+						t.Fatalf("CreateSprint foreign: %v", err)
+					}
+					if err := fx.st.ActivateSprint(fx.ownerCtx, other.ID, sp.ID); err != nil {
+						t.Fatalf("ActivateSprint foreign: %v", err)
+					}
+					sprintID = sp.ID
+				}
+				stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+				defer stream.close()
+				fx.wrapped.activateTrace()
+				resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, "sprints_close", map[string]any{"projectSlug": fx.project.Slug, "sprintId": sprintID})
+				assertSprintLifecycleMCPError(t, transport, resp, out, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+				assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role", "target")
+				if fx.wrapped.closeCalls != 0 {
+					t.Fatalf("%s close calls=%d", targetKind, fx.wrapped.closeCalls)
+				}
+				assertSprintLifecycleMCPSilence(t, stream)
+			})
+		}
+	}
+}
+
+func TestSprintLifecycleMCPCommittedProjectionFailureContract(t *testing.T) {
+	sentinel := errors.New("sprint lifecycle projection failed")
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		for _, operation := range []string{"activate", "close"} {
+			transport, operation := transport, operation
+			t.Run(transport+"/"+operation, func(t *testing.T) {
+				fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-projection-failure-"+transport+"-"+operation)
+				var prior store.Sprint
+				var target store.Sprint
+				if operation == "activate" {
+					prior = createSprintLifecycleMCPSprint(t, fx, "Prior active", store.SprintStateActive)
+					target = createSprintLifecycleMCPSprint(t, fx, "Activation target", store.SprintStatePlanned)
+				} else {
+					target = createSprintLifecycleMCPSprint(t, fx, "Close target", store.SprintStateActive)
+				}
+				stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+				defer stream.close()
+				fx.wrapped.projectionErr = sentinel
+				fx.wrapped.activateTrace()
+
+				resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, "sprints_"+operation, map[string]any{"projectSlug": fx.project.Slug, "sprintId": target.ID})
+				assertSprintLifecycleMCPError(t, transport, resp, out, http.StatusInternalServerError, "INTERNAL", "internal error", nil)
+				assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role", "target", operation, "projection")
+				if fx.wrapped.readCalls != 2 || !reflect.DeepEqual(fx.wrapped.readIDs, []int64{target.ID, target.ID}) {
+					t.Fatalf("projection failure reads=%d ids=%v, want target and projection once", fx.wrapped.readCalls, fx.wrapped.readIDs)
+				}
+				after := getSprintLifecycleMCPSprint(t, fx, target.ID)
+				if operation == "activate" {
+					if fx.wrapped.activateCalls != 1 || !fx.wrapped.activateCommitted || fx.wrapped.closeCalls != 0 || after.State != store.SprintStateActive {
+						t.Fatalf("activate projection failure calls=%d committed=%v closeCalls=%d target=%+v", fx.wrapped.activateCalls, fx.wrapped.activateCommitted, fx.wrapped.closeCalls, after)
+					}
+					priorAfter := getSprintLifecycleMCPSprint(t, fx, prior.ID)
+					if priorAfter.State != store.SprintStateClosed || priorAfter.ClosedAt == nil {
+						t.Fatalf("prior active not durably closed after projection failure: %+v", priorAfter)
+					}
+				} else if fx.wrapped.closeCalls != 1 || !fx.wrapped.closeCommitted || fx.wrapped.activateCalls != 0 || after.State != store.SprintStateClosed {
+					t.Fatalf("close projection failure calls=%d committed=%v activateCalls=%d target=%+v", fx.wrapped.closeCalls, fx.wrapped.closeCommitted, fx.wrapped.activateCalls, after)
+				}
+				assertSprintLifecycleMCPSilence(t, stream)
+			})
+		}
+	}
+}
+
+func TestSprintLifecycleMCPDeleteDetachesTodos(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		transport := transport
+		t.Run(transport, func(t *testing.T) {
+			fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-delete-detach-"+transport)
+			target := createSprintLifecycleMCPSprint(t, fx, "Target", store.SprintStateClosed)
+			controlSprint := createSprintLifecycleMCPSprint(t, fx, "Control", store.SprintStatePlanned)
+			points := int64(5)
+			assigned, err := fx.st.CreateTodo(fx.ownerCtx, fx.project.ID, store.CreateTodoInput{
+				Title: "Assigned", Body: "assigned body", Tags: []string{"phase20"}, ColumnKey: store.DefaultColumnDoing,
+				EstimationPoints: &points, AssigneeUserID: &fx.actorID, SprintID: &target.ID,
+			}, store.ModeFull)
+			if err != nil {
+				t.Fatalf("CreateTodo assigned: %v", err)
+			}
+			control, err := fx.st.CreateTodo(fx.ownerCtx, fx.project.ID, store.CreateTodoInput{
+				Title: "Control", Body: "control body", ColumnKey: store.DefaultColumnBacklog, SprintID: &controlSprint.ID,
+			}, store.ModeFull)
+			if err != nil {
+				t.Fatalf("CreateTodo control: %v", err)
+			}
+			stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+			defer stream.close()
+			fx.wrapped.activateTrace()
+
+			resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, "sprints_delete", map[string]any{"projectSlug": fx.project.Slug, "sprintId": target.ID})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("delete detach status=%d response=%+v", resp.StatusCode, out)
+			}
+			data := sprintLifecycleMCPData(t, transport, out)
+			if data["status"] != "deleted" || data["projectSlug"] != fx.project.Slug || int64(data["sprintId"].(float64)) != target.ID {
+				t.Fatalf("delete detach echo=%+v", data)
+			}
+			assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role", "target", "delete")
+			if fx.wrapped.readCalls != 1 || fx.wrapped.deleteCalls != 1 {
+				t.Fatalf("delete detach reads=%d calls=%d", fx.wrapped.readCalls, fx.wrapped.deleteCalls)
+			}
+			afterAssigned, err := fx.st.GetTodoByLocalID(fx.ownerCtx, fx.project.ID, assigned.LocalID, store.ModeFull)
+			if err != nil {
+				t.Fatalf("GetTodoByLocalID assigned: %v", err)
+			}
+			wantAssigned := assigned
+			wantAssigned.SprintID = nil
+			wantAssigned.AssignmentChanged = false
+			if !reflect.DeepEqual(afterAssigned, wantAssigned) {
+				t.Fatalf("assigned todo changed beyond detachment before=%+v after=%+v", assigned, afterAssigned)
+			}
+			afterControl, err := fx.st.GetTodoByLocalID(fx.ownerCtx, fx.project.ID, control.LocalID, store.ModeFull)
+			if err != nil {
+				t.Fatalf("GetTodoByLocalID control: %v", err)
+			}
+			wantControl := control
+			wantControl.AssignmentChanged = false
+			if !reflect.DeepEqual(afterControl, wantControl) {
+				t.Fatalf("control todo changed before=%+v after=%+v", control, afterControl)
+			}
+			assertSprintLifecycleMCPSilence(t, stream)
+		})
+	}
+}
+
+func prepareSprintLifecycleMCPFailureTarget(t *testing.T, fx *sprintLifecycleMCPFixture, operation string) (string, map[string]any, store.Sprint) {
+	t.Helper()
+	state := store.SprintStatePlanned
+	if operation == "close" {
+		state = store.SprintStateActive
+	}
+	target := createSprintLifecycleMCPSprint(t, fx, "Failure target", state)
+	return "sprints_" + operation, map[string]any{"projectSlug": fx.project.Slug, "sprintId": target.ID}, getSprintLifecycleMCPSprint(t, fx, target.ID)
+}
+
+func injectSprintLifecycleMCPFailure(wrapped *sprintLifecycleMCPStore, operation, stage string, err error) {
+	switch stage {
+	case "access":
+		wrapped.accessErr = err
+	case "role":
+		wrapped.roleErr = err
+	case "target":
+		wrapped.targetErr = err
+	case "mutation":
+		switch operation {
+		case "activate":
+			wrapped.activateErr = err
+		case "close":
+			wrapped.closeErr = err
+		case "delete":
+			wrapped.deleteErr = err
+		}
+	case "projection":
+		wrapped.projectionErr = err
+	}
+}
+
+func sprintLifecycleMCPFailureTrace(operation, stage string) []string {
+	trace := []string{"access"}
+	if stage == "access" {
+		return trace
+	}
+	trace = append(trace, "role")
+	if stage == "role" {
+		return trace
+	}
+	trace = append(trace, "target")
+	if stage == "target" {
+		return trace
+	}
+	trace = append(trace, operation)
+	if stage == "mutation" {
+		return trace
+	}
+	return append(trace, "projection")
+}
+
+func assertSprintLifecycleMCPFailurePersistence(t *testing.T, fx *sprintLifecycleMCPFixture, operation, stage string, before store.Sprint) {
+	t.Helper()
+	after := getSprintLifecycleMCPSprint(t, fx, before.ID)
+	if stage != "projection" {
+		if !reflect.DeepEqual(after, before) {
+			t.Fatalf("pre-commit failure changed sprint before=%+v after=%+v", before, after)
+		}
+		return
+	}
+	if operation == "activate" {
+		if after.State != store.SprintStateActive || after.StartedAt == nil || !fx.wrapped.activateCommitted || fx.wrapped.activateCalls != 1 || fx.wrapped.closeCalls != 0 {
+			t.Fatalf("activation projection failure state=%+v calls=%d committed=%v closeCalls=%d", after, fx.wrapped.activateCalls, fx.wrapped.activateCommitted, fx.wrapped.closeCalls)
+		}
+		return
+	}
+	if after.State != store.SprintStateClosed || after.ClosedAt == nil || !fx.wrapped.closeCommitted || fx.wrapped.closeCalls != 1 || fx.wrapped.activateCalls != 0 {
+		t.Fatalf("close projection failure state=%+v calls=%d committed=%v activateCalls=%d", after, fx.wrapped.closeCalls, fx.wrapped.closeCommitted, fx.wrapped.activateCalls)
+	}
+}
+
+func TestSprintLifecycleMCPDependencyFailureContract(t *testing.T) {
+	sentinel := errors.New("sprint lifecycle MCP injected failure")
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		for _, operation := range []string{"activate", "close", "delete"} {
+			for _, stage := range []string{"access", "role", "target", "mutation"} {
+				transport, operation, stage := transport, operation, stage
+				t.Run(transport+"/"+operation+"/"+stage, func(t *testing.T) {
+					fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-failure-"+transport+"-"+operation+"-"+stage)
+					tool, args, before := prepareSprintLifecycleMCPFailureTarget(t, fx, operation)
+					stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+					defer stream.close()
+					injectSprintLifecycleMCPFailure(fx.wrapped, operation, stage, sentinel)
+					fx.wrapped.activateTrace()
+
+					resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, tool, args)
+					assertSprintLifecycleMCPError(t, transport, resp, out, http.StatusInternalServerError, "INTERNAL", "internal error", nil)
+					assertSprintLifecycleMCPTrace(t, fx.wrapped, sprintLifecycleMCPFailureTrace(operation, stage)...)
+					assertSprintLifecycleMCPFailurePersistence(t, fx, operation, stage, before)
+					if fx.wrapped.activateCommitted || fx.wrapped.closeCommitted || fx.wrapped.deleteCommitted {
+						t.Fatalf("pre-commit failure recorded committed mutation: activate=%v close=%v delete=%v", fx.wrapped.activateCommitted, fx.wrapped.closeCommitted, fx.wrapped.deleteCommitted)
+					}
+					assertSprintLifecycleMCPSilence(t, stream)
+				})
+			}
+		}
+	}
+}
+
+func TestSprintLifecycleMCPCancellationContract(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		for _, operation := range []string{"activate", "close", "delete"} {
+			stages := []string{"access", "role", "target", "mutation"}
+			if operation != "delete" {
+				stages = append(stages, "projection")
+			}
+			for _, stage := range stages {
+				transport, operation, stage := transport, operation, stage
+				t.Run(transport+"/"+operation+"/"+stage, func(t *testing.T) {
+					fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-cancel-"+transport+"-"+operation+"-"+stage)
+					tool, args, before := prepareSprintLifecycleMCPFailureTarget(t, fx, operation)
+					stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+					defer stream.close()
+					injectSprintLifecycleMCPFailure(fx.wrapped, operation, stage, context.Canceled)
+					fx.wrapped.activateTrace()
+
+					resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, tool, args)
+					assertSprintLifecycleMCPError(t, transport, resp, out, http.StatusInternalServerError, "INTERNAL", "internal error", nil)
+					assertSprintLifecycleMCPTrace(t, fx.wrapped, sprintLifecycleMCPFailureTrace(operation, stage)...)
+					assertSprintLifecycleMCPFailurePersistence(t, fx, operation, stage, before)
+					if stage == "projection" {
+						if fx.wrapped.readCalls != 2 {
+							t.Fatalf("projection cancellation reads=%d, want two", fx.wrapped.readCalls)
+						}
+					} else if fx.wrapped.activateCommitted || fx.wrapped.closeCommitted || fx.wrapped.deleteCommitted {
+						t.Fatalf("pre-commit cancellation recorded committed mutation")
+					}
+					assertSprintLifecycleMCPSilence(t, stream)
+				})
+			}
+		}
+	}
+}
+
+func TestSprintLifecycleMCPStoreErrorMappingContract(t *testing.T) {
+	validationErr := fmt.Errorf("%w: lifecycle mutation rejected", store.ErrValidation)
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		for _, operation := range []string{"activate", "close", "delete"} {
+			for _, tc := range []struct {
+				name        string
+				stage       string
+				err         error
+				wantStatus  int
+				wantCode    string
+				wantMessage string
+			}{
+				{name: "access not found", stage: "access", err: store.ErrNotFound, wantStatus: 404, wantCode: "NOT_FOUND", wantMessage: "not found"},
+				{name: "access unauthorized", stage: "access", err: store.ErrUnauthorized, wantStatus: 401, wantCode: "AUTH_REQUIRED", wantMessage: "Sign-in required for this tool"},
+				{name: "role forbidden", stage: "role", err: store.ErrForbidden, wantStatus: 403, wantCode: "FORBIDDEN", wantMessage: "forbidden"},
+				{name: "role not found", stage: "role", err: store.ErrNotFound, wantStatus: 404, wantCode: "NOT_FOUND", wantMessage: "not found"},
+				{name: "mutation validation", stage: "mutation", err: validationErr, wantStatus: 400, wantCode: "VALIDATION_ERROR", wantMessage: validationErr.Error()},
+				{name: "mutation not found", stage: "mutation", err: store.ErrNotFound, wantStatus: 404, wantCode: "NOT_FOUND", wantMessage: "not found"},
+			} {
+				transport, operation, tc := transport, operation, tc
+				t.Run(transport+"/"+operation+"/"+tc.name, func(t *testing.T) {
+					fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-mapping-"+transport+"-"+operation+"-"+strings.ReplaceAll(tc.name, " ", "-"))
+					tool, args, before := prepareSprintLifecycleMCPFailureTarget(t, fx, operation)
+					stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+					defer stream.close()
+					injectSprintLifecycleMCPFailure(fx.wrapped, operation, tc.stage, tc.err)
+					fx.wrapped.activateTrace()
+
+					resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, tool, args)
+					assertSprintLifecycleMCPError(t, transport, resp, out, tc.wantStatus, tc.wantCode, tc.wantMessage, nil)
+					assertSprintLifecycleMCPTrace(t, fx.wrapped, sprintLifecycleMCPFailureTrace(operation, tc.stage)...)
+					assertSprintLifecycleMCPFailurePersistence(t, fx, operation, tc.stage, before)
+					assertSprintLifecycleMCPSilence(t, stream)
+				})
+			}
+		}
+	}
+}
+
+func TestSprintLifecycleMCPDeleteFailureContract(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		for _, targetKind := range []string{"missing", "foreign"} {
+			transport, targetKind := transport, targetKind
+			t.Run(transport+"/"+targetKind, func(t *testing.T) {
+				fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-delete-"+targetKind+"-"+transport)
+				sprintID := int64(920001)
+				var foreignProjectID int64
+				if targetKind == "foreign" {
+					other, err := fx.st.CreateProject(fx.ownerCtx, "mcp-lifecycle-delete-foreign-project-"+transport)
+					if err != nil {
+						t.Fatalf("CreateProject foreign: %v", err)
+					}
+					foreignProjectID = other.ID
+					now := time.Now().UTC()
+					sp, err := fx.st.CreateSprint(fx.ownerCtx, other.ID, "Foreign", now.Add(-time.Hour), now.Add(48*time.Hour))
+					if err != nil {
+						t.Fatalf("CreateSprint foreign: %v", err)
+					}
+					sprintID = sp.ID
+				}
+				stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+				defer stream.close()
+				fx.wrapped.activateTrace()
+
+				resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, "sprints_delete", map[string]any{"projectSlug": fx.project.Slug, "sprintId": sprintID})
+				assertSprintLifecycleMCPError(t, transport, resp, out, http.StatusNotFound, "NOT_FOUND", "not found", nil)
+				assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role", "target")
+				if fx.wrapped.readCalls != 1 || fx.wrapped.deleteCalls != 0 || fx.wrapped.deleteCommitted {
+					t.Fatalf("delete failure observations=(reads=%d calls=%d committed=%v)", fx.wrapped.readCalls, fx.wrapped.deleteCalls, fx.wrapped.deleteCommitted)
+				}
+				if targetKind == "foreign" {
+					sp := getSprintLifecycleMCPSprint(t, fx, sprintID)
+					if sp.ProjectID != foreignProjectID {
+						t.Fatalf("foreign sprint changed=%+v", sp)
+					}
+				}
+				assertSprintLifecycleMCPSilence(t, stream)
+			})
+		}
+	}
+}
+
+func TestSprintLifecycleMCPFreshRoleThresholdContract(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		for _, operation := range []string{"activate", "close", "delete"} {
+			for _, role := range []store.ProjectRole{store.RoleViewer, store.RoleContributor} {
+				transport, operation, role := transport, operation, role
+				t.Run(transport+"/"+operation+"/"+string(role), func(t *testing.T) {
+					fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-role-"+transport+"-"+operation+"-"+strings.ToLower(string(role)))
+					tool, args, before := prepareSprintLifecycleMCPFailureTarget(t, fx, operation)
+					pc := fx.projectPC
+					pc.Role = store.RoleOwner
+					fx.wrapped.accessOverride = &pc
+					fx.wrapped.roleOverride = &role
+					stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+					defer stream.close()
+					fx.wrapped.activateTrace()
+
+					resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, tool, args)
+					assertSprintLifecycleMCPError(t, transport, resp, out, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required", nil)
+					assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role")
+					if fx.wrapped.rolePID != fx.project.ID || fx.wrapped.roleUID != fx.actorID || fx.wrapped.readCalls != 0 || fx.wrapped.activateCalls+fx.wrapped.closeCalls+fx.wrapped.deleteCalls != 0 {
+						t.Fatalf("role observations=(project=%d actor=%d reads=%d mutations=%d)", fx.wrapped.rolePID, fx.wrapped.roleUID, fx.wrapped.readCalls, fx.wrapped.activateCalls+fx.wrapped.closeCalls+fx.wrapped.deleteCalls)
+					}
+					assertSprintLifecycleMCPFailurePersistence(t, fx, operation, "role", before)
+					assertSprintLifecycleMCPSilence(t, stream)
+				})
+			}
+		}
+	}
+}
+
+func TestSprintLifecycleMCPAuthenticationAndCapabilityContract(t *testing.T) {
+	toolNames := []string{"sprints_activate", "sprints_close", "sprints_delete"}
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		for _, tool := range toolNames {
+			transport, tool := transport, tool
+			t.Run("signed-out/"+transport+"/"+tool, func(t *testing.T) {
+				fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-signed-out-"+transport+"-"+tool)
+				stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+				defer stream.close()
+				fx.wrapped.activateTrace()
+				args := map[string]any{"projectSlug": fx.project.Slug, "sprintId": int64(1)}
+				client := newStatelessClient(fx.ts)
+				var resp *http.Response
+				var out map[string]any
+				if transport == "legacy" {
+					resp, out = doMCP(t, client, fx.ts.URL+"/mcp", map[string]any{"tool": tool, "input": args})
+					assertSprintLifecycleMCPError(t, transport, resp, out, http.StatusUnauthorized, "AUTH_REQUIRED", "Sign-in required for this tool", nil)
+				} else {
+					resp, out = callSprintDefinitionJSONRPCWithoutRetry(t, client, fx.ts.URL, map[string]any{
+						"jsonrpc": "2.0", "id": 801, "method": "tools/call", "params": map[string]any{"name": tool, "arguments": args},
+					})
+					if resp.StatusCode != http.StatusUnauthorized || out != nil {
+						t.Fatalf("signed-out JSON-RPC status=%d response=%+v, want bare 401", resp.StatusCode, out)
+					}
+				}
+				assertSprintLifecycleMCPTrace(t, fx.wrapped)
+				assertSprintLifecycleMCPSilence(t, stream)
+			})
+
+			t.Run("anonymous/"+transport+"/"+tool, func(t *testing.T) {
+				ts, _, cleanup := newTestServer(t, "anonymous")
+				defer cleanup()
+				args := map[string]any{"projectSlug": "demo", "sprintId": int64(1)}
+				var resp *http.Response
+				var out map[string]any
+				if transport == "legacy" {
+					resp, out = doMCP(t, ts.Client(), ts.URL+"/mcp", map[string]any{"tool": tool, "input": args})
+				} else {
+					resp, out = callSprintDefinitionJSONRPCWithoutRetry(t, ts.Client(), ts.URL, map[string]any{
+						"jsonrpc": "2.0", "id": 802, "method": "tools/call", "params": map[string]any{"name": tool, "arguments": args},
+					})
+				}
+				assertSprintLifecycleMCPError(t, transport, resp, out, http.StatusForbidden, "CAPABILITY_UNAVAILABLE", tool+" is unavailable in anonymous mode", nil)
+			})
+
+			t.Run("bootstrap/"+transport+"/"+tool, func(t *testing.T) {
+				ts, _, cleanup := newTestServer(t, "full")
+				defer cleanup()
+				args := map[string]any{"projectSlug": "demo", "sprintId": int64(1)}
+				var resp *http.Response
+				var out map[string]any
+				if transport == "legacy" {
+					resp, out = doMCP(t, ts.Client(), ts.URL+"/mcp", map[string]any{"tool": tool, "input": args})
+				} else {
+					resp, out = callSprintDefinitionJSONRPCWithoutRetry(t, ts.Client(), ts.URL, map[string]any{
+						"jsonrpc": "2.0", "id": 803, "method": "tools/call", "params": map[string]any{"name": tool, "arguments": args},
+					})
+				}
+				if transport == "jsonrpc" {
+					if resp.StatusCode != http.StatusUnauthorized || out != nil {
+						t.Fatalf("pre-bootstrap JSON-RPC status=%d response=%+v, want bare 401 before tool dispatch", resp.StatusCode, out)
+					}
+					return
+				}
+				assertSprintLifecycleMCPError(t, transport, resp, out, http.StatusForbidden, "CAPABILITY_UNAVAILABLE", tool+" is unavailable before bootstrap", nil)
+			})
+		}
+	}
+}
+
+func TestSprintLifecycleMCPInputContract(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		for _, operation := range []string{"activate", "close", "delete"} {
+			for _, tc := range []struct {
+				name        string
+				args        func(*sprintLifecycleMCPFixture) map[string]any
+				wantMessage string
+				wantDetails map[string]any
+				wantTrace   []string
+			}{
+				{
+					name: "missing project slug",
+					args: func(_ *sprintLifecycleMCPFixture) map[string]any {
+						return map[string]any{"sprintId": int64(1)}
+					},
+					wantMessage: "missing projectSlug", wantDetails: map[string]any{"field": "projectSlug"},
+				},
+				{
+					name: "invalid sprint id",
+					args: func(fx *sprintLifecycleMCPFixture) map[string]any {
+						return map[string]any{"projectSlug": fx.project.Slug, "sprintId": int64(0)}
+					},
+					wantMessage: "invalid sprintId", wantDetails: map[string]any{"field": "sprintId"},
+				},
+			} {
+				transport, operation, tc := transport, operation, tc
+				t.Run(transport+"/"+operation+"/"+tc.name, func(t *testing.T) {
+					fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-input-"+transport+"-"+operation+"-"+strings.ReplaceAll(tc.name, " ", "-"))
+					stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+					defer stream.close()
+					fx.wrapped.activateTrace()
+					resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, "sprints_"+operation, tc.args(fx))
+					wantMessage := tc.wantMessage
+					if transport == "jsonrpc" && tc.name == "missing project slug" {
+						wantMessage = "missing required field: projectSlug"
+					}
+					assertSprintLifecycleMCPError(t, transport, resp, out, http.StatusBadRequest, "VALIDATION_ERROR", wantMessage, tc.wantDetails)
+					assertSprintLifecycleMCPTrace(t, fx.wrapped, tc.wantTrace...)
+					assertSprintLifecycleMCPSilence(t, stream)
+				})
+			}
+		}
+	}
+}
+
+func TestSprintLifecycleMCPAliasesRemainDispatchOnly(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		transport := transport
+		t.Run(transport, func(t *testing.T) {
+			fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-alias-"+transport)
+			target := createSprintLifecycleMCPSprint(t, fx, "Alias target", store.SprintStatePlanned)
+			ownerEquivalent := store.RoleOwner
+			fx.wrapped.roleOverride = &ownerEquivalent
+			stream := subscribeSprintLifecycleMCPEvents(t, fx, fx.client)
+			defer stream.close()
+
+			fx.wrapped.activateTrace()
+			resp, out := callSprintLifecycleMCP(t, fx, fx.client, transport, "sprints.activate", map[string]any{"projectSlug": fx.project.Slug, "sprintId": target.ID})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("activate alias status=%d response=%+v", resp.StatusCode, out)
+			}
+			active := getSprintLifecycleMCPSprint(t, fx, target.ID)
+			assertSprintLifecycleMCPItem(t, sprintLifecycleMCPData(t, transport, out), fx.project.Slug, active)
+			assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role", "target", "activate", "projection")
+
+			fx.wrapped.activateTrace()
+			resp, out = callSprintLifecycleMCP(t, fx, fx.client, transport, "sprints.close", map[string]any{"projectSlug": fx.project.Slug, "sprintId": target.ID})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("close alias status=%d response=%+v", resp.StatusCode, out)
+			}
+			closed := getSprintLifecycleMCPSprint(t, fx, target.ID)
+			assertSprintLifecycleMCPItem(t, sprintLifecycleMCPData(t, transport, out), fx.project.Slug, closed)
+			assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role", "target", "close", "projection")
+
+			fx.wrapped.activateTrace()
+			resp, out = callSprintLifecycleMCP(t, fx, fx.client, transport, "sprints.delete", map[string]any{"projectSlug": fx.project.Slug, "sprintId": target.ID})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("delete alias status=%d response=%+v", resp.StatusCode, out)
+			}
+			data := sprintLifecycleMCPData(t, transport, out)
+			if data["status"] != "deleted" || data["projectSlug"] != fx.project.Slug || int64(data["sprintId"].(float64)) != target.ID {
+				t.Fatalf("delete alias echo=%+v", data)
+			}
+			assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role", "target", "delete")
+			if fx.wrapped.roleUID != fx.actorID {
+				t.Fatalf("alias fresh role actor=%d, want %d", fx.wrapped.roleUID, fx.actorID)
+			}
+			assertSprintLifecycleMCPSilence(t, stream)
+		})
+	}
+
+	fx := newSprintLifecycleMCPFixture(t, "mcp-lifecycle-advertisement")
+	resp, out := doJSONRPC(t, fx.client, fx.ts.URL, map[string]any{"jsonrpc": "2.0", "id": 804, "method": "tools/list", "params": map[string]any{}})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("tools/list status=%d response=%+v", resp.StatusCode, out)
+	}
+	result := out["result"].(map[string]any)
+	tools := result["tools"].([]any)
+	seen := map[string]bool{}
+	for _, raw := range tools {
+		seen[raw.(map[string]any)["name"].(string)] = true
+	}
+	for _, canonical := range []string{"sprints_activate", "sprints_close", "sprints_delete"} {
+		if !seen[canonical] {
+			t.Fatalf("canonical tool %q is not advertised", canonical)
+		}
+	}
+	for _, alias := range []string{"sprints.activate", "sprints.close", "sprints.delete"} {
+		if seen[alias] {
+			t.Fatalf("compatibility alias %q is unexpectedly advertised", alias)
+		}
+	}
+}

--- a/internal/mcp/sprint_lifecycle_transport_contract_test.go
+++ b/internal/mcp/sprint_lifecycle_transport_contract_test.go
@@ -51,6 +51,7 @@ type sprintLifecycleMCPStore struct {
 	activateID        int64
 	activateCommitted bool
 	closeCalls        int
+	closePID          int64
 	closeID           int64
 	closeCommitted    bool
 	deleteCalls       int
@@ -173,19 +174,20 @@ func (s *sprintLifecycleMCPStore) ActivateSprint(ctx context.Context, projectID,
 	return nil
 }
 
-func (s *sprintLifecycleMCPStore) CloseSprint(ctx context.Context, sprintID int64) error {
+func (s *sprintLifecycleMCPStore) CloseSprint(ctx context.Context, projectID, sprintID int64) error {
 	if !s.record("close") {
-		return s.Store.CloseSprint(ctx, sprintID)
+		return s.Store.CloseSprint(ctx, projectID, sprintID)
 	}
 	s.mu.Lock()
 	s.closeCalls++
+	s.closePID = projectID
 	s.closeID = sprintID
 	err := s.closeErr
 	s.mu.Unlock()
 	if err != nil {
 		return err
 	}
-	if err := s.Store.CloseSprint(ctx, sprintID); err != nil {
+	if err := s.Store.CloseSprint(ctx, projectID, sprintID); err != nil {
 		return err
 	}
 	s.mu.Lock()
@@ -316,7 +318,7 @@ func createSprintLifecycleMCPSprint(t *testing.T, fx *sprintLifecycleMCPFixture,
 		}
 	}
 	if state == store.SprintStateClosed {
-		if err := fx.st.CloseSprint(fx.ownerCtx, sp.ID); err != nil {
+		if err := fx.st.CloseSprint(fx.ownerCtx, fx.project.ID, sp.ID); err != nil {
 			t.Fatalf("CloseSprint setup: %v", err)
 		}
 	}
@@ -505,8 +507,8 @@ func TestSprintLifecycleMCPCloseContract(t *testing.T) {
 			}
 			assertSprintLifecycleMCPItem(t, sprintLifecycleMCPData(t, transport, out), fx.project.Slug, stored)
 			assertSprintLifecycleMCPTrace(t, fx.wrapped, "access", "role", "target", "close", "projection")
-			if fx.wrapped.readCalls != 2 || !reflect.DeepEqual(fx.wrapped.readIDs, []int64{sp.ID, sp.ID}) || fx.wrapped.closeCalls != 1 || fx.wrapped.closeID != sp.ID || !fx.wrapped.closeCommitted {
-				t.Fatalf("close observations=(reads=%d ids=%v calls=%d sprint=%d committed=%v)", fx.wrapped.readCalls, fx.wrapped.readIDs, fx.wrapped.closeCalls, fx.wrapped.closeID, fx.wrapped.closeCommitted)
+			if fx.wrapped.readCalls != 2 || !reflect.DeepEqual(fx.wrapped.readIDs, []int64{sp.ID, sp.ID}) || fx.wrapped.closeCalls != 1 || fx.wrapped.closePID != fx.project.ID || fx.wrapped.closeID != sp.ID || !fx.wrapped.closeCommitted {
+				t.Fatalf("close observations=(reads=%d ids=%v calls=%d project=%d sprint=%d committed=%v)", fx.wrapped.readCalls, fx.wrapped.readIDs, fx.wrapped.closeCalls, fx.wrapped.closePID, fx.wrapped.closeID, fx.wrapped.closeCommitted)
 			}
 			if fx.wrapped.closeID == sp.Number {
 				t.Fatalf("Sprint.Number %d was used as close persistence identity", sp.Number)

--- a/internal/mcp/sprint_tools.go
+++ b/internal/mcp/sprint_tools.go
@@ -3,9 +3,11 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"time"
 
+	sprintapp "scrumboy/internal/application/sprint"
 	"scrumboy/internal/store"
 )
 
@@ -29,6 +31,19 @@ type sprintUpdateEnvelope struct {
 	ProjectSlug string          `json:"projectSlug"`
 	SprintID    int64           `json:"sprintId"`
 	Patch       json.RawMessage `json:"patch"`
+}
+
+func mapSprintDefinitionPrepareError(err error) *adapterError {
+	switch {
+	case errors.Is(err, sprintapp.ErrActorRequired):
+		return newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
+	case errors.Is(err, sprintapp.ErrMaintainerRequired):
+		return newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
+	case errors.Is(err, sprintapp.ErrSprintNotInProject):
+		return newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
+	default:
+		return mapStoreError(err)
+	}
 }
 
 func (a *Adapter) handleSprintsList(ctx context.Context, input any) (any, map[string]any, *adapterError) {
@@ -212,24 +227,19 @@ func (a *Adapter) handleSprintsCreate(ctx context.Context, input any) (any, map[
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid plannedEndAt", map[string]any{"field": "plannedEndAt", "detail": parseErr.Error()})
 	}
 
-	pc, pcErr := a.store.GetProjectContextBySlug(ctx, in.ProjectSlug, a.storeMode())
-	if pcErr != nil {
-		return nil, nil, mapStoreError(pcErr)
+	prepared, prepareErr := a.sprintDefinitions.PrepareCreate(ctx, sprintapp.MCPProjectTarget{
+		ProjectSlug: in.ProjectSlug,
+		Mode:        a.storeMode(),
+	})
+	if prepareErr != nil {
+		return nil, nil, mapSprintDefinitionPrepareError(prepareErr)
 	}
 
-	userID, ok := store.UserIDFromContext(ctx)
-	if !ok {
-		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
-	}
-	role, roleErr := a.store.GetProjectRole(ctx, pc.Project.ID, userID)
-	if roleErr != nil {
-		return nil, nil, mapStoreError(roleErr)
-	}
-	if !role.HasMinimumRole(store.RoleMaintainer) {
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
-	}
-
-	sp, createErr := a.store.CreateSprint(ctx, pc.Project.ID, in.Name, plannedStartAt, plannedEndAt)
+	sp, createErr := prepared.Create(sprintapp.CreateCommand{
+		Name:           in.Name,
+		PlannedStartAt: plannedStartAt,
+		PlannedEndAt:   plannedEndAt,
+	})
 	if createErr != nil {
 		return nil, nil, mapStoreError(createErr)
 	}
@@ -268,46 +278,23 @@ func (a *Adapter) handleSprintsUpdate(ctx context.Context, input any) (any, map[
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "missing patch", map[string]any{"field": "patch"})
 	}
 
-	pc, pcErr := a.store.GetProjectContextBySlug(ctx, env.ProjectSlug, a.storeMode())
-	if pcErr != nil {
-		return nil, nil, mapStoreError(pcErr)
-	}
-	userID, ok := store.UserIDFromContext(ctx)
-	if !ok {
-		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
-	}
-	role, roleErr := a.store.GetProjectRole(ctx, pc.Project.ID, userID)
-	if roleErr != nil {
-		return nil, nil, mapStoreError(roleErr)
-	}
-	if !role.HasMinimumRole(store.RoleMaintainer) {
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
+	prepared, prepareErr := a.sprintDefinitions.PrepareUpdate(ctx, sprintapp.MCPSprintTarget{
+		ProjectSlug: env.ProjectSlug,
+		SprintID:    env.SprintID,
+		Mode:        a.storeMode(),
+	})
+	if prepareErr != nil {
+		return nil, nil, mapSprintDefinitionPrepareError(prepareErr)
 	}
 
-	sp, getErr := a.store.GetSprintByID(ctx, env.SprintID)
-	if getErr != nil {
-		return nil, nil, mapStoreError(getErr)
-	}
-	if sp.ProjectID != pc.Project.ID {
-		return nil, nil, newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
-	}
-
-	updateIn, changed, patchErr := buildSprintUpdateInput(env.Patch)
+	command, patchErr := buildSprintUpdateCommand(env.Patch)
 	if patchErr != nil {
 		return nil, nil, patchErr
 	}
-	if !changed {
-		return map[string]any{
-			"sprint": sprintToItem(env.ProjectSlug, sp, nil),
-		}, map[string]any{}, nil
-	}
 
-	if err := a.store.UpdateSprint(ctx, env.SprintID, updateIn); err != nil {
-		return nil, nil, mapStoreError(err)
-	}
-	updated, updatedErr := a.store.GetSprintByID(ctx, env.SprintID)
-	if updatedErr != nil {
-		return nil, nil, mapStoreError(updatedErr)
+	updated, updateErr := prepared.Update(command)
+	if updateErr != nil {
+		return nil, nil, mapStoreError(updateErr)
 	}
 
 	return map[string]any{
@@ -492,13 +479,13 @@ func sprintToItem(projectSlug string, sp store.Sprint, todoCount *int64) sprintI
 	}
 }
 
-func buildSprintUpdateInput(patchRaw json.RawMessage) (store.UpdateSprintInput, bool, *adapterError) {
+func buildSprintUpdateCommand(patchRaw json.RawMessage) (sprintapp.UpdateCommand, *adapterError) {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(patchRaw, &raw); err != nil {
-		return store.UpdateSprintInput{}, false, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid patch", map[string]any{"detail": err.Error()})
+		return sprintapp.UpdateCommand{}, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid patch", map[string]any{"detail": err.Error()})
 	}
 	if raw == nil {
-		return store.UpdateSprintInput{}, false, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid patch", map[string]any{"field": "patch"})
+		return sprintapp.UpdateCommand{}, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid patch", map[string]any{"field": "patch"})
 	}
 
 	allowed := map[string]struct{}{
@@ -508,50 +495,46 @@ func buildSprintUpdateInput(patchRaw json.RawMessage) (store.UpdateSprintInput, 
 	}
 	for key := range raw {
 		if _, ok := allowed[key]; !ok {
-			return store.UpdateSprintInput{}, false, newAdapterError(http.StatusBadRequest, CodeValidationError, "unsupported patch field", map[string]any{"field": key})
+			return sprintapp.UpdateCommand{}, newAdapterError(http.StatusBadRequest, CodeValidationError, "unsupported patch field", map[string]any{"field": key})
 		}
 	}
 
-	var in store.UpdateSprintInput
-	changed := false
+	var command sprintapp.UpdateCommand
 
 	if v, ok := raw["name"]; ok {
 		if isNullJSON(v) {
-			return store.UpdateSprintInput{}, false, newAdapterError(http.StatusBadRequest, CodeValidationError, "name cannot be null", map[string]any{"field": "name"})
+			return sprintapp.UpdateCommand{}, newAdapterError(http.StatusBadRequest, CodeValidationError, "name cannot be null", map[string]any{"field": "name"})
 		}
 		var name string
 		if err := json.Unmarshal(v, &name); err != nil {
-			return store.UpdateSprintInput{}, false, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid name", map[string]any{"field": "name"})
+			return sprintapp.UpdateCommand{}, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid name", map[string]any{"field": "name"})
 		}
-		in.Name = &name
-		changed = true
+		command.Name = &name
 	}
 
 	if v, ok := raw["plannedStartAt"]; ok {
 		if isNullJSON(v) {
-			return store.UpdateSprintInput{}, false, newAdapterError(http.StatusBadRequest, CodeValidationError, "plannedStartAt cannot be null", map[string]any{"field": "plannedStartAt"})
+			return sprintapp.UpdateCommand{}, newAdapterError(http.StatusBadRequest, CodeValidationError, "plannedStartAt cannot be null", map[string]any{"field": "plannedStartAt"})
 		}
 		var ms int64
 		if err := json.Unmarshal(v, &ms); err != nil {
-			return store.UpdateSprintInput{}, false, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid plannedStartAt", map[string]any{"field": "plannedStartAt"})
+			return sprintapp.UpdateCommand{}, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid plannedStartAt", map[string]any{"field": "plannedStartAt"})
 		}
 		t := time.UnixMilli(ms).UTC()
-		in.PlannedStartAt = &t
-		changed = true
+		command.PlannedStartAt = &t
 	}
 
 	if v, ok := raw["plannedEndAt"]; ok {
 		if isNullJSON(v) {
-			return store.UpdateSprintInput{}, false, newAdapterError(http.StatusBadRequest, CodeValidationError, "plannedEndAt cannot be null", map[string]any{"field": "plannedEndAt"})
+			return sprintapp.UpdateCommand{}, newAdapterError(http.StatusBadRequest, CodeValidationError, "plannedEndAt cannot be null", map[string]any{"field": "plannedEndAt"})
 		}
 		var ms int64
 		if err := json.Unmarshal(v, &ms); err != nil {
-			return store.UpdateSprintInput{}, false, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid plannedEndAt", map[string]any{"field": "plannedEndAt"})
+			return sprintapp.UpdateCommand{}, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid plannedEndAt", map[string]any{"field": "plannedEndAt"})
 		}
 		t := time.UnixMilli(ms).UTC()
-		in.PlannedEndAt = &t
-		changed = true
+		command.PlannedEndAt = &t
 	}
 
-	return in, changed, nil
+	return command, nil
 }

--- a/internal/mcp/sprint_tools.go
+++ b/internal/mcp/sprint_tools.go
@@ -46,6 +46,19 @@ func mapSprintDefinitionPrepareError(err error) *adapterError {
 	}
 }
 
+func mapSprintLifecyclePrepareError(err error) *adapterError {
+	switch {
+	case errors.Is(err, sprintapp.ErrSprintMustBePlanned):
+		return newAdapterError(http.StatusBadRequest, CodeValidationError, "sprint must be PLANNED to activate", map[string]any{"field": "sprintId"})
+	case errors.Is(err, sprintapp.ErrSprintEndNotAfterNow):
+		return newAdapterError(http.StatusBadRequest, CodeValidationError, "sprint end date is on or before now; cannot activate", map[string]any{"field": "plannedEndAt"})
+	case errors.Is(err, sprintapp.ErrSprintMustBeActive):
+		return newAdapterError(http.StatusBadRequest, CodeValidationError, "sprint must be ACTIVE to close", map[string]any{"field": "sprintId"})
+	default:
+		return mapSprintDefinitionPrepareError(err)
+	}
+}
+
 func (a *Adapter) handleSprintsList(ctx context.Context, input any) (any, map[string]any, *adapterError) {
 	auth, bootstrapAvailable, err := a.authState(ctx)
 	if err != nil {
@@ -336,32 +349,16 @@ func (a *Adapter) handleSprintsDelete(ctx context.Context, input any) (any, map[
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid sprintId", map[string]any{"field": "sprintId"})
 	}
 
-	pc, pcErr := a.store.GetProjectContextBySlug(ctx, in.ProjectSlug, a.storeMode())
-	if pcErr != nil {
-		return nil, nil, mapStoreError(pcErr)
+	prepared, prepareErr := a.sprintDeletions.PrepareDelete(ctx, sprintapp.MCPDeletionTarget{
+		ProjectSlug: in.ProjectSlug,
+		SprintID:    in.SprintID,
+		Mode:        a.storeMode(),
+	})
+	if prepareErr != nil {
+		return nil, nil, mapSprintDefinitionPrepareError(prepareErr)
 	}
-	userID, ok := store.UserIDFromContext(ctx)
-	if !ok {
-		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
-	}
-	role, roleErr := a.store.GetProjectRole(ctx, pc.Project.ID, userID)
-	if roleErr != nil {
-		return nil, nil, mapStoreError(roleErr)
-	}
-	if !role.HasMinimumRole(store.RoleMaintainer) {
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
-	}
-
-	sp, getErr := a.store.GetSprintByID(ctx, in.SprintID)
-	if getErr != nil {
-		return nil, nil, mapStoreError(getErr)
-	}
-	if sp.ProjectID != pc.Project.ID {
-		return nil, nil, newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
-	}
-
-	if err := a.store.DeleteSprint(ctx, pc.Project.ID, in.SprintID); err != nil {
-		return nil, nil, mapStoreError(err)
+	if deleteErr := prepared.Delete(); deleteErr != nil {
+		return nil, nil, mapStoreError(deleteErr)
 	}
 
 	return map[string]any{
@@ -398,55 +395,38 @@ func (a *Adapter) handleSprintAction(ctx context.Context, input any, action stri
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid sprintId", map[string]any{"field": "sprintId"})
 	}
 
-	pc, pcErr := a.store.GetProjectContextBySlug(ctx, in.ProjectSlug, a.storeMode())
-	if pcErr != nil {
-		return nil, nil, mapStoreError(pcErr)
-	}
-	userID, ok := store.UserIDFromContext(ctx)
-	if !ok {
-		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
-	}
-	role, roleErr := a.store.GetProjectRole(ctx, pc.Project.ID, userID)
-	if roleErr != nil {
-		return nil, nil, mapStoreError(roleErr)
-	}
-	if !role.HasMinimumRole(store.RoleMaintainer) {
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
-	}
-
-	sp, getErr := a.store.GetSprintByID(ctx, in.SprintID)
-	if getErr != nil {
-		return nil, nil, mapStoreError(getErr)
-	}
-	if sp.ProjectID != pc.Project.ID {
-		return nil, nil, newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
-	}
-
+	var updated store.Sprint
 	switch action {
 	case "activate":
-		if sp.State != store.SprintStatePlanned {
-			return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "sprint must be PLANNED to activate", map[string]any{"field": "sprintId"})
+		prepared, prepareErr := a.sprintLifecycle.PrepareActivate(ctx, sprintapp.MCPLifecycleTarget{
+			ProjectSlug: in.ProjectSlug,
+			SprintID:    in.SprintID,
+			Mode:        a.storeMode(),
+		})
+		if prepareErr != nil {
+			return nil, nil, mapSprintLifecyclePrepareError(prepareErr)
 		}
-		if !sp.PlannedEndAt.After(time.Now().UTC()) {
-			return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "sprint end date is on or before now; cannot activate", map[string]any{"field": "plannedEndAt"})
-		}
-		if err := a.store.ActivateSprint(ctx, pc.Project.ID, in.SprintID); err != nil {
-			return nil, nil, mapStoreError(err)
+		var activateErr error
+		updated, activateErr = prepared.Activate()
+		if activateErr != nil {
+			return nil, nil, mapStoreError(activateErr)
 		}
 	case "close":
-		if sp.State != store.SprintStateActive {
-			return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "sprint must be ACTIVE to close", map[string]any{"field": "sprintId"})
+		prepared, prepareErr := a.sprintLifecycle.PrepareClose(ctx, sprintapp.MCPLifecycleTarget{
+			ProjectSlug: in.ProjectSlug,
+			SprintID:    in.SprintID,
+			Mode:        a.storeMode(),
+		})
+		if prepareErr != nil {
+			return nil, nil, mapSprintLifecyclePrepareError(prepareErr)
 		}
-		if err := a.store.CloseSprint(ctx, pc.Project.ID, in.SprintID); err != nil {
-			return nil, nil, mapStoreError(err)
+		var closeErr error
+		updated, closeErr = prepared.Close()
+		if closeErr != nil {
+			return nil, nil, mapStoreError(closeErr)
 		}
 	default:
 		return nil, nil, newAdapterError(http.StatusInternalServerError, CodeInternal, "internal error", map[string]any{"detail": "unknown sprint action"})
-	}
-
-	updated, updatedErr := a.store.GetSprintByID(ctx, in.SprintID)
-	if updatedErr != nil {
-		return nil, nil, mapStoreError(updatedErr)
 	}
 
 	return map[string]any{

--- a/internal/mcp/sprint_tools.go
+++ b/internal/mcp/sprint_tools.go
@@ -437,7 +437,7 @@ func (a *Adapter) handleSprintAction(ctx context.Context, input any, action stri
 		if sp.State != store.SprintStateActive {
 			return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "sprint must be ACTIVE to close", map[string]any{"field": "sprintId"})
 		}
-		if err := a.store.CloseSprint(ctx, in.SprintID); err != nil {
+		if err := a.store.CloseSprint(ctx, pc.Project.ID, in.SprintID); err != nil {
 			return nil, nil, mapStoreError(err)
 		}
 	default:

--- a/internal/store/sprint_definition_contract_test.go
+++ b/internal/store/sprint_definition_contract_test.go
@@ -1,0 +1,136 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSprintDefinitionCreate_InsertRemainsCommittedWhenReturnReadFails(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	project, err := st.CreateProject(ctx, "sprint-definition-committed-create")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	const corruptValue = "checkpoint-one-return-read-failure"
+	if _, err := st.db.ExecContext(ctx, `
+		CREATE TRIGGER sprint_definition_corrupt_created_row
+		AFTER INSERT ON sprints
+		BEGIN
+			UPDATE sprints
+			SET planned_start_at = '`+corruptValue+`'
+			WHERE id = NEW.id;
+		END
+	`); err != nil {
+		t.Fatalf("create post-insert fault trigger: %v", err)
+	}
+
+	start := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
+	created, err := st.CreateSprint(ctx, project.ID, "Committed sprint", start, start.Add(7*24*time.Hour))
+	if err == nil {
+		t.Fatalf("CreateSprint returned %+v, want return-read failure", created)
+	}
+	if !strings.Contains(err.Error(), "get sprint") || !strings.Contains(err.Error(), corruptValue) {
+		t.Fatalf("CreateSprint error=%q, want typed return-read failure containing %q", err, corruptValue)
+	}
+
+	var (
+		rowCount       int
+		storedName     string
+		storedStartRaw string
+		storedNumber   int64
+	)
+	if err := st.db.QueryRowContext(ctx, `
+		SELECT COUNT(*), MIN(name), MIN(CAST(planned_start_at AS TEXT)), MIN(number)
+		FROM sprints
+		WHERE project_id = ?
+	`, project.ID).Scan(&rowCount, &storedName, &storedStartRaw, &storedNumber); err != nil {
+		t.Fatalf("query committed sprint row: %v", err)
+	}
+	if rowCount != 1 {
+		t.Fatalf("committed sprint rows=%d, want exactly one insert attempt", rowCount)
+	}
+	if storedName != "Committed sprint" || storedStartRaw != corruptValue || storedNumber != 1 {
+		t.Fatalf("committed row=(name=%q start=%q number=%d), want inserted sprint with post-insert fault", storedName, storedStartRaw, storedNumber)
+	}
+
+	if _, err := st.GetSprintByProjectNumber(ctx, project.ID, storedNumber); err == nil || !strings.Contains(err.Error(), corruptValue) {
+		t.Fatalf("GetSprintByProjectNumber error=%v, want independent proof the committed row remains unreadable", err)
+	}
+}
+
+func TestSprintDefinitionStoreOwnsDefinitionValidationByState(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	project, err := st.CreateProject(ctx, "sprint-definition-store-policy")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	start := time.Date(2026, time.August, 10, 12, 0, 0, 0, time.UTC)
+
+	t.Run("create trims names and rejects duplicates and reversed dates", func(t *testing.T) {
+		created, err := st.CreateSprint(ctx, project.ID, "  Definition A  ", start, start.Add(7*24*time.Hour))
+		if err != nil {
+			t.Fatalf("CreateSprint: %v", err)
+		}
+		if created.Name != "Definition A" {
+			t.Fatalf("created name=%q, want store-trimmed name", created.Name)
+		}
+		if _, err := st.CreateSprint(ctx, project.ID, "Definition A", start, start.Add(7*24*time.Hour)); err == nil || !strings.Contains(err.Error(), "already exists") {
+			t.Fatalf("duplicate CreateSprint error=%v", err)
+		}
+		if _, err := st.CreateSprint(ctx, project.ID, "Definition B", start, start.Add(-time.Millisecond)); err == nil || !strings.Contains(err.Error(), "end_at must be >= start_at") {
+			t.Fatalf("reversed-date CreateSprint error=%v", err)
+		}
+	})
+
+	t.Run("active allows only planned end", func(t *testing.T) {
+		active, err := st.CreateSprint(ctx, project.ID, "Active definition", start, start.Add(7*24*time.Hour))
+		if err != nil {
+			t.Fatalf("CreateSprint: %v", err)
+		}
+		if err := st.ActivateSprint(ctx, project.ID, active.ID); err != nil {
+			t.Fatalf("ActivateSprint: %v", err)
+		}
+		newName := "renamed active"
+		if err := st.UpdateSprint(ctx, active.ID, UpdateSprintInput{Name: &newName}); err == nil || !strings.Contains(err.Error(), "only endAt") {
+			t.Fatalf("active name UpdateSprint error=%v", err)
+		}
+		newEnd := start.Add(8 * 24 * time.Hour)
+		if err := st.UpdateSprint(ctx, active.ID, UpdateSprintInput{PlannedEndAt: &newEnd}); err != nil {
+			t.Fatalf("active end UpdateSprint: %v", err)
+		}
+	})
+
+	t.Run("closed allows only name", func(t *testing.T) {
+		closed, err := st.CreateSprint(ctx, project.ID, "Closed definition", start.Add(20*24*time.Hour), start.Add(27*24*time.Hour))
+		if err != nil {
+			t.Fatalf("CreateSprint: %v", err)
+		}
+		if _, err := st.db.ExecContext(ctx, `UPDATE sprints SET state = ?, started_at = ?, closed_at = ? WHERE id = ?`, SprintStateClosed, start.UnixMilli(), start.Add(24*time.Hour).UnixMilli(), closed.ID); err != nil {
+			t.Fatalf("set closed fixture state: %v", err)
+		}
+		newEnd := start.Add(28 * 24 * time.Hour)
+		if err := st.UpdateSprint(ctx, closed.ID, UpdateSprintInput{PlannedEndAt: &newEnd}); err == nil || !strings.Contains(err.Error(), "dates cannot be updated") {
+			t.Fatalf("closed date UpdateSprint error=%v", err)
+		}
+		newName := "Renamed closed definition"
+		if err := st.UpdateSprint(ctx, closed.ID, UpdateSprintInput{Name: &newName}); err != nil {
+			t.Fatalf("closed name UpdateSprint: %v", err)
+		}
+		got, err := st.GetSprintByID(ctx, closed.ID)
+		if err != nil {
+			t.Fatalf("GetSprintByID: %v", err)
+		}
+		if got.Name != newName || got.State != SprintStateClosed {
+			t.Fatalf("closed sprint=%+v, want renamed definition without state change", got)
+		}
+	})
+}

--- a/internal/store/sprint_lifecycle_contract_test.go
+++ b/internal/store/sprint_lifecycle_contract_test.go
@@ -122,7 +122,7 @@ func TestSprintLifecycleStoreActivateContract(t *testing.T) {
 		if err := st.ActivateSprint(ctx, project.ID, sp.ID); err != nil {
 			t.Fatalf("ActivateSprint setup: %v", err)
 		}
-		if err := st.CloseSprint(ctx, sp.ID); err != nil {
+		if err := st.CloseSprint(ctx, project.ID, sp.ID); err != nil {
 			t.Fatalf("CloseSprint setup: %v", err)
 		}
 
@@ -280,14 +280,14 @@ func TestSprintLifecycleStoreCloseCurrentContract(t *testing.T) {
 		}
 		before := getLifecycleSprint(t, st, sp.ID)
 
-		if err := st.CloseSprint(ctx, sp.ID); err != nil {
+		if err := st.CloseSprint(ctx, project.ID, sp.ID); err != nil {
 			t.Fatalf("CloseSprint: %v", err)
 		}
 		after := assertLifecycleState(t, st, sp.ID, SprintStateClosed)
 		if after.ClosedAt == nil || after.StartedAt == nil || before.StartedAt == nil || !after.StartedAt.Equal(*before.StartedAt) {
 			t.Fatalf("closed sprint timestamps before=%+v after=%+v", before, after)
 		}
-		if err := st.CloseSprint(ctx, sp.ID); !errors.Is(err, ErrNotFound) {
+		if err := st.CloseSprint(ctx, project.ID, sp.ID); !errors.Is(err, ErrNotFound) {
 			t.Fatalf("repeat CloseSprint error=%v, want ErrNotFound", err)
 		}
 	})
@@ -303,16 +303,16 @@ func TestSprintLifecycleStoreCloseCurrentContract(t *testing.T) {
 		now := time.Now().UTC()
 		sp := createLifecycleSprint(t, st, project.ID, "Planned", now.Add(-time.Hour), now.Add(24*time.Hour))
 
-		if err := st.CloseSprint(ctx, sp.ID); !errors.Is(err, ErrNotFound) {
+		if err := st.CloseSprint(ctx, project.ID, sp.ID); !errors.Is(err, ErrNotFound) {
 			t.Fatalf("planned CloseSprint error=%v, want ErrNotFound", err)
 		}
-		if err := st.CloseSprint(ctx, sp.ID+100000); !errors.Is(err, ErrNotFound) {
+		if err := st.CloseSprint(ctx, project.ID, sp.ID+100000); !errors.Is(err, ErrNotFound) {
 			t.Fatalf("missing CloseSprint error=%v, want ErrNotFound", err)
 		}
 		assertLifecycleState(t, st, sp.ID, SprintStatePlanned)
 	})
 
-	t.Run("global row id closes another project without project input", func(t *testing.T) {
+	t.Run("foreign project is rejected by durable mutation authority", func(t *testing.T) {
 		st, cleanup := newTestStore(t)
 		defer cleanup()
 		ctx := context.Background()
@@ -333,8 +333,12 @@ func TestSprintLifecycleStoreCloseCurrentContract(t *testing.T) {
 			t.Fatalf("ActivateSprint B: %v", err)
 		}
 
-		if err := st.CloseSprint(ctx, sp.ID); err != nil {
-			t.Fatalf("CloseSprint(global B id): %v", err)
+		if err := st.CloseSprint(ctx, projectA.ID, sp.ID); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("CloseSprint(project A, sprint B) error=%v, want ErrNotFound", err)
+		}
+		assertLifecycleState(t, st, sp.ID, SprintStateActive)
+		if err := st.CloseSprint(ctx, projectB.ID, sp.ID); err != nil {
+			t.Fatalf("CloseSprint(project B, sprint B): %v", err)
 		}
 		assertLifecycleState(t, st, sp.ID, SprintStateClosed)
 	})
@@ -359,7 +363,7 @@ func TestSprintLifecycleStoreDeleteContract(t *testing.T) {
 				}
 			}
 			if state == SprintStateClosed {
-				if err := st.CloseSprint(ctx, sp.ID); err != nil {
+				if err := st.CloseSprint(ctx, project.ID, sp.ID); err != nil {
 					t.Fatalf("CloseSprint setup: %v", err)
 				}
 			}

--- a/internal/store/sprint_lifecycle_contract_test.go
+++ b/internal/store/sprint_lifecycle_contract_test.go
@@ -1,0 +1,503 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func createLifecycleSprint(t *testing.T, st *Store, projectID int64, name string, start, end time.Time) Sprint {
+	t.Helper()
+	sp, err := st.CreateSprint(context.Background(), projectID, name, start, end)
+	if err != nil {
+		t.Fatalf("CreateSprint(%q): %v", name, err)
+	}
+	return sp
+}
+
+func getLifecycleSprint(t *testing.T, st *Store, sprintID int64) Sprint {
+	t.Helper()
+	sp, err := st.GetSprintByID(context.Background(), sprintID)
+	if err != nil {
+		t.Fatalf("GetSprintByID(%d): %v", sprintID, err)
+	}
+	return sp
+}
+
+func assertLifecycleState(t *testing.T, st *Store, sprintID int64, want string) Sprint {
+	t.Helper()
+	sp := getLifecycleSprint(t, st, sprintID)
+	if sp.State != want {
+		t.Fatalf("sprint %d state=%q, want %q", sprintID, sp.State, want)
+	}
+	return sp
+}
+
+func TestSprintLifecycleStoreActivateContract(t *testing.T) {
+	t.Run("planned future succeeds", func(t *testing.T) {
+		st, cleanup := newTestStore(t)
+		defer cleanup()
+
+		ctx := context.Background()
+		project, err := st.CreateProject(ctx, "lifecycle-activate-future")
+		if err != nil {
+			t.Fatalf("CreateProject: %v", err)
+		}
+		now := time.Now().UTC()
+		sp := createLifecycleSprint(t, st, project.ID, "Future", now.Add(-time.Hour), now.Add(24*time.Hour))
+
+		if err := st.ActivateSprint(ctx, project.ID, sp.ID); err != nil {
+			t.Fatalf("ActivateSprint: %v", err)
+		}
+		got := assertLifecycleState(t, st, sp.ID, SprintStateActive)
+		if got.StartedAt == nil || got.ClosedAt != nil {
+			t.Fatalf("activated sprint timestamps started=%v closed=%v", got.StartedAt, got.ClosedAt)
+		}
+	})
+
+	t.Run("planned safely past fails", func(t *testing.T) {
+		st, cleanup := newTestStore(t)
+		defer cleanup()
+
+		ctx := context.Background()
+		project, err := st.CreateProject(ctx, "lifecycle-activate-past")
+		if err != nil {
+			t.Fatalf("CreateProject: %v", err)
+		}
+		now := time.Now().UTC()
+		sp := createLifecycleSprint(t, st, project.ID, "Past", now.Add(-48*time.Hour), now.Add(-24*time.Hour))
+
+		err = st.ActivateSprint(ctx, project.ID, sp.ID)
+		if !errors.Is(err, ErrValidation) || !strings.Contains(err.Error(), "on or before now") {
+			t.Fatalf("ActivateSprint error=%v, want end-in-past validation", err)
+		}
+		got := assertLifecycleState(t, st, sp.ID, SprintStatePlanned)
+		if got.StartedAt != nil || got.ClosedAt != nil {
+			t.Fatalf("rejected sprint timestamps started=%v closed=%v", got.StartedAt, got.ClosedAt)
+		}
+	})
+
+	t.Run("already active is idempotent", func(t *testing.T) {
+		st, cleanup := newTestStore(t)
+		defer cleanup()
+
+		ctx := context.Background()
+		project, err := st.CreateProject(ctx, "lifecycle-activate-idempotent")
+		if err != nil {
+			t.Fatalf("CreateProject: %v", err)
+		}
+		now := time.Now().UTC()
+		sp := createLifecycleSprint(t, st, project.ID, "Active", now.Add(-time.Hour), now.Add(24*time.Hour))
+		if err := st.ActivateSprint(ctx, project.ID, sp.ID); err != nil {
+			t.Fatalf("first ActivateSprint: %v", err)
+		}
+		before := getLifecycleSprint(t, st, sp.ID)
+
+		if err := st.ActivateSprint(ctx, project.ID, sp.ID); err != nil {
+			t.Fatalf("second ActivateSprint: %v", err)
+		}
+		after := getLifecycleSprint(t, st, sp.ID)
+		if after.State != SprintStateActive || after.StartedAt == nil || before.StartedAt == nil {
+			t.Fatalf("idempotent sprint before=%+v after=%+v", before, after)
+		}
+		if !after.StartedAt.Equal(*before.StartedAt) || !after.UpdatedAt.Equal(before.UpdatedAt) {
+			t.Fatalf("idempotent activation changed timestamps before=%+v after=%+v", before, after)
+		}
+	})
+
+	t.Run("closed and missing fail", func(t *testing.T) {
+		st, cleanup := newTestStore(t)
+		defer cleanup()
+
+		ctx := context.Background()
+		project, err := st.CreateProject(ctx, "lifecycle-activate-invalid")
+		if err != nil {
+			t.Fatalf("CreateProject: %v", err)
+		}
+		now := time.Now().UTC()
+		sp := createLifecycleSprint(t, st, project.ID, "Closed", now.Add(-time.Hour), now.Add(24*time.Hour))
+		if err := st.ActivateSprint(ctx, project.ID, sp.ID); err != nil {
+			t.Fatalf("ActivateSprint setup: %v", err)
+		}
+		if err := st.CloseSprint(ctx, sp.ID); err != nil {
+			t.Fatalf("CloseSprint setup: %v", err)
+		}
+
+		err = st.ActivateSprint(ctx, project.ID, sp.ID)
+		if !errors.Is(err, ErrValidation) || !strings.Contains(err.Error(), "must be PLANNED") {
+			t.Fatalf("closed ActivateSprint error=%v, want planned-state validation", err)
+		}
+		if err := st.ActivateSprint(ctx, project.ID, sp.ID+100000); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("missing ActivateSprint error=%v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("foreign project is validation and leaves target unchanged", func(t *testing.T) {
+		st, cleanup := newTestStore(t)
+		defer cleanup()
+
+		ctx := context.Background()
+		projectA, err := st.CreateProject(ctx, "lifecycle-activate-project-a")
+		if err != nil {
+			t.Fatalf("CreateProject A: %v", err)
+		}
+		projectB, err := st.CreateProject(ctx, "lifecycle-activate-project-b")
+		if err != nil {
+			t.Fatalf("CreateProject B: %v", err)
+		}
+		now := time.Now().UTC()
+		sp := createLifecycleSprint(t, st, projectB.ID, "Foreign", now.Add(-time.Hour), now.Add(24*time.Hour))
+
+		err = st.ActivateSprint(ctx, projectA.ID, sp.ID)
+		if !errors.Is(err, ErrValidation) || !strings.Contains(err.Error(), "does not belong to project") {
+			t.Fatalf("foreign ActivateSprint error=%v, want project validation", err)
+		}
+		assertLifecycleState(t, st, sp.ID, SprintStatePlanned)
+	})
+}
+
+func TestSprintLifecycleStoreActivateReplacesCurrentAtomically(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	project, err := st.CreateProject(ctx, "lifecycle-activate-replace")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	otherProject, err := st.CreateProject(ctx, "lifecycle-activate-other")
+	if err != nil {
+		t.Fatalf("CreateProject other: %v", err)
+	}
+	now := time.Now().UTC()
+	active := createLifecycleSprint(t, st, project.ID, "Current", now.Add(-time.Hour), now.Add(48*time.Hour))
+	target := createLifecycleSprint(t, st, project.ID, "Target", now.Add(-time.Hour), now.Add(72*time.Hour))
+	other := createLifecycleSprint(t, st, otherProject.ID, "Other active", now.Add(-time.Hour), now.Add(48*time.Hour))
+	if err := st.ActivateSprint(ctx, project.ID, active.ID); err != nil {
+		t.Fatalf("ActivateSprint current: %v", err)
+	}
+	if err := st.ActivateSprint(ctx, otherProject.ID, other.ID); err != nil {
+		t.Fatalf("ActivateSprint other: %v", err)
+	}
+	activeBefore := getLifecycleSprint(t, st, active.ID)
+
+	if err := st.ActivateSprint(ctx, project.ID, target.ID); err != nil {
+		t.Fatalf("ActivateSprint target: %v", err)
+	}
+	activeAfter := assertLifecycleState(t, st, active.ID, SprintStateClosed)
+	targetAfter := assertLifecycleState(t, st, target.ID, SprintStateActive)
+	otherAfter := assertLifecycleState(t, st, other.ID, SprintStateActive)
+	if activeAfter.StartedAt == nil || activeBefore.StartedAt == nil || !activeAfter.StartedAt.Equal(*activeBefore.StartedAt) {
+		t.Fatalf("previous start timestamp changed before=%v after=%v", activeBefore.StartedAt, activeAfter.StartedAt)
+	}
+	if activeAfter.ClosedAt == nil || targetAfter.StartedAt == nil || !activeAfter.ClosedAt.Equal(*targetAfter.StartedAt) {
+		t.Fatalf("replacement timestamps closed=%v started=%v, want equal transaction time", activeAfter.ClosedAt, targetAfter.StartedAt)
+	}
+	if otherAfter.ClosedAt != nil {
+		t.Fatalf("other project active sprint was closed: %+v", otherAfter)
+	}
+	gotActive, err := st.GetActiveSprintByProjectID(ctx, project.ID)
+	if err != nil {
+		t.Fatalf("GetActiveSprintByProjectID: %v", err)
+	}
+	if gotActive == nil || gotActive.ID != target.ID {
+		t.Fatalf("active sprint=%+v, want target %d", gotActive, target.ID)
+	}
+}
+
+func TestSprintLifecycleStoreActivateRollbackRestoresPriorActive(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	project, err := st.CreateProject(ctx, "lifecycle-activate-rollback")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	now := time.Now().UTC()
+	active := createLifecycleSprint(t, st, project.ID, "Current", now.Add(-time.Hour), now.Add(48*time.Hour))
+	target := createLifecycleSprint(t, st, project.ID, "Target", now.Add(-time.Hour), now.Add(72*time.Hour))
+	if err := st.ActivateSprint(ctx, project.ID, active.ID); err != nil {
+		t.Fatalf("ActivateSprint current: %v", err)
+	}
+	activeBefore := getLifecycleSprint(t, st, active.ID)
+
+	const triggerName = "sprint_lifecycle_abort_target_activation"
+	const triggerMarker = "checkpoint-one-target-activation-abort"
+	triggerSQL := fmt.Sprintf(`
+		CREATE TRIGGER %s
+		BEFORE UPDATE OF state ON sprints
+		WHEN OLD.id = %d
+		 AND OLD.state = '%s'
+		 AND NEW.state = '%s'
+		BEGIN
+			SELECT RAISE(ABORT, '%s');
+		END
+	`, triggerName, target.ID, SprintStatePlanned, SprintStateActive, triggerMarker)
+	if _, err := st.db.ExecContext(ctx, triggerSQL); err != nil {
+		t.Fatalf("create activation fault trigger: %v", err)
+	}
+
+	err = st.ActivateSprint(ctx, project.ID, target.ID)
+	if err == nil || !strings.Contains(err.Error(), triggerMarker) {
+		t.Fatalf("ActivateSprint error=%v, want trigger marker %q", err, triggerMarker)
+	}
+	activeAfter := assertLifecycleState(t, st, active.ID, SprintStateActive)
+	targetAfter := assertLifecycleState(t, st, target.ID, SprintStatePlanned)
+	if activeAfter.ClosedAt != nil || activeAfter.StartedAt == nil || activeBefore.StartedAt == nil || !activeAfter.StartedAt.Equal(*activeBefore.StartedAt) {
+		t.Fatalf("prior active was partially changed before=%+v after=%+v", activeBefore, activeAfter)
+	}
+	if targetAfter.StartedAt != nil || targetAfter.ClosedAt != nil {
+		t.Fatalf("target was partially changed: %+v", targetAfter)
+	}
+
+	if _, err := st.db.ExecContext(ctx, `DROP TRIGGER `+triggerName); err != nil {
+		t.Fatalf("drop activation fault trigger: %v", err)
+	}
+	if err := st.ActivateSprint(ctx, project.ID, target.ID); err != nil {
+		t.Fatalf("ActivateSprint after trigger removal: %v", err)
+	}
+	assertLifecycleState(t, st, active.ID, SprintStateClosed)
+	assertLifecycleState(t, st, target.ID, SprintStateActive)
+}
+
+func TestSprintLifecycleStoreCloseCurrentContract(t *testing.T) {
+	t.Run("active closes and repeat is not found", func(t *testing.T) {
+		st, cleanup := newTestStore(t)
+		defer cleanup()
+		ctx := context.Background()
+		project, err := st.CreateProject(ctx, "lifecycle-close-active")
+		if err != nil {
+			t.Fatalf("CreateProject: %v", err)
+		}
+		now := time.Now().UTC()
+		sp := createLifecycleSprint(t, st, project.ID, "Active", now.Add(-time.Hour), now.Add(24*time.Hour))
+		if err := st.ActivateSprint(ctx, project.ID, sp.ID); err != nil {
+			t.Fatalf("ActivateSprint: %v", err)
+		}
+		before := getLifecycleSprint(t, st, sp.ID)
+
+		if err := st.CloseSprint(ctx, sp.ID); err != nil {
+			t.Fatalf("CloseSprint: %v", err)
+		}
+		after := assertLifecycleState(t, st, sp.ID, SprintStateClosed)
+		if after.ClosedAt == nil || after.StartedAt == nil || before.StartedAt == nil || !after.StartedAt.Equal(*before.StartedAt) {
+			t.Fatalf("closed sprint timestamps before=%+v after=%+v", before, after)
+		}
+		if err := st.CloseSprint(ctx, sp.ID); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("repeat CloseSprint error=%v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("planned and missing are not found", func(t *testing.T) {
+		st, cleanup := newTestStore(t)
+		defer cleanup()
+		ctx := context.Background()
+		project, err := st.CreateProject(ctx, "lifecycle-close-invalid")
+		if err != nil {
+			t.Fatalf("CreateProject: %v", err)
+		}
+		now := time.Now().UTC()
+		sp := createLifecycleSprint(t, st, project.ID, "Planned", now.Add(-time.Hour), now.Add(24*time.Hour))
+
+		if err := st.CloseSprint(ctx, sp.ID); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("planned CloseSprint error=%v, want ErrNotFound", err)
+		}
+		if err := st.CloseSprint(ctx, sp.ID+100000); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("missing CloseSprint error=%v, want ErrNotFound", err)
+		}
+		assertLifecycleState(t, st, sp.ID, SprintStatePlanned)
+	})
+
+	t.Run("global row id closes another project without project input", func(t *testing.T) {
+		st, cleanup := newTestStore(t)
+		defer cleanup()
+		ctx := context.Background()
+		projectA, err := st.CreateProject(ctx, "lifecycle-close-global-a")
+		if err != nil {
+			t.Fatalf("CreateProject A: %v", err)
+		}
+		projectB, err := st.CreateProject(ctx, "lifecycle-close-global-b")
+		if err != nil {
+			t.Fatalf("CreateProject B: %v", err)
+		}
+		if projectA.ID == projectB.ID {
+			t.Fatal("fixture project IDs unexpectedly equal")
+		}
+		now := time.Now().UTC()
+		sp := createLifecycleSprint(t, st, projectB.ID, "Foreign active", now.Add(-time.Hour), now.Add(24*time.Hour))
+		if err := st.ActivateSprint(ctx, projectB.ID, sp.ID); err != nil {
+			t.Fatalf("ActivateSprint B: %v", err)
+		}
+
+		if err := st.CloseSprint(ctx, sp.ID); err != nil {
+			t.Fatalf("CloseSprint(global B id): %v", err)
+		}
+		assertLifecycleState(t, st, sp.ID, SprintStateClosed)
+	})
+}
+
+func TestSprintLifecycleStoreDeleteContract(t *testing.T) {
+	for _, state := range []string{SprintStatePlanned, SprintStateActive, SprintStateClosed} {
+		state := state
+		t.Run(strings.ToLower(state), func(t *testing.T) {
+			st, cleanup := newTestStore(t)
+			defer cleanup()
+			ctx := context.Background()
+			project, err := st.CreateProject(ctx, "lifecycle-delete-"+strings.ToLower(state))
+			if err != nil {
+				t.Fatalf("CreateProject: %v", err)
+			}
+			now := time.Now().UTC()
+			sp := createLifecycleSprint(t, st, project.ID, state, now.Add(-time.Hour), now.Add(24*time.Hour))
+			if state != SprintStatePlanned {
+				if err := st.ActivateSprint(ctx, project.ID, sp.ID); err != nil {
+					t.Fatalf("ActivateSprint setup: %v", err)
+				}
+			}
+			if state == SprintStateClosed {
+				if err := st.CloseSprint(ctx, sp.ID); err != nil {
+					t.Fatalf("CloseSprint setup: %v", err)
+				}
+			}
+
+			if err := st.DeleteSprint(ctx, project.ID, sp.ID); err != nil {
+				t.Fatalf("DeleteSprint(%s): %v", state, err)
+			}
+			if _, err := st.GetSprintByID(ctx, sp.ID); !errors.Is(err, ErrNotFound) {
+				t.Fatalf("GetSprintByID after delete error=%v, want ErrNotFound", err)
+			}
+			active, err := st.GetActiveSprintByProjectID(ctx, project.ID)
+			if err != nil {
+				t.Fatalf("GetActiveSprintByProjectID: %v", err)
+			}
+			if active != nil {
+				t.Fatalf("active sprint after %s delete=%+v, want nil", state, active)
+			}
+		})
+	}
+
+	t.Run("foreign and missing preserve target", func(t *testing.T) {
+		st, cleanup := newTestStore(t)
+		defer cleanup()
+		ctx := context.Background()
+		projectA, err := st.CreateProject(ctx, "lifecycle-delete-project-a")
+		if err != nil {
+			t.Fatalf("CreateProject A: %v", err)
+		}
+		projectB, err := st.CreateProject(ctx, "lifecycle-delete-project-b")
+		if err != nil {
+			t.Fatalf("CreateProject B: %v", err)
+		}
+		now := time.Now().UTC()
+		sp := createLifecycleSprint(t, st, projectB.ID, "Foreign", now.Add(-time.Hour), now.Add(24*time.Hour))
+
+		if err := st.DeleteSprint(ctx, projectA.ID, sp.ID); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("foreign DeleteSprint error=%v, want ErrNotFound", err)
+		}
+		assertLifecycleState(t, st, sp.ID, SprintStatePlanned)
+		if err := st.DeleteSprint(ctx, projectA.ID, sp.ID+100000); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("missing DeleteSprint error=%v, want ErrNotFound", err)
+		}
+	})
+}
+
+func TestSprintLifecycleStoreDeleteDetachesTodos(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	project, err := st.CreateProject(ctx, "lifecycle-delete-detach")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	now := time.Now().UTC()
+	target := createLifecycleSprint(t, st, project.ID, "Target", now.Add(-time.Hour), now.Add(24*time.Hour))
+	controlSprint := createLifecycleSprint(t, st, project.ID, "Control", now.Add(-time.Hour), now.Add(48*time.Hour))
+	points := int64(5)
+	assignedOne, err := st.CreateTodo(ctx, project.ID, CreateTodoInput{
+		Title: "Assigned one", Body: "body one", Tags: []string{"phase20"}, ColumnKey: DefaultColumnBacklog,
+		EstimationPoints: &points, SprintID: &target.ID,
+	}, ModeFull)
+	if err != nil {
+		t.Fatalf("CreateTodo assigned one: %v", err)
+	}
+	assignedTwo, err := st.CreateTodo(ctx, project.ID, CreateTodoInput{
+		Title: "Assigned two", Body: "body two", ColumnKey: DefaultColumnDoing, SprintID: &target.ID,
+	}, ModeFull)
+	if err != nil {
+		t.Fatalf("CreateTodo assigned two: %v", err)
+	}
+	controlAssigned, err := st.CreateTodo(ctx, project.ID, CreateTodoInput{
+		Title: "Control assigned", ColumnKey: DefaultColumnBacklog, SprintID: &controlSprint.ID,
+	}, ModeFull)
+	if err != nil {
+		t.Fatalf("CreateTodo control assigned: %v", err)
+	}
+	backlog, err := st.CreateTodo(ctx, project.ID, CreateTodoInput{
+		Title: "Backlog", ColumnKey: DefaultColumnBacklog,
+	}, ModeFull)
+	if err != nil {
+		t.Fatalf("CreateTodo backlog: %v", err)
+	}
+
+	if err := st.DeleteSprint(ctx, project.ID, target.ID); err != nil {
+		t.Fatalf("DeleteSprint: %v", err)
+	}
+
+	for _, before := range []Todo{assignedOne, assignedTwo} {
+		after, err := st.GetTodoByLocalID(ctx, project.ID, before.LocalID, ModeFull)
+		if err != nil {
+			t.Fatalf("GetTodoByLocalID(%d): %v", before.LocalID, err)
+		}
+		if after.SprintID != nil {
+			t.Fatalf("todo %d SprintID=%v, want nil after delete", before.LocalID, after.SprintID)
+		}
+		if after.ID != before.ID || after.ProjectID != before.ProjectID || after.LocalID != before.LocalID || after.Title != before.Title || after.Body != before.Body || after.ColumnKey != before.ColumnKey || after.Rank != before.Rank {
+			t.Fatalf("todo changed beyond sprint detachment before=%+v after=%+v", before, after)
+		}
+	}
+	afterControl, err := st.GetTodoByLocalID(ctx, project.ID, controlAssigned.LocalID, ModeFull)
+	if err != nil {
+		t.Fatalf("GetTodoByLocalID control: %v", err)
+	}
+	if afterControl.SprintID == nil || *afterControl.SprintID != controlSprint.ID {
+		t.Fatalf("control todo SprintID=%v, want %d", afterControl.SprintID, controlSprint.ID)
+	}
+	afterBacklog, err := st.GetTodoByLocalID(ctx, project.ID, backlog.LocalID, ModeFull)
+	if err != nil {
+		t.Fatalf("GetTodoByLocalID backlog: %v", err)
+	}
+	if afterBacklog.SprintID != nil {
+		t.Fatalf("backlog SprintID=%v, want nil", afterBacklog.SprintID)
+	}
+}
+
+func TestSprintLifecycleStoreCanceledActivationDoesNotPartiallyTransition(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	project, err := st.CreateProject(ctx, "lifecycle-canceled-activate")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	now := time.Now().UTC()
+	active := createLifecycleSprint(t, st, project.ID, "Current", now.Add(-time.Hour), now.Add(24*time.Hour))
+	target := createLifecycleSprint(t, st, project.ID, "Target", now.Add(-time.Hour), now.Add(48*time.Hour))
+	if err := st.ActivateSprint(ctx, project.ID, active.ID); err != nil {
+		t.Fatalf("ActivateSprint current: %v", err)
+	}
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = st.ActivateSprint(canceled, project.ID, target.ID)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("ActivateSprint canceled error=%v, want context.Canceled", err)
+	}
+	assertLifecycleState(t, st, active.ID, SprintStateActive)
+	assertLifecycleState(t, st, target.ID, SprintStatePlanned)
+}

--- a/internal/store/sprints.go
+++ b/internal/store/sprints.go
@@ -394,13 +394,13 @@ func (s *Store) ActivateSprint(ctx context.Context, projectID, sprintID int64) e
 	return tx.Commit()
 }
 
-func (s *Store) CloseSprint(ctx context.Context, sprintID int64) error {
+func (s *Store) CloseSprint(ctx context.Context, projectID, sprintID int64) error {
 	nowMs := time.Now().UTC().UnixMilli()
 	res, err := s.db.ExecContext(ctx, `
 		UPDATE sprints
 		SET state = ?, closed_at = COALESCE(closed_at, ?), updated_at = ?
-		WHERE id = ? AND state = ?
-	`, SprintStateClosed, nowMs, nowMs, sprintID, SprintStateActive)
+		WHERE id = ? AND project_id = ? AND state = ?
+	`, SprintStateClosed, nowMs, nowMs, sprintID, projectID, SprintStateActive)
 	if err != nil {
 		return fmt.Errorf("close sprint: %w", err)
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.29.7"
+const Version = "3.29.8"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
- add prepared application services with narrow capability boundaries for REST and MCP sprint creation, updates, lifecycle transitions, and deletion.
- Preserve existing validation, authorization, response, event-publication, and compatibility contracts.
- Fix cross-project sprint closure by scoping mutations to both project and sprint identity.
- Add comprehensive application, store, REST, and MCP contract coverage.