### PR TITLE
Use yellow for the default Low priority tier color

### DIFF
--- a/internal/store/priorities.go
+++ b/internal/store/priorities.go
@@ -76,7 +76,7 @@ func priorityTierCountReason(count int) string {
 
 func defaultPriorityTiers() []PriorityTier {
 	return []PriorityTier{
-		{Key: "low", Name: "Low", Color: "#9CA3AF", Position: 0},
+		{Key: "low", Name: "Low", Color: "#EAB308", Position: 0},
 		{Key: "medium", Name: "Medium", Color: "#F59E0B", Position: 1},
 		{Key: "high", Name: "High", Color: "#F97316", Position: 2},
 		{Key: "urgent", Name: "Urgent", Color: "#EF4444", Position: 3},


### PR DESCRIPTION
## Summary
- Closes most of #226 (UI: priority pill/icon on cards) — the pill is already rendered on cards with per-tier colors (added in #216), and medium/high/urgent already use amber/orange/red as requested there. This just fixes the last mismatch: the seeded default `low` tier was still generic gray (`#9CA3AF`) instead of yellow.
- New default: `low` → `#EAB308` (yellow), matching the red/orange/amber/yellow scale from the issue.
- Confirmed the pill is a plain non-interactive `<span>` (matches the "shouldn't be clickable" conclusion in the issue thread) and that mobile card layout (`.card__badges` grid placement) already handles the badge without overflow — no CSS changes needed there.
- Only affects the *default* seed for newly-created projects; existing projects that already have a `low` tier keep whatever color they have (including any prior custom edits), since project owners can always recolor tiers in Settings → Priorities.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1 -timeout=5m` (full suite green)
- [x] Confirmed no test hardcodes the previous default `#9CA3AF` for a freshly-seeded project (the one match in `priorities_concurrency_test.go` is an unrelated import-fixture color)

Closes #226