### PR TITLE
Refactor/21 todo deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.31.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags), **3.29.0** (MCP JSON-RPC error/`board_get` identity), **3.30.0** (reversible per-project sprint capability), **3.31.0** (per-project priority tiers) - see those releases.
 
+## [3.31.2] - 2026-08-12
+
+### Changed
+
+- **Todo deletions move behind application services** - REST and MCP todo
+  deletions now share `internal/application/todo` command boundaries instead of
+  owning write logic in the transports. HTTP and MCP adapters stay thin
+  wrappers; permissions, validation, response shapes, and REST board-refresh
+  side effects are preserved (MCP remains realtime-silent). Contract tests lock
+  the migrated deletion paths.
+
 ## [3.31.1] - 2026-08-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.31.1-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.31.2-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/internal/application/todo/delete.go
+++ b/internal/application/todo/delete.go
@@ -1,0 +1,27 @@
+package todo
+
+import (
+	"context"
+
+	"scrumboy/internal/store"
+)
+
+const RefreshReasonTodoDeleted = "todo_deleted"
+
+// DeleteCommand identifies a todo by its project-local ID within the project
+// already bound by a prepared deletion service.
+type DeleteCommand struct {
+	LocalID int64
+}
+
+// DeleteStore is the persistence capability required to delete a todo
+// addressed by its project-local identifier. Authorization, audit, related
+// data cleanup, project touch, and board activity remain store-owned.
+type DeleteStore interface {
+	DeleteTodoByLocalID(
+		ctx context.Context,
+		projectID int64,
+		localID int64,
+		mode store.Mode,
+	) error
+}

--- a/internal/application/todo/mcp_delete.go
+++ b/internal/application/todo/mcp_delete.go
@@ -1,0 +1,73 @@
+package todo
+
+import (
+	"context"
+
+	"scrumboy/internal/store"
+)
+
+// MCPDeleteAccessStore resolves the project slug access boundary before an
+// MCP deletion may use its project-local todo identity.
+type MCPDeleteAccessStore interface {
+	GetProjectContextBySlug(ctx context.Context, slug string, mode store.Mode) (store.ProjectContext, error)
+}
+
+type MCPDeleteServiceDependencies struct {
+	Access MCPDeleteAccessStore
+	Delete DeleteStore
+}
+
+// MCPDeleteService owns slug access followed by local-ID deletion. It has no
+// refresh dependency, preserving MCP deletion's realtime silence.
+type MCPDeleteService struct {
+	access MCPDeleteAccessStore
+	delete DeleteStore
+}
+
+func NewMCPDeleteService(deps MCPDeleteServiceDependencies) *MCPDeleteService {
+	return &MCPDeleteService{
+		access: deps.Access,
+		delete: deps.Delete,
+	}
+}
+
+// SlugDeleteTarget identifies the project slug whose access must be resolved
+// before deletion. The todo local ID remains part of DeleteCommand.
+type SlugDeleteTarget struct {
+	Slug string
+	Mode store.Mode
+}
+
+// PreparedMCPDelete binds the access context and value copies of the resolved
+// project context and mode to deletion execution.
+type PreparedMCPDelete struct {
+	ctx            context.Context
+	service        *MCPDeleteService
+	projectContext store.ProjectContext
+	mode           store.Mode
+}
+
+func (s *MCPDeleteService) Prepare(ctx context.Context, target SlugDeleteTarget) (*PreparedMCPDelete, error) {
+	projectContext, err := s.access.GetProjectContextBySlug(ctx, target.Slug, target.Mode)
+	if err != nil {
+		return nil, err
+	}
+	return &PreparedMCPDelete{
+		ctx:            ctx,
+		service:        s,
+		projectContext: projectContext,
+		mode:           target.Mode,
+	}, nil
+}
+
+// Delete performs exactly one local-ID deletion using the prepared project.
+// Store errors pass through unchanged and no projection or realtime event is
+// produced by this service.
+func (d *PreparedMCPDelete) Delete(command DeleteCommand) error {
+	return d.service.delete.DeleteTodoByLocalID(
+		d.ctx,
+		d.projectContext.Project.ID,
+		command.LocalID,
+		d.mode,
+	)
+}

--- a/internal/application/todo/mcp_delete_test.go
+++ b/internal/application/todo/mcp_delete_test.go
@@ -1,0 +1,223 @@
+package todo
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+var (
+	_ MCPDeleteAccessStore = (*store.Store)(nil)
+	_ DeleteStore          = (*store.Store)(nil)
+)
+
+type mcpDeleteAccessCall struct {
+	ctx  context.Context
+	slug string
+	mode store.Mode
+}
+
+type mcpDeleteAccessFake struct {
+	calls          []mcpDeleteAccessCall
+	projectContext store.ProjectContext
+	err            error
+	trace          *[]string
+}
+
+func (f *mcpDeleteAccessFake) GetProjectContextBySlug(ctx context.Context, slug string, mode store.Mode) (store.ProjectContext, error) {
+	f.calls = append(f.calls, mcpDeleteAccessCall{ctx: ctx, slug: slug, mode: mode})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "access")
+	}
+	if f.err != nil {
+		return store.ProjectContext{}, f.err
+	}
+	if err := ctx.Err(); err != nil {
+		return store.ProjectContext{}, err
+	}
+	return f.projectContext, nil
+}
+
+type mcpDeleteStoreCall struct {
+	ctx       context.Context
+	projectID int64
+	localID   int64
+	mode      store.Mode
+}
+
+type mcpDeleteStoreFake struct {
+	calls []mcpDeleteStoreCall
+	err   error
+	trace *[]string
+}
+
+func (f *mcpDeleteStoreFake) DeleteTodoByLocalID(
+	ctx context.Context,
+	projectID int64,
+	localID int64,
+	mode store.Mode,
+) error {
+	f.calls = append(f.calls, mcpDeleteStoreCall{
+		ctx:       ctx,
+		projectID: projectID,
+		localID:   localID,
+		mode:      mode,
+	})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "delete")
+	}
+	if f.err != nil {
+		return f.err
+	}
+	return ctx.Err()
+}
+
+func TestMCPDeleteServicePrepareBindsAccessTargetAndDeletesResolvedTodo(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx := context.WithValue(context.Background(), key, "bound")
+	trace := []string{}
+	access := &mcpDeleteAccessFake{
+		projectContext: store.ProjectContext{
+			Project: store.Project{ID: 7, Slug: "canonical"},
+			Role:    store.RoleMaintainer,
+		},
+		trace: &trace,
+	}
+	deletes := &mcpDeleteStoreFake{trace: &trace}
+	service := NewMCPDeleteService(MCPDeleteServiceDependencies{Access: access, Delete: deletes})
+	target := SlugDeleteTarget{Slug: "requested", Mode: store.ModeFull}
+
+	prepared, err := service.Prepare(ctx, target)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if prepared == nil {
+		t.Fatal("Prepare returned nil capability")
+	}
+	if len(access.calls) != 1 {
+		t.Fatalf("access calls = %d, want 1", len(access.calls))
+	}
+	accessCall := access.calls[0]
+	if accessCall.ctx != ctx || accessCall.ctx.Value(key) != "bound" || accessCall.slug != "requested" || accessCall.mode != store.ModeFull {
+		t.Fatalf("access call = %+v, want bound context, requested slug, full mode", accessCall)
+	}
+	if len(deletes.calls) != 0 {
+		t.Fatalf("delete calls during preparation = %d, want 0", len(deletes.calls))
+	}
+
+	access.projectContext.Project.ID = 99
+	access.projectContext.Project.Slug = "mutated"
+	access.projectContext.Role = store.RoleViewer
+	target.Slug = "mutated"
+	target.Mode = store.ModeAnonymous
+
+	if err := prepared.Delete(DeleteCommand{LocalID: 4}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if prepared.projectContext.Project.Slug != "canonical" || prepared.projectContext.Role != store.RoleMaintainer {
+		t.Fatalf("prepared project context changed after source mutation: %+v", prepared.projectContext)
+	}
+	if len(deletes.calls) != 1 {
+		t.Fatalf("delete calls = %d, want 1", len(deletes.calls))
+	}
+	deleteCall := deletes.calls[0]
+	if deleteCall.ctx != ctx || deleteCall.ctx.Value(key) != "bound" || deleteCall.projectID != 7 || deleteCall.localID != 4 || deleteCall.mode != store.ModeFull {
+		t.Fatalf("delete call = %+v, want bound context, project 7, local 4, full mode", deleteCall)
+	}
+	if !reflect.DeepEqual(trace, []string{"access", "delete"}) {
+		t.Fatalf("call trace = %#v, want access then delete", trace)
+	}
+}
+
+func TestMCPDeleteServiceAccessFailureReturnsNoCapabilityOrPersistence(t *testing.T) {
+	wantErr := errors.New("access failed")
+	trace := []string{}
+	access := &mcpDeleteAccessFake{err: wantErr, trace: &trace}
+	deletes := &mcpDeleteStoreFake{trace: &trace}
+	service := NewMCPDeleteService(MCPDeleteServiceDependencies{Access: access, Delete: deletes})
+
+	prepared, err := service.Prepare(context.Background(), SlugDeleteTarget{Slug: "hidden", Mode: store.ModeFull})
+	if err != wantErr {
+		t.Fatalf("Prepare error = %v, want identical error %v", err, wantErr)
+	}
+	if prepared != nil {
+		t.Fatalf("prepared capability = %+v, want nil", prepared)
+	}
+	if len(access.calls) != 1 || len(deletes.calls) != 0 {
+		t.Fatalf("calls after access failure: access=%d delete=%d, want 1/0", len(access.calls), len(deletes.calls))
+	}
+	if !reflect.DeepEqual(trace, []string{"access"}) {
+		t.Fatalf("call trace = %#v, want access only", trace)
+	}
+}
+
+func TestPreparedMCPDeleteStoreFailureReturnsSameErrorWithoutRetry(t *testing.T) {
+	wantErr := errors.New("delete failed")
+	access := &mcpDeleteAccessFake{projectContext: store.ProjectContext{Project: store.Project{ID: 7}}}
+	deletes := &mcpDeleteStoreFake{err: wantErr}
+	prepared, err := NewMCPDeleteService(MCPDeleteServiceDependencies{Access: access, Delete: deletes}).Prepare(
+		context.Background(),
+		SlugDeleteTarget{Slug: "requested", Mode: store.ModeFull},
+	)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	err = prepared.Delete(DeleteCommand{LocalID: 4})
+	if err != wantErr {
+		t.Fatalf("Delete error = %v, want identical error %v", err, wantErr)
+	}
+	if len(deletes.calls) != 1 {
+		t.Fatalf("delete calls = %d, want 1", len(deletes.calls))
+	}
+}
+
+func TestMCPDeleteServiceCancellationAfterPreparationUsesBoundContext(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), key, "bound"))
+	access := &mcpDeleteAccessFake{projectContext: store.ProjectContext{Project: store.Project{ID: 7}}}
+	deletes := &mcpDeleteStoreFake{}
+	prepared, err := NewMCPDeleteService(MCPDeleteServiceDependencies{Access: access, Delete: deletes}).Prepare(
+		ctx,
+		SlugDeleteTarget{Slug: "requested", Mode: store.ModeFull},
+	)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	cancel()
+
+	err = prepared.Delete(DeleteCommand{LocalID: 4})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Delete error = %v, want context canceled", err)
+	}
+	if len(deletes.calls) != 1 {
+		t.Fatalf("delete calls = %d, want 1", len(deletes.calls))
+	}
+	if got := deletes.calls[0].ctx; got != ctx || got.Value(key) != "bound" || !errors.Is(got.Err(), context.Canceled) {
+		t.Fatalf("delete context = %v, want bound cancelled context", got)
+	}
+}
+
+func TestPreparedMCPDeleteForwardsUnvalidatedLocalID(t *testing.T) {
+	access := &mcpDeleteAccessFake{projectContext: store.ProjectContext{Project: store.Project{ID: 7}}}
+	deletes := &mcpDeleteStoreFake{}
+	prepared, err := NewMCPDeleteService(MCPDeleteServiceDependencies{Access: access, Delete: deletes}).Prepare(
+		context.Background(),
+		SlugDeleteTarget{Slug: "requested", Mode: store.ModeFull},
+	)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	if err := prepared.Delete(DeleteCommand{LocalID: 0}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(deletes.calls) != 1 || deletes.calls[0].localID != 0 {
+		t.Fatalf("delete calls = %+v, want one call with local ID 0", deletes.calls)
+	}
+}

--- a/internal/application/todo/rest_delete.go
+++ b/internal/application/todo/rest_delete.go
@@ -1,0 +1,76 @@
+package todo
+
+import (
+	"context"
+
+	"scrumboy/internal/store"
+)
+
+// DeleteServiceDependencies names the persistence and ancillary capabilities
+// used by the canonical REST delete use case.
+type DeleteServiceDependencies struct {
+	Delete  DeleteStore
+	Refresh BoardRefreshPublisher
+}
+
+// DeleteService owns REST delete persistence and post-commit refresh
+// sequencing. Slug access and local-ID validation remain in the REST adapter,
+// while deletion authorization remains in the store.
+type DeleteService struct {
+	delete  DeleteStore
+	refresh BoardRefreshPublisher
+}
+
+func NewDeleteService(deps DeleteServiceDependencies) *DeleteService {
+	refresh := deps.Refresh
+	if refresh == nil {
+		refresh = nopBoardRefreshPublisher{}
+	}
+	return &DeleteService{delete: deps.Delete, refresh: refresh}
+}
+
+// ResolvedDeleteTarget carries the project context already authorized by the
+// shared REST board router. Preparation intentionally performs no lookup or
+// authorization.
+type ResolvedDeleteTarget struct {
+	ProjectContext store.ProjectContext
+	Mode           store.Mode
+}
+
+// PreparedDelete binds the request context and value copies of the authorized
+// project context and mode to the subsequent deletion.
+type PreparedDelete struct {
+	ctx            context.Context
+	service        *DeleteService
+	projectContext store.ProjectContext
+	mode           store.Mode
+}
+
+// Prepare binds an already-resolved REST board target without performing
+// persistence or repeating route-owned access resolution.
+func (s *DeleteService) Prepare(ctx context.Context, target ResolvedDeleteTarget) *PreparedDelete {
+	return &PreparedDelete{
+		ctx:            ctx,
+		service:        s,
+		projectContext: target.ProjectContext,
+		mode:           target.Mode,
+	}
+}
+
+// Delete performs exactly one local-ID deletion and publishes one best-effort
+// REST refresh only after persistence succeeds. No post-delete projection is
+// needed by either the application or transport contract.
+func (d *PreparedDelete) Delete(command DeleteCommand) error {
+	project := d.projectContext.Project
+	if err := d.service.delete.DeleteTodoByLocalID(
+		d.ctx,
+		project.ID,
+		command.LocalID,
+		d.mode,
+	); err != nil {
+		return err
+	}
+
+	d.service.refresh.PublishBoardRefresh(d.ctx, project.ID, RefreshReasonTodoDeleted)
+	return nil
+}

--- a/internal/application/todo/rest_delete_test.go
+++ b/internal/application/todo/rest_delete_test.go
@@ -1,0 +1,183 @@
+package todo
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+type restDeleteStoreCall struct {
+	ctx       context.Context
+	projectID int64
+	localID   int64
+	mode      store.Mode
+}
+
+type restDeleteStoreFake struct {
+	calls []restDeleteStoreCall
+	err   error
+	trace *[]string
+}
+
+func (f *restDeleteStoreFake) DeleteTodoByLocalID(
+	ctx context.Context,
+	projectID int64,
+	localID int64,
+	mode store.Mode,
+) error {
+	f.calls = append(f.calls, restDeleteStoreCall{
+		ctx:       ctx,
+		projectID: projectID,
+		localID:   localID,
+		mode:      mode,
+	})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "delete")
+	}
+	if f.err != nil {
+		return f.err
+	}
+	return ctx.Err()
+}
+
+type restDeleteRefreshCall struct {
+	ctx       context.Context
+	projectID int64
+	reason    string
+}
+
+type restDeleteRefreshFake struct {
+	calls []restDeleteRefreshCall
+	trace *[]string
+}
+
+func (f *restDeleteRefreshFake) PublishBoardRefresh(ctx context.Context, projectID int64, reason string) {
+	f.calls = append(f.calls, restDeleteRefreshCall{ctx: ctx, projectID: projectID, reason: reason})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "refresh")
+	}
+}
+
+func TestDeleteServicePreparedDeleteBindsTargetAndPublishesOnce(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx := context.WithValue(context.Background(), key, "bound")
+
+	trace := []string{}
+	deletes := &restDeleteStoreFake{trace: &trace}
+	refresh := &restDeleteRefreshFake{trace: &trace}
+	service := NewDeleteService(DeleteServiceDependencies{Delete: deletes, Refresh: refresh})
+	target := ResolvedDeleteTarget{
+		ProjectContext: store.ProjectContext{
+			Project: store.Project{ID: 7, Slug: "canonical"},
+			Role:    store.RoleMaintainer,
+		},
+		Mode: store.ModeFull,
+	}
+	prepared := service.Prepare(ctx, target)
+
+	// PreparedDelete owns value copies of the resolved target and mode.
+	target.ProjectContext.Project.ID = 99
+	target.ProjectContext.Project.Slug = "mutated"
+	target.ProjectContext.Role = store.RoleViewer
+	target.Mode = store.ModeAnonymous
+
+	if err := prepared.Delete(DeleteCommand{LocalID: 4}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if prepared.projectContext.Project.Slug != "canonical" || prepared.projectContext.Role != store.RoleMaintainer {
+		t.Fatalf("prepared project context = %+v, want original slug and role", prepared.projectContext)
+	}
+	if len(deletes.calls) != 1 {
+		t.Fatalf("delete calls = %d, want 1", len(deletes.calls))
+	}
+	call := deletes.calls[0]
+	if call.ctx != ctx || call.ctx.Value(key) != "bound" {
+		t.Fatalf("delete context = %v, want prepared context", call.ctx)
+	}
+	if call.projectID != 7 || call.localID != 4 || call.mode != store.ModeFull {
+		t.Fatalf("delete call = %+v, want project 7 local 4 mode %q", call, store.ModeFull)
+	}
+	if len(refresh.calls) != 1 {
+		t.Fatalf("refresh calls = %d, want 1", len(refresh.calls))
+	}
+	if got := refresh.calls[0]; got.ctx != ctx || got.ctx.Value(key) != "bound" || got.projectID != 7 || got.reason != RefreshReasonTodoDeleted {
+		t.Fatalf("refresh call = %+v, want bound context, project 7, reason %q", got, RefreshReasonTodoDeleted)
+	}
+	if !reflect.DeepEqual(trace, []string{"delete", "refresh"}) {
+		t.Fatalf("call trace = %#v, want delete then refresh", trace)
+	}
+}
+
+func TestDeleteServiceStoreFailureReturnsSameErrorAndSkipsRefresh(t *testing.T) {
+	wantErr := errors.New("delete failed")
+	trace := []string{}
+	deletes := &restDeleteStoreFake{err: wantErr, trace: &trace}
+	refresh := &restDeleteRefreshFake{trace: &trace}
+	prepared := NewDeleteService(DeleteServiceDependencies{Delete: deletes, Refresh: refresh}).Prepare(
+		context.Background(),
+		ResolvedDeleteTarget{ProjectContext: store.ProjectContext{Project: store.Project{ID: 7}}, Mode: store.ModeFull},
+	)
+
+	err := prepared.Delete(DeleteCommand{LocalID: 4})
+	if err != wantErr {
+		t.Fatalf("Delete error = %v, want identical error %v", err, wantErr)
+	}
+	if len(deletes.calls) != 1 {
+		t.Fatalf("delete calls = %d, want 1", len(deletes.calls))
+	}
+	if len(refresh.calls) != 0 {
+		t.Fatalf("refresh calls = %d, want 0", len(refresh.calls))
+	}
+	if !reflect.DeepEqual(trace, []string{"delete"}) {
+		t.Fatalf("call trace = %#v, want only delete", trace)
+	}
+}
+
+func TestDeleteServiceCancellationAfterPreparationUsesBoundContext(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), key, "bound"))
+	deletes := &restDeleteStoreFake{}
+	refresh := &restDeleteRefreshFake{}
+	prepared := NewDeleteService(DeleteServiceDependencies{Delete: deletes, Refresh: refresh}).Prepare(
+		ctx,
+		ResolvedDeleteTarget{ProjectContext: store.ProjectContext{Project: store.Project{ID: 7}}, Mode: store.ModeFull},
+	)
+	cancel()
+
+	err := prepared.Delete(DeleteCommand{LocalID: 4})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Delete error = %v, want context canceled", err)
+	}
+	if len(deletes.calls) != 1 {
+		t.Fatalf("delete calls = %d, want 1", len(deletes.calls))
+	}
+	if got := deletes.calls[0].ctx; got != ctx || got.Value(key) != "bound" || !errors.Is(got.Err(), context.Canceled) {
+		t.Fatalf("store context = %v, want bound cancelled context", got)
+	}
+	if len(refresh.calls) != 0 {
+		t.Fatalf("refresh calls = %d, want 0", len(refresh.calls))
+	}
+}
+
+func TestDeleteServiceNilRefreshIsNoOpAndLocalIDValidationRemainsTransportOwned(t *testing.T) {
+	deletes := &restDeleteStoreFake{}
+	prepared := NewDeleteService(DeleteServiceDependencies{Delete: deletes}).Prepare(
+		context.Background(),
+		ResolvedDeleteTarget{ProjectContext: store.ProjectContext{Project: store.Project{ID: 7}}, Mode: store.ModeFull},
+	)
+
+	if err := prepared.Delete(DeleteCommand{LocalID: 0}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(deletes.calls) != 1 {
+		t.Fatalf("delete calls = %d, want 1", len(deletes.calls))
+	}
+	if got := deletes.calls[0]; got.projectID != 7 || got.localID != 0 || got.mode != store.ModeFull {
+		t.Fatalf("delete call = %+v, want unvalidated local ID forwarded unchanged", got)
+	}
+}

--- a/internal/httpapi/routing_board.go
+++ b/internal/httpapi/routing_board.go
@@ -854,7 +854,11 @@ func (s *Server) handleBoardTodoItemRoutes(w http.ResponseWriter, r *http.Reques
 			return true
 
 		case http.MethodDelete:
-			if err := s.store.DeleteTodoByLocalID(s.requestContext(r), project.ID, localID, s.storeMode()); err != nil {
+			prepared := s.todoDeletes.Prepare(s.requestContext(r), todoapp.ResolvedDeleteTarget{
+				ProjectContext: *pc,
+				Mode:           s.storeMode(),
+			})
+			if err := prepared.Delete(todoapp.DeleteCommand{LocalID: localID}); err != nil {
 				if errors.Is(err, store.ErrUnauthorized) {
 					writeError(w, http.StatusForbidden, "FORBIDDEN", "forbidden", nil)
 					return true
@@ -862,7 +866,6 @@ func (s *Server) handleBoardTodoItemRoutes(w http.ResponseWriter, r *http.Reques
 				writeStoreErr(w, err, true)
 				return true
 			}
-			s.emitRefreshNeeded(s.requestContext(r), project.ID, "todo_deleted")
 			w.WriteHeader(http.StatusNoContent)
 			return true
 		}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -101,6 +101,7 @@ type Server struct {
 	store               storeAPI
 	boardReads          *boardapp.ReadService
 	todoCreates         *todoapp.CreateService
+	todoDeletes         *todoapp.DeleteService
 	todoMoves           *todoapp.MoveService
 	todoUpdates         *todoapp.UpdateService
 	todoLinkMutations   *todolinkapp.RESTMutationService
@@ -593,6 +594,10 @@ func NewServer(st storeAPI, opts Options) *Server {
 	})
 	server.todoCreates = todoapp.NewCreateService(todoapp.CreateServiceDependencies{
 		Create:  st,
+		Refresh: boardRefreshPublisher,
+	})
+	server.todoDeletes = todoapp.NewDeleteService(todoapp.DeleteServiceDependencies{
+		Delete:  st,
 		Refresh: boardRefreshPublisher,
 	})
 	server.todoMoves = todoapp.NewMoveService(todoapp.MoveServiceDependencies{

--- a/internal/httpapi/todo_delete_transport_contract_test.go
+++ b/internal/httpapi/todo_delete_transport_contract_test.go
@@ -1,0 +1,496 @@
+package httpapi
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"scrumboy/internal/db"
+	"scrumboy/internal/eventbus"
+	"scrumboy/internal/migrate"
+	"scrumboy/internal/store"
+)
+
+type todoDeleteRESTFixture struct {
+	ts        *httptest.Server
+	db        *sql.DB
+	store     *store.Store
+	collector *collectingConsumer
+}
+
+func newTodoDeleteRESTFixture(t *testing.T, mode string) *todoDeleteRESTFixture {
+	t.Helper()
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "app.db"), db.Options{
+		BusyTimeout: 5000,
+		JournalMode: "WAL",
+		Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := migrate.Apply(context.Background(), sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+	st := store.New(sqlDB, nil)
+	collector := &collectingConsumer{}
+	srv := NewServer(st, Options{MaxRequestBody: 1 << 20, ScrumboyMode: mode})
+	srv.fanout = eventbus.NewFanout(newSSEBridge(srv.hub), collector)
+	st.SetTodoAssignedPublisher(srv.PublishTodoAssigned)
+	ts := httptest.NewServer(srv)
+	fixture := &todoDeleteRESTFixture{ts: ts, db: sqlDB, store: st, collector: collector}
+	t.Cleanup(func() {
+		ts.Close()
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		srv.Close(closeCtx)
+		_ = sqlDB.Close()
+	})
+	return fixture
+}
+
+func todoDeleteRESTClientForUser(t *testing.T, fixture *todoDeleteRESTFixture, userID int64) *http.Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookie jar: %v", err)
+	}
+	client := &http.Client{Transport: fixture.ts.Client().Transport, Jar: jar}
+	token, expiresAt, err := fixture.store.CreateSession(context.Background(), userID, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	baseURL, err := url.Parse(fixture.ts.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	jar.SetCookies(baseURL, []*http.Cookie{{
+		Name:    "scrumboy_session",
+		Value:   token,
+		Path:    "/",
+		Expires: expiresAt,
+	}})
+	return client
+}
+
+func newTodoDeleteRESTOwner(t *testing.T, fixture *todoDeleteRESTFixture, email string) (store.User, context.Context, *http.Client) {
+	t.Helper()
+	owner, err := fixture.store.BootstrapUser(context.Background(), email, "password123", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	ctx := store.WithUserID(context.Background(), owner.ID)
+	return owner, ctx, todoDeleteRESTClientForUser(t, fixture, owner.ID)
+}
+
+func createTodoDeleteRESTTodo(t *testing.T, fixture *todoDeleteRESTFixture, ctx context.Context, projectID int64, title string) store.Todo {
+	t.Helper()
+	todo, err := fixture.store.CreateTodo(ctx, projectID, store.CreateTodoInput{
+		Title:     title,
+		ColumnKey: store.DefaultColumnBacklog,
+	}, store.ModeFull)
+	if err != nil {
+		t.Fatalf("CreateTodo %q: %v", title, err)
+	}
+	return todo
+}
+
+func todoDeleteRESTAuditCount(t *testing.T, sqlDB *sql.DB, todoID int64) int {
+	t.Helper()
+	var count int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM audit_events WHERE action = 'todo_deleted' AND target_type = 'todo' AND target_id = ?`, todoID).Scan(&count); err != nil {
+		t.Fatalf("count todo_deleted audits: %v", err)
+	}
+	return count
+}
+
+func todoDeleteRESTEventsForProject(collector *collectingConsumer, projectID int64) []eventbus.Event {
+	var events []eventbus.Event
+	for _, event := range collector.events {
+		if event.ProjectID == projectID {
+			events = append(events, event)
+		}
+	}
+	return events
+}
+
+func assertTodoDeleteRESTError(t *testing.T, body []byte, wantCode string) apiErrorEnvelope {
+	t.Helper()
+	var got apiErrorEnvelope
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode API error: %v body=%q", err, body)
+	}
+	if got.Error.Code != wantCode {
+		t.Fatalf("error code=%q want %q body=%s", got.Error.Code, wantCode, body)
+	}
+	return got
+}
+
+func TestTodoDeleteRESTRealtimeContracts(t *testing.T) {
+	t.Run("success publishes one internal and one SSE refresh", func(t *testing.T) {
+		fixture := newTodoDeleteRESTFixture(t, "full")
+		owner, ownerCtx, client := newTodoDeleteRESTOwner(t, fixture, "owner-success@example.com")
+		project, err := fixture.store.CreateProject(ownerCtx, "REST delete success")
+		if err != nil {
+			t.Fatalf("CreateProject: %v", err)
+		}
+		todo := createTodoDeleteRESTTodo(t, fixture, ownerCtx, project.ID, "Delete me")
+		stream := subscribeTodoUpdateEvents(t, client, fixture.ts.URL+"/api/board/"+project.Slug+"/events")
+
+		resp, body := doJSON(t, client, http.MethodDelete, fmt.Sprintf("%s/api/board/%s/todos/%d", fixture.ts.URL, project.Slug, todo.LocalID), nil, nil)
+		if resp.StatusCode != http.StatusNoContent || len(body) != 0 {
+			t.Fatalf("delete response status=%d body=%q want 204 with empty body", resp.StatusCode, body)
+		}
+
+		var todoRows int
+		if err := fixture.db.QueryRow(`SELECT COUNT(*) FROM todos WHERE id = ?`, todo.ID).Scan(&todoRows); err != nil {
+			t.Fatalf("count todo: %v", err)
+		}
+		if todoRows != 0 || todoDeleteRESTAuditCount(t, fixture.db, todo.ID) != 1 {
+			t.Fatalf("delete persistence todoRows=%d auditCount=%d want 0,1", todoRows, todoDeleteRESTAuditCount(t, fixture.db, todo.ID))
+		}
+
+		internalEvents := todoDeleteRESTEventsForProject(fixture.collector, project.ID)
+		if len(internalEvents) != 1 || internalEvents[0].Type != "board.refresh_needed" {
+			t.Fatalf("internal events=%+v want one board.refresh_needed", internalEvents)
+		}
+		var payload struct {
+			Reason      string `json:"reason"`
+			ActorUserID int64  `json:"actorUserId"`
+		}
+		if err := json.Unmarshal(internalEvents[0].Payload, &payload); err != nil {
+			t.Fatalf("decode refresh payload: %v", err)
+		}
+		if payload.Reason != "todo_deleted" || payload.ActorUserID != owner.ID {
+			t.Fatalf("refresh payload=%+v want reason todo_deleted actor %d", payload, owner.ID)
+		}
+
+		wireEvents := collectTodoUpdateEvents(t, stream)
+		if len(wireEvents) != 1 || wireEvents[0].Type != "refresh_needed" || wireEvents[0].ProjectID != project.ID || wireEvents[0].Reason != "todo_deleted" {
+			t.Fatalf("SSE events=%+v want one todo_deleted refresh for project %d", wireEvents, project.ID)
+		}
+	})
+
+	t.Run("missing todo is silent", func(t *testing.T) {
+		fixture := newTodoDeleteRESTFixture(t, "full")
+		_, ownerCtx, client := newTodoDeleteRESTOwner(t, fixture, "owner-missing@example.com")
+		project, err := fixture.store.CreateProject(ownerCtx, "REST missing todo")
+		if err != nil {
+			t.Fatalf("CreateProject: %v", err)
+		}
+		control := createTodoDeleteRESTTodo(t, fixture, ownerCtx, project.ID, "Keep me")
+		stream := subscribeTodoUpdateEvents(t, client, fixture.ts.URL+"/api/board/"+project.Slug+"/events")
+
+		resp, body := doJSON(t, client, http.MethodDelete, fmt.Sprintf("%s/api/board/%s/todos/%d", fixture.ts.URL, project.Slug, control.LocalID+1000), nil, nil)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("missing delete status=%d body=%s want 404", resp.StatusCode, body)
+		}
+		assertTodoDeleteRESTError(t, body, "NOT_FOUND")
+		var controlRows int
+		if err := fixture.db.QueryRow(`SELECT COUNT(*) FROM todos WHERE id = ?`, control.ID).Scan(&controlRows); err != nil {
+			t.Fatalf("count control todo: %v", err)
+		}
+		if controlRows != 1 || todoDeleteRESTAuditCount(t, fixture.db, control.ID) != 0 {
+			t.Fatalf("missing delete changed persistence todoRows=%d audits=%d", controlRows, todoDeleteRESTAuditCount(t, fixture.db, control.ID))
+		}
+		if events := todoDeleteRESTEventsForProject(fixture.collector, project.ID); len(events) != 0 {
+			t.Fatalf("missing delete published internal events: %+v", events)
+		}
+		if events := collectTodoUpdateEvents(t, stream); len(events) != 0 {
+			t.Fatalf("missing delete published SSE events: %+v", events)
+		}
+	})
+
+	t.Run("persistence failure is silent", func(t *testing.T) {
+		fixture := newTodoDeleteRESTFixture(t, "full")
+		_, ownerCtx, client := newTodoDeleteRESTOwner(t, fixture, "owner-failure@example.com")
+		project, err := fixture.store.CreateProject(ownerCtx, "REST persistence failure")
+		if err != nil {
+			t.Fatalf("CreateProject: %v", err)
+		}
+		todo := createTodoDeleteRESTTodo(t, fixture, ownerCtx, project.ID, "Retain me")
+		if _, err := fixture.db.Exec(`
+			CREATE TRIGGER phase21_rest_abort_todo_delete
+			BEFORE DELETE ON todos
+			BEGIN
+				SELECT RAISE(ABORT, 'forced todo delete failure');
+			END`); err != nil {
+			t.Fatalf("create aborting trigger: %v", err)
+		}
+		defer func() {
+			if _, err := fixture.db.Exec(`DROP TRIGGER IF EXISTS phase21_rest_abort_todo_delete`); err != nil {
+				t.Errorf("drop aborting trigger: %v", err)
+			}
+		}()
+		stream := subscribeTodoUpdateEvents(t, client, fixture.ts.URL+"/api/board/"+project.Slug+"/events")
+
+		resp, body := doJSON(t, client, http.MethodDelete, fmt.Sprintf("%s/api/board/%s/todos/%d", fixture.ts.URL, project.Slug, todo.LocalID), nil, nil)
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("failed delete status=%d body=%s want 500", resp.StatusCode, body)
+		}
+		assertTodoDeleteRESTError(t, body, "INTERNAL")
+		var todoRows int
+		if err := fixture.db.QueryRow(`SELECT COUNT(*) FROM todos WHERE id = ?`, todo.ID).Scan(&todoRows); err != nil {
+			t.Fatalf("count retained todo: %v", err)
+		}
+		if todoRows != 1 || todoDeleteRESTAuditCount(t, fixture.db, todo.ID) != 0 {
+			t.Fatalf("failed delete persistence todoRows=%d auditCount=%d", todoRows, todoDeleteRESTAuditCount(t, fixture.db, todo.ID))
+		}
+		if events := todoDeleteRESTEventsForProject(fixture.collector, project.ID); len(events) != 0 {
+			t.Fatalf("failed delete published internal events: %+v", events)
+		}
+		if events := collectTodoUpdateEvents(t, stream); len(events) != 0 {
+			t.Fatalf("failed delete published SSE events: %+v", events)
+		}
+	})
+}
+
+func TestTodoDeleteRESTAccessRoleAndModeContracts(t *testing.T) {
+	durableCases := []struct {
+		name       string
+		role       store.ProjectRole
+		auth       bool
+		missing    bool
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "owner", auth: true, wantStatus: http.StatusNoContent},
+		{name: "maintainer", role: store.RoleMaintainer, auth: true, wantStatus: http.StatusNoContent},
+		{name: "contributor existing todo", role: store.RoleContributor, auth: true, wantStatus: http.StatusForbidden, wantCode: "FORBIDDEN"},
+		{name: "contributor missing todo", role: store.RoleContributor, auth: true, missing: true, wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND"},
+		{name: "viewer", role: store.RoleViewer, auth: true, wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND"},
+		{name: "non-member", auth: true, wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND"},
+		{name: "no session", wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND"},
+	}
+
+	for index, tc := range durableCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newTodoDeleteRESTFixture(t, "full")
+			owner, ownerCtx, ownerClient := newTodoDeleteRESTOwner(t, fixture, fmt.Sprintf("owner-role-%d@example.com", index))
+			project, err := fixture.store.CreateProject(ownerCtx, "REST durable access "+tc.name)
+			if err != nil {
+				t.Fatalf("CreateProject: %v", err)
+			}
+			todo := createTodoDeleteRESTTodo(t, fixture, ownerCtx, project.ID, "Role target")
+			client := newCookieClient(t)
+			if tc.name == "owner" {
+				client = ownerClient
+			} else if tc.auth {
+				user, err := fixture.store.CreateUser(context.Background(), fmt.Sprintf("actor-role-%d@example.com", index), "password123", "Actor")
+				if err != nil {
+					t.Fatalf("CreateUser: %v", err)
+				}
+				if tc.role != "" {
+					if err := fixture.store.AddProjectMember(ownerCtx, owner.ID, project.ID, user.ID, tc.role); err != nil {
+						t.Fatalf("AddProjectMember: %v", err)
+					}
+				}
+				client = todoDeleteRESTClientForUser(t, fixture, user.ID)
+			}
+			localID := todo.LocalID
+			if tc.missing {
+				localID += 1000
+			}
+			resp, body := doJSON(t, client, http.MethodDelete, fmt.Sprintf("%s/api/board/%s/todos/%d", fixture.ts.URL, project.Slug, localID), nil, nil)
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("status=%d body=%s want %d", resp.StatusCode, body, tc.wantStatus)
+			}
+			if tc.wantCode != "" {
+				assertTodoDeleteRESTError(t, body, tc.wantCode)
+			}
+			var todoRows int
+			if err := fixture.db.QueryRow(`SELECT COUNT(*) FROM todos WHERE id = ?`, todo.ID).Scan(&todoRows); err != nil {
+				t.Fatalf("count todo: %v", err)
+			}
+			if tc.wantStatus == http.StatusNoContent {
+				if todoRows != 0 || len(body) != 0 {
+					t.Fatalf("successful delete todoRows=%d body=%q want 0 and empty", todoRows, body)
+				}
+			} else if todoRows != 1 || todoDeleteRESTAuditCount(t, fixture.db, todo.ID) != 0 {
+				t.Fatalf("failed delete todoRows=%d audits=%d want 1,0", todoRows, todoDeleteRESTAuditCount(t, fixture.db, todo.ID))
+			}
+		})
+	}
+
+	t.Run("anonymous link-holder on unexpired temporary board", func(t *testing.T) {
+		fixture := newTodoDeleteRESTFixture(t, "full")
+		_, ownerCtx, _ := newTodoDeleteRESTOwner(t, fixture, "owner-temp@example.com")
+		project, err := fixture.store.CreateAnonymousBoard(ownerCtx)
+		if err != nil {
+			t.Fatalf("CreateAnonymousBoard: %v", err)
+		}
+		todo := createTodoDeleteRESTTodo(t, fixture, ownerCtx, project.ID, "Temporary target")
+		oldActivity := time.Now().UTC().Add(-time.Hour).UnixMilli()
+		oldExpiry := time.Now().UTC().Add(24 * time.Hour).UnixMilli()
+		if _, err := fixture.db.Exec(`UPDATE projects SET last_activity_at = ?, expires_at = ? WHERE id = ?`, oldActivity, oldExpiry, project.ID); err != nil {
+			t.Fatalf("seed temporary timestamps: %v", err)
+		}
+
+		resp, body := doJSON(t, newCookieClient(t), http.MethodDelete, fmt.Sprintf("%s/api/board/%s/todos/%d", fixture.ts.URL, project.Slug, todo.LocalID), nil, nil)
+		if resp.StatusCode != http.StatusNoContent || len(body) != 0 {
+			t.Fatalf("temporary delete status=%d body=%q want empty 204", resp.StatusCode, body)
+		}
+		var actor sql.NullInt64
+		if err := fixture.db.QueryRow(`SELECT actor_user_id FROM audit_events WHERE action = 'todo_deleted' AND target_id = ?`, todo.ID).Scan(&actor); err != nil {
+			t.Fatalf("read temporary delete actor: %v", err)
+		}
+		if actor.Valid {
+			t.Fatalf("temporary anonymous delete actor=%d want NULL", actor.Int64)
+		}
+		var lastActivity, expiresAt int64
+		if err := fixture.db.QueryRow(`SELECT last_activity_at, expires_at FROM projects WHERE id = ?`, project.ID).Scan(&lastActivity, &expiresAt); err != nil {
+			t.Fatalf("read temporary activity: %v", err)
+		}
+		if lastActivity <= oldActivity || expiresAt <= oldExpiry {
+			t.Fatalf("temporary activity not extended last=%d expiry=%d old=(%d,%d)", lastActivity, expiresAt, oldActivity, oldExpiry)
+		}
+		events := todoDeleteRESTEventsForProject(fixture.collector, project.ID)
+		if len(events) != 1 {
+			t.Fatalf("temporary delete events=%+v want one", events)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(events[0].Payload, &payload); err != nil {
+			t.Fatalf("decode temporary refresh payload: %v", err)
+		}
+		if payload["reason"] != "todo_deleted" {
+			t.Fatalf("temporary refresh payload=%+v", payload)
+		}
+		if _, present := payload["actorUserId"]; present {
+			t.Fatalf("anonymous temporary refresh unexpectedly included actor: %+v", payload)
+		}
+	})
+
+	t.Run("expired temporary board", func(t *testing.T) {
+		fixture := newTodoDeleteRESTFixture(t, "full")
+		_, ownerCtx, _ := newTodoDeleteRESTOwner(t, fixture, "owner-expired@example.com")
+		project, err := fixture.store.CreateAnonymousBoard(ownerCtx)
+		if err != nil {
+			t.Fatalf("CreateAnonymousBoard: %v", err)
+		}
+		todo := createTodoDeleteRESTTodo(t, fixture, ownerCtx, project.ID, "Expired target")
+		if _, err := fixture.db.Exec(`UPDATE projects SET expires_at = ? WHERE id = ?`, time.Now().UTC().Add(-time.Minute).UnixMilli(), project.ID); err != nil {
+			t.Fatalf("expire temporary board: %v", err)
+		}
+		resp, body := doJSON(t, newCookieClient(t), http.MethodDelete, fmt.Sprintf("%s/api/board/%s/todos/%d", fixture.ts.URL, project.Slug, todo.LocalID), nil, nil)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expired delete status=%d body=%s want 404", resp.StatusCode, body)
+		}
+		assertTodoDeleteRESTError(t, body, "NOT_FOUND")
+		if todoDeleteRESTAuditCount(t, fixture.db, todo.ID) != 0 || len(todoDeleteRESTEventsForProject(fixture.collector, project.ID)) != 0 {
+			t.Fatal("expired temporary delete mutated or published")
+		}
+	})
+
+	t.Run("missing project", func(t *testing.T) {
+		fixture := newTodoDeleteRESTFixture(t, "full")
+		owner, _, client := newTodoDeleteRESTOwner(t, fixture, "owner-project-missing@example.com")
+		_ = owner
+		resp, body := doJSON(t, client, http.MethodDelete, fixture.ts.URL+"/api/board/missing-project/todos/1", nil, nil)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("missing project status=%d body=%s want 404", resp.StatusCode, body)
+		}
+		assertTodoDeleteRESTError(t, body, "NOT_FOUND")
+		if len(fixture.collector.events) != 0 {
+			t.Fatalf("missing project published events: %+v", fixture.collector.events)
+		}
+	})
+}
+
+func TestTodoDeleteRESTAccessPrecedesLocalIDValidation(t *testing.T) {
+	fixture := newTodoDeleteRESTFixture(t, "full")
+	owner, ownerCtx, ownerClient := newTodoDeleteRESTOwner(t, fixture, "owner-precedence@example.com")
+	project, err := fixture.store.CreateProject(ownerCtx, "REST delete precedence")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	control := createTodoDeleteRESTTodo(t, fixture, ownerCtx, project.ID, "Control")
+	outsider, err := fixture.store.CreateUser(context.Background(), "outsider-precedence@example.com", "password123", "Outsider")
+	if err != nil {
+		t.Fatalf("CreateUser outsider: %v", err)
+	}
+	outsiderClient := todoDeleteRESTClientForUser(t, fixture, outsider.ID)
+
+	cases := []struct {
+		name       string
+		client     *http.Client
+		slug       string
+		localID    string
+		wantStatus int
+		wantCode   string
+		wantReason string
+		wantField  string
+	}{
+		{name: "accessible malformed local ID", client: ownerClient, slug: project.Slug, localID: "not-a-number", wantStatus: http.StatusBadRequest, wantCode: "VALIDATION_ERROR", wantReason: "invalid_todo_local_id", wantField: "localId"},
+		{name: "accessible non-positive local ID", client: ownerClient, slug: project.Slug, localID: "0", wantStatus: http.StatusBadRequest, wantCode: "VALIDATION_ERROR", wantReason: "invalid_todo_local_id", wantField: "localId"},
+		{name: "missing project hides malformed local ID", client: ownerClient, slug: "missing-project", localID: "not-a-number", wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND"},
+		{name: "inaccessible project hides malformed local ID", client: outsiderClient, slug: project.Slug, localID: "not-a-number", wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, body := doJSON(t, tc.client, http.MethodDelete, fixture.ts.URL+"/api/board/"+tc.slug+"/todos/"+tc.localID, nil, nil)
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("status=%d body=%s want %d", resp.StatusCode, body, tc.wantStatus)
+			}
+			got := assertTodoDeleteRESTError(t, body, tc.wantCode)
+			if tc.wantReason != "" {
+				if got.Error.Message != "invalid todo localId" || got.Error.Details["reason"] != tc.wantReason || got.Error.Details["field"] != tc.wantField {
+					t.Fatalf("validation error=%+v", got.Error)
+				}
+			}
+		})
+	}
+	var controlRows int
+	if err := fixture.db.QueryRow(`SELECT COUNT(*) FROM todos WHERE id = ?`, control.ID).Scan(&controlRows); err != nil {
+		t.Fatalf("count control todo: %v", err)
+	}
+	if controlRows != 1 || todoDeleteRESTAuditCount(t, fixture.db, control.ID) != 0 || len(fixture.collector.events) != 0 {
+		t.Fatalf("precedence probes mutated/published todoRows=%d audits=%d events=%+v", controlRows, todoDeleteRESTAuditCount(t, fixture.db, control.ID), fixture.collector.events)
+	}
+	_ = owner
+}
+
+func TestLegacyTodoDeleteMasksContributorUnauthorizedAsNotFound(t *testing.T) {
+	fixture := newTodoDeleteRESTFixture(t, "full")
+	owner, ownerCtx, ownerClient := newTodoDeleteRESTOwner(t, fixture, "owner-legacy@example.com")
+	project, err := fixture.store.CreateProject(ownerCtx, "Legacy numeric delete")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	todo := createTodoDeleteRESTTodo(t, fixture, ownerCtx, project.ID, "Legacy target")
+	contributor, err := fixture.store.CreateUser(context.Background(), "contributor-legacy@example.com", "password123", "Contributor")
+	if err != nil {
+		t.Fatalf("CreateUser contributor: %v", err)
+	}
+	if err := fixture.store.AddProjectMember(ownerCtx, owner.ID, project.ID, contributor.ID, store.RoleContributor); err != nil {
+		t.Fatalf("AddProjectMember: %v", err)
+	}
+	contributorClient := todoDeleteRESTClientForUser(t, fixture, contributor.ID)
+	stream := subscribeTodoUpdateEvents(t, ownerClient, fixture.ts.URL+"/api/board/"+project.Slug+"/events")
+
+	resp, body := doJSON(t, contributorClient, http.MethodDelete, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), nil, nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("legacy contributor delete status=%d body=%s want 404", resp.StatusCode, body)
+	}
+	assertTodoDeleteRESTError(t, body, "NOT_FOUND")
+	var todoRows int
+	if err := fixture.db.QueryRow(`SELECT COUNT(*) FROM todos WHERE id = ?`, todo.ID).Scan(&todoRows); err != nil {
+		t.Fatalf("count retained todo: %v", err)
+	}
+	if todoRows != 1 || todoDeleteRESTAuditCount(t, fixture.db, todo.ID) != 0 {
+		t.Fatalf("legacy failed delete todoRows=%d audits=%d want 1,0", todoRows, todoDeleteRESTAuditCount(t, fixture.db, todo.ID))
+	}
+	if events := todoDeleteRESTEventsForProject(fixture.collector, project.ID); len(events) != 0 {
+		t.Fatalf("legacy failed delete published internal events: %+v", events)
+	}
+	if events := collectTodoUpdateEvents(t, stream); len(events) != 0 {
+		t.Fatalf("legacy failed delete published SSE events: %+v", events)
+	}
+}

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -90,6 +90,7 @@ type Adapter struct {
 	store               storeAPI
 	boardReads          *boardapp.MCPBoardReadService
 	todoCreates         *todoapp.MCPCreateService
+	todoDeletes         *todoapp.MCPDeleteService
 	todoMoves           *todoapp.MCPMoveService
 	todoUpdates         *todoapp.MCPUpdateService
 	todoLinkMutations   *todolinkapp.MCPMutationService
@@ -135,6 +136,10 @@ func New(st storeAPI, opts Options) *Adapter {
 			Access: st,
 			Lookup: st,
 			Create: st,
+		}),
+		todoDeletes: todoapp.NewMCPDeleteService(todoapp.MCPDeleteServiceDependencies{
+			Access: st,
+			Delete: st,
 		}),
 		todoMoves: todoapp.NewMCPMoveService(todoapp.MCPMoveServiceDependencies{
 			Access: st,

--- a/internal/mcp/todo_delete_transport_contract_test.go
+++ b/internal/mcp/todo_delete_transport_contract_test.go
@@ -1,0 +1,481 @@
+package mcp_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"scrumboy/internal/store"
+)
+
+func todoDeleteMCPSessionClient(t *testing.T, tsURL string, transport http.RoundTripper, st *store.Store, userID int64) *http.Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookie jar: %v", err)
+	}
+	token, expiresAt, err := st.CreateSession(context.Background(), userID, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	baseURL, err := url.Parse(tsURL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	jar.SetCookies(baseURL, []*http.Cookie{{Name: "scrumboy_session", Value: token, Path: "/", Expires: expiresAt}})
+	return &http.Client{Transport: transport, Jar: jar}
+}
+
+func createTodoDeleteMCPUser(t *testing.T, st *store.Store, email, name string) store.User {
+	t.Helper()
+	user, err := st.CreateUser(context.Background(), email, "password123", name)
+	if err != nil {
+		t.Fatalf("CreateUser %s: %v", email, err)
+	}
+	return user
+}
+
+func bootstrapTodoDeleteMCPOwner(t *testing.T, st *store.Store, email string) (store.User, context.Context) {
+	t.Helper()
+	owner, err := st.BootstrapUser(context.Background(), email, "password123", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	return owner, store.WithUserID(context.Background(), owner.ID)
+}
+
+func createTodoDeleteMCPTodo(t *testing.T, st *store.Store, ctx context.Context, projectID int64, title string) store.Todo {
+	t.Helper()
+	todo, err := st.CreateTodo(ctx, projectID, store.CreateTodoInput{
+		Title:     title,
+		ColumnKey: store.DefaultColumnBacklog,
+	}, store.ModeFull)
+	if err != nil {
+		t.Fatalf("CreateTodo %q: %v", title, err)
+	}
+	return todo
+}
+
+func todoDeleteMCPAuditCount(t *testing.T, sqlDB *sql.DB, projectID, todoID int64) int {
+	t.Helper()
+	var count int
+	if err := sqlDB.QueryRow(`
+		SELECT COUNT(*)
+		FROM audit_events
+		WHERE project_id = ? AND action = 'todo_deleted' AND target_type = 'todo' AND target_id = ?`, projectID, todoID).Scan(&count); err != nil {
+		t.Fatalf("count todo_deleted audits: %v", err)
+	}
+	return count
+}
+
+func todoDeleteMCPProjectAuditCount(t *testing.T, sqlDB *sql.DB, projectID int64) int {
+	t.Helper()
+	var count int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM audit_events WHERE project_id = ? AND action = 'todo_deleted'`, projectID).Scan(&count); err != nil {
+		t.Fatalf("count project todo_deleted audits: %v", err)
+	}
+	return count
+}
+
+func assertTodoDeleteMCPSuccess(t *testing.T, transport string, response map[string]any, slug string, localID int64) {
+	t.Helper()
+	var data map[string]any
+	if transport == "legacy" {
+		if got, want := sortedMapKeys(response), []string{"data", "meta", "ok"}; !reflect.DeepEqual(got, want) || response["ok"] != true {
+			t.Fatalf("legacy success envelope=%+v keys=%v want=%v", response, got, want)
+		}
+		meta, ok := response["meta"].(map[string]any)
+		if !ok || len(meta) != 0 {
+			t.Fatalf("legacy meta=%+v want empty object", response["meta"])
+		}
+		data = response["data"].(map[string]any)
+	} else {
+		if got, want := sortedMapKeys(response), []string{"id", "jsonrpc", "result"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("JSON-RPC envelope keys=%v want=%v response=%+v", got, want, response)
+		}
+		if response["jsonrpc"] != "2.0" || response["id"] != float64(14) {
+			t.Fatalf("JSON-RPC identity mismatch: %+v", response)
+		}
+		result := response["result"].(map[string]any)
+		if got, want := sortedMapKeys(result), []string{"content", "structuredContent"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("JSON-RPC result keys=%v want=%v result=%+v", got, want, result)
+		}
+		data = result["structuredContent"].(map[string]any)
+		content := result["content"].([]any)
+		if len(content) != 1 || content[0].(map[string]any)["type"] != "text" {
+			t.Fatalf("JSON-RPC content=%+v", content)
+		}
+		var textData map[string]any
+		if err := json.Unmarshal([]byte(content[0].(map[string]any)["text"].(string)), &textData); err != nil {
+			t.Fatalf("decode JSON-RPC text content: %v", err)
+		}
+		if !reflect.DeepEqual(textData, data) {
+			t.Fatalf("JSON-RPC text/structured divergence: text=%+v structured=%+v", textData, data)
+		}
+		if _, present := data["meta"]; present {
+			t.Fatalf("JSON-RPC structured content unexpectedly includes legacy meta: %+v", data)
+		}
+	}
+	if got, want := sortedMapKeys(data), []string{"localId", "projectSlug", "status"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("delete data keys=%v want=%v data=%+v", got, want, data)
+	}
+	if data["status"] != "deleted" || data["projectSlug"] != slug || data["localId"] != float64(localID) {
+		t.Fatalf("delete projection=%+v want status=deleted slug=%q localId=%d", data, slug, localID)
+	}
+	if _, present := data["id"]; present {
+		t.Fatalf("delete projection exposed global todo id: %+v", data)
+	}
+}
+
+func assertTodoDeleteMCPLegacyError(t *testing.T, resp *http.Response, response map[string]any, wantStatus int, wantCode, wantMessage string) map[string]any {
+	t.Helper()
+	if resp.StatusCode != wantStatus {
+		t.Fatalf("legacy error status=%d response=%+v want %d", resp.StatusCode, response, wantStatus)
+	}
+	return assertTodoCreateMCPLegacyError(t, response, wantCode, wantMessage)
+}
+
+func TestTodoDeleteMCPTransportAliasMatrix(t *testing.T) {
+	ts, sqlDB, st, cleanup := newTodoUpdateMCPServer(t, "full")
+	defer cleanup()
+	owner, ownerCtx := bootstrapTodoDeleteMCPOwner(t, st, "owner-matrix@example.com")
+	client := todoDeleteMCPSessionClient(t, ts.URL, ts.Client().Transport, st, owner.ID)
+
+	for index, tc := range []struct {
+		transport string
+		tool      string
+	}{
+		{transport: "legacy", tool: "todos_delete"},
+		{transport: "legacy", tool: "todos.delete"},
+		{transport: "jsonrpc", tool: "todos_delete"},
+		{transport: "jsonrpc", tool: "todos.delete"},
+	} {
+		t.Run(tc.transport+"/"+tc.tool, func(t *testing.T) {
+			project, err := st.CreateProject(ownerCtx, fmt.Sprintf("MCP delete matrix %d", index))
+			if err != nil {
+				t.Fatalf("CreateProject: %v", err)
+			}
+			todo := createTodoDeleteMCPTodo(t, st, ownerCtx, project.ID, "Delete via "+tc.tool)
+			resp, out := callTodoUpdateMCP(t, client, ts.URL, tc.transport, tc.tool, map[string]any{
+				"projectSlug": project.Slug,
+				"localId":     todo.LocalID,
+			})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d response=%+v want 200", resp.StatusCode, out)
+			}
+			assertTodoDeleteMCPSuccess(t, tc.transport, out, project.Slug, todo.LocalID)
+			if _, err := st.GetTodoByLocalID(ownerCtx, project.ID, todo.LocalID, store.ModeFull); !errors.Is(err, store.ErrNotFound) {
+				t.Fatalf("GetTodoByLocalID after delete err=%v want ErrNotFound", err)
+			}
+			if audits := todoDeleteMCPAuditCount(t, sqlDB, project.ID, todo.ID); audits != 1 {
+				t.Fatalf("delete audits=%d want 1", audits)
+			}
+		})
+	}
+}
+
+func TestTodoDeleteMCPRealtimeContracts(t *testing.T) {
+	t.Run("success is realtime silent", func(t *testing.T) {
+		ts, sqlDB, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		defer cleanup()
+		owner, ownerCtx := bootstrapTodoDeleteMCPOwner(t, st, "owner-realtime-success@example.com")
+		client := todoDeleteMCPSessionClient(t, ts.URL, ts.Client().Transport, st, owner.ID)
+		project, err := st.CreateProject(ownerCtx, "MCP realtime success")
+		if err != nil {
+			t.Fatalf("CreateProject: %v", err)
+		}
+		todo := createTodoDeleteMCPTodo(t, st, ownerCtx, project.ID, "Delete silently")
+		stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+		defer stream.close()
+
+		resp, out := callTodoUpdateMCP(t, client, ts.URL, "legacy", "todos_delete", map[string]any{"projectSlug": project.Slug, "localId": todo.LocalID})
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoDeleteMCPSuccess(t, "legacy", out, project.Slug, todo.LocalID)
+		if _, err := st.GetTodoByLocalID(ownerCtx, project.ID, todo.LocalID, store.ModeFull); !errors.Is(err, store.ErrNotFound) {
+			t.Fatalf("deleted todo lookup err=%v want ErrNotFound", err)
+		}
+		if todoDeleteMCPAuditCount(t, sqlDB, project.ID, todo.ID) != 1 {
+			t.Fatal("successful MCP delete did not create exactly one audit")
+		}
+		if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+			t.Fatalf("successful MCP delete emitted realtime events: %+v", events)
+		}
+	})
+
+	t.Run("missing todo is realtime silent", func(t *testing.T) {
+		ts, sqlDB, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		defer cleanup()
+		owner, ownerCtx := bootstrapTodoDeleteMCPOwner(t, st, "owner-realtime-missing@example.com")
+		client := todoDeleteMCPSessionClient(t, ts.URL, ts.Client().Transport, st, owner.ID)
+		project, err := st.CreateProject(ownerCtx, "MCP realtime missing")
+		if err != nil {
+			t.Fatalf("CreateProject: %v", err)
+		}
+		control := createTodoDeleteMCPTodo(t, st, ownerCtx, project.ID, "Keep me")
+		stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+		defer stream.close()
+
+		resp, out := callTodoUpdateMCP(t, client, ts.URL, "legacy", "todos_delete", map[string]any{"projectSlug": project.Slug, "localId": control.LocalID + 1000})
+		assertTodoDeleteMCPLegacyError(t, resp, out, http.StatusNotFound, "NOT_FOUND", "not found")
+		if _, err := st.GetTodoByLocalID(ownerCtx, project.ID, control.LocalID, store.ModeFull); err != nil {
+			t.Fatalf("control todo changed: %v", err)
+		}
+		if todoDeleteMCPProjectAuditCount(t, sqlDB, project.ID) != 0 {
+			t.Fatal("missing MCP delete created deletion audit")
+		}
+		if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+			t.Fatalf("missing MCP delete emitted realtime events: %+v", events)
+		}
+	})
+
+	t.Run("persistence failure is realtime silent", func(t *testing.T) {
+		ts, sqlDB, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		defer cleanup()
+		owner, ownerCtx := bootstrapTodoDeleteMCPOwner(t, st, "owner-realtime-failure@example.com")
+		client := todoDeleteMCPSessionClient(t, ts.URL, ts.Client().Transport, st, owner.ID)
+		project, err := st.CreateProject(ownerCtx, "MCP realtime failure")
+		if err != nil {
+			t.Fatalf("CreateProject: %v", err)
+		}
+		todo := createTodoDeleteMCPTodo(t, st, ownerCtx, project.ID, "Retain me")
+		if _, err := sqlDB.Exec(`
+			CREATE TRIGGER phase21_mcp_abort_todo_delete
+			BEFORE DELETE ON todos
+			BEGIN
+				SELECT RAISE(ABORT, 'forced todo delete failure');
+			END`); err != nil {
+			t.Fatalf("create aborting trigger: %v", err)
+		}
+		defer func() {
+			if _, err := sqlDB.Exec(`DROP TRIGGER IF EXISTS phase21_mcp_abort_todo_delete`); err != nil {
+				t.Errorf("drop aborting trigger: %v", err)
+			}
+		}()
+		stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+		defer stream.close()
+
+		resp, out := callTodoUpdateMCP(t, client, ts.URL, "legacy", "todos_delete", map[string]any{"projectSlug": project.Slug, "localId": todo.LocalID})
+		publicError := assertTodoDeleteMCPLegacyError(t, resp, out, http.StatusInternalServerError, "INTERNAL", "internal error")
+		if details, ok := publicError["details"].(map[string]any); !ok || len(details) != 0 {
+			t.Fatalf("public INTERNAL details=%+v want empty", publicError["details"])
+		}
+		if _, err := st.GetTodoByLocalID(ownerCtx, project.ID, todo.LocalID, store.ModeFull); err != nil {
+			t.Fatalf("failed delete did not retain todo: %v", err)
+		}
+		if todoDeleteMCPAuditCount(t, sqlDB, project.ID, todo.ID) != 0 {
+			t.Fatal("failed MCP delete committed deletion audit")
+		}
+		if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+			t.Fatalf("failed MCP delete emitted realtime events: %+v", events)
+		}
+	})
+}
+
+func TestTodoDeleteMCPAccessRoleAndModeContracts(t *testing.T) {
+	durableCases := []struct {
+		name       string
+		role       store.ProjectRole
+		owner      bool
+		missing    bool
+		wantStatus int
+		wantCode   string
+		wantMsg    string
+	}{
+		{name: "owner", owner: true, wantStatus: http.StatusOK},
+		{name: "maintainer", role: store.RoleMaintainer, wantStatus: http.StatusOK},
+		{name: "contributor existing todo", role: store.RoleContributor, wantStatus: http.StatusForbidden, wantCode: "FORBIDDEN", wantMsg: "forbidden"},
+		{name: "contributor missing todo", role: store.RoleContributor, missing: true, wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND", wantMsg: "not found"},
+		{name: "viewer", role: store.RoleViewer, wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND", wantMsg: "not found"},
+		{name: "non-member", wantStatus: http.StatusNotFound, wantCode: "NOT_FOUND", wantMsg: "not found"},
+	}
+
+	for index, tc := range durableCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, sqlDB, st, cleanup := newTodoUpdateMCPServer(t, "full")
+			defer cleanup()
+			owner, ownerCtx := bootstrapTodoDeleteMCPOwner(t, st, fmt.Sprintf("owner-role-%d@example.com", index))
+			project, err := st.CreateProject(ownerCtx, "MCP durable access "+tc.name)
+			if err != nil {
+				t.Fatalf("CreateProject: %v", err)
+			}
+			todo := createTodoDeleteMCPTodo(t, st, ownerCtx, project.ID, "Role target")
+			actor := owner
+			if !tc.owner {
+				actor = createTodoDeleteMCPUser(t, st, fmt.Sprintf("actor-role-%d@example.com", index), "Actor")
+				if tc.role != "" {
+					if err := st.AddProjectMember(ownerCtx, owner.ID, project.ID, actor.ID, tc.role); err != nil {
+						t.Fatalf("AddProjectMember: %v", err)
+					}
+				}
+			}
+			client := todoDeleteMCPSessionClient(t, ts.URL, ts.Client().Transport, st, actor.ID)
+			ownerEventsClient := todoDeleteMCPSessionClient(t, ts.URL, ts.Client().Transport, st, owner.ID)
+			stream := subscribeTodoUpdateMCPEvents(t, ownerEventsClient, ts.URL+"/api/board/"+project.Slug+"/events")
+			defer stream.close()
+			localID := todo.LocalID
+			if tc.missing {
+				localID += 1000
+			}
+			resp, out := callTodoUpdateMCP(t, client, ts.URL, "legacy", "todos_delete", map[string]any{"projectSlug": project.Slug, "localId": localID})
+			if tc.wantStatus == http.StatusOK {
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("status=%d response=%+v want 200", resp.StatusCode, out)
+				}
+				assertTodoDeleteMCPSuccess(t, "legacy", out, project.Slug, todo.LocalID)
+				if todoDeleteMCPAuditCount(t, sqlDB, project.ID, todo.ID) != 1 {
+					t.Fatal("successful role delete did not create one audit")
+				}
+			} else {
+				assertTodoDeleteMCPLegacyError(t, resp, out, tc.wantStatus, tc.wantCode, tc.wantMsg)
+				if _, err := st.GetTodoByLocalID(ownerCtx, project.ID, todo.LocalID, store.ModeFull); err != nil {
+					t.Fatalf("failed role delete changed todo: %v", err)
+				}
+				if todoDeleteMCPAuditCount(t, sqlDB, project.ID, todo.ID) != 0 {
+					t.Fatal("failed role delete created deletion audit")
+				}
+			}
+			if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+				t.Fatalf("role delete emitted realtime events: %+v", events)
+			}
+		})
+	}
+
+	t.Run("missing project", func(t *testing.T) {
+		ts, _, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		defer cleanup()
+		owner, ownerCtx := bootstrapTodoDeleteMCPOwner(t, st, "owner-missing-project@example.com")
+		client := todoDeleteMCPSessionClient(t, ts.URL, ts.Client().Transport, st, owner.ID)
+		controlProject, err := st.CreateProject(ownerCtx, "MCP missing-project event control")
+		if err != nil {
+			t.Fatalf("CreateProject control: %v", err)
+		}
+		stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+controlProject.Slug+"/events")
+		defer stream.close()
+		resp, out := callTodoUpdateMCP(t, client, ts.URL, "legacy", "todos_delete", map[string]any{"projectSlug": "missing-project", "localId": 1})
+		assertTodoDeleteMCPLegacyError(t, resp, out, http.StatusNotFound, "NOT_FOUND", "not found")
+		if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+			t.Fatalf("missing-project MCP delete emitted realtime events: %+v", events)
+		}
+	})
+
+	t.Run("authenticated link-holder on unexpired temporary board", func(t *testing.T) {
+		ts, sqlDB, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		defer cleanup()
+		owner, ownerCtx := bootstrapTodoDeleteMCPOwner(t, st, "owner-temp-link@example.com")
+		project, err := st.CreateAnonymousBoard(ownerCtx)
+		if err != nil {
+			t.Fatalf("CreateAnonymousBoard: %v", err)
+		}
+		todo := createTodoDeleteMCPTodo(t, st, ownerCtx, project.ID, "Temporary target")
+		linkHolder := createTodoDeleteMCPUser(t, st, "link-holder@example.com", "Link Holder")
+		client := todoDeleteMCPSessionClient(t, ts.URL, ts.Client().Transport, st, linkHolder.ID)
+		ownerClient := todoDeleteMCPSessionClient(t, ts.URL, ts.Client().Transport, st, owner.ID)
+		stream := subscribeTodoUpdateMCPEvents(t, ownerClient, ts.URL+"/api/board/"+project.Slug+"/events")
+		defer stream.close()
+
+		resp, out := callTodoUpdateMCP(t, client, ts.URL, "legacy", "todos_delete", map[string]any{"projectSlug": project.Slug, "localId": todo.LocalID})
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+		}
+		assertTodoDeleteMCPSuccess(t, "legacy", out, project.Slug, todo.LocalID)
+		var actor sql.NullInt64
+		if err := sqlDB.QueryRow(`SELECT actor_user_id FROM audit_events WHERE action = 'todo_deleted' AND target_id = ?`, todo.ID).Scan(&actor); err != nil {
+			t.Fatalf("read temporary delete actor: %v", err)
+		}
+		if !actor.Valid || actor.Int64 != linkHolder.ID {
+			t.Fatalf("temporary MCP delete actor=%+v want %d", actor, linkHolder.ID)
+		}
+		if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+			t.Fatalf("temporary MCP delete emitted realtime events: %+v", events)
+		}
+	})
+
+	t.Run("authenticated caller on expired temporary board", func(t *testing.T) {
+		ts, sqlDB, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		defer cleanup()
+		owner, ownerCtx := bootstrapTodoDeleteMCPOwner(t, st, "owner-expired-temp@example.com")
+		project, err := st.CreateAnonymousBoard(ownerCtx)
+		if err != nil {
+			t.Fatalf("CreateAnonymousBoard: %v", err)
+		}
+		todo := createTodoDeleteMCPTodo(t, st, ownerCtx, project.ID, "Expired target")
+		client := todoDeleteMCPSessionClient(t, ts.URL, ts.Client().Transport, st, owner.ID)
+		stream := subscribeTodoUpdateMCPEvents(t, client, ts.URL+"/api/board/"+project.Slug+"/events")
+		defer stream.close()
+		if _, err := sqlDB.Exec(`UPDATE projects SET expires_at = ? WHERE id = ?`, time.Now().UTC().Add(-time.Minute).UnixMilli(), project.ID); err != nil {
+			t.Fatalf("expire temporary board: %v", err)
+		}
+		resp, out := callTodoUpdateMCP(t, client, ts.URL, "legacy", "todos_delete", map[string]any{"projectSlug": project.Slug, "localId": todo.LocalID})
+		assertTodoDeleteMCPLegacyError(t, resp, out, http.StatusNotFound, "NOT_FOUND", "not found")
+		if todoDeleteMCPAuditCount(t, sqlDB, project.ID, todo.ID) != 0 {
+			t.Fatal("expired temporary MCP delete created deletion audit")
+		}
+		if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+			t.Fatalf("expired temporary MCP delete emitted realtime events: %+v", events)
+		}
+	})
+}
+
+func TestTodoDeleteMCPGateAndValidationPrecedence(t *testing.T) {
+	t.Run("anonymous mode capability gate precedes malformed input", func(t *testing.T) {
+		ts, _, _, cleanup := newTodoUpdateMCPServer(t, "anonymous")
+		defer cleanup()
+		resp, out := doMCP(t, newStatelessClient(ts), ts.URL+"/mcp", map[string]any{"tool": "todos_delete", "input": "malformed"})
+		publicError := assertTodoDeleteMCPLegacyError(t, resp, out, http.StatusForbidden, "CAPABILITY_UNAVAILABLE", "todos_delete is unavailable in anonymous mode")
+		if details := publicError["details"].(map[string]any); len(details) != 0 {
+			t.Fatalf("capability details=%+v want empty", details)
+		}
+	})
+
+	t.Run("bootstrap gate precedes malformed input", func(t *testing.T) {
+		ts, _, _, cleanup := newTodoUpdateMCPServer(t, "full")
+		defer cleanup()
+		resp, out := doMCP(t, newStatelessClient(ts), ts.URL+"/mcp", map[string]any{"tool": "todos_delete", "input": "malformed"})
+		assertTodoDeleteMCPLegacyError(t, resp, out, http.StatusForbidden, "CAPABILITY_UNAVAILABLE", "todos_delete is unavailable before bootstrap")
+	})
+
+	t.Run("authentication gate precedes malformed input", func(t *testing.T) {
+		ts, _, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		defer cleanup()
+		bootstrapTodoDeleteMCPOwner(t, st, "owner-auth-gate@example.com")
+		resp, out := doMCP(t, newStatelessClient(ts), ts.URL+"/mcp", map[string]any{"tool": "todos_delete", "input": "malformed"})
+		assertTodoDeleteMCPLegacyError(t, resp, out, http.StatusUnauthorized, "AUTH_REQUIRED", "Sign-in required for this tool")
+	})
+
+	t.Run("authenticated validation precedes project lookup", func(t *testing.T) {
+		ts, _, st, cleanup := newTodoUpdateMCPServer(t, "full")
+		defer cleanup()
+		owner, _ := bootstrapTodoDeleteMCPOwner(t, st, "owner-validation@example.com")
+		client := todoDeleteMCPSessionClient(t, ts.URL, ts.Client().Transport, st, owner.ID)
+		cases := []struct {
+			name      string
+			input     map[string]any
+			wantMsg   string
+			wantField string
+		}{
+			{name: "missing projectSlug", input: map[string]any{"localId": 1}, wantMsg: "missing projectSlug", wantField: "projectSlug"},
+			{name: "non-positive localId", input: map[string]any{"projectSlug": "missing-project", "localId": 0}, wantMsg: "invalid localId", wantField: "localId"},
+			{name: "invalid localId masks missing project", input: map[string]any{"projectSlug": "missing-project", "localId": -1}, wantMsg: "invalid localId", wantField: "localId"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				resp, out := doMCP(t, client, ts.URL+"/mcp", map[string]any{"tool": "todos_delete", "input": tc.input})
+				publicError := assertTodoDeleteMCPLegacyError(t, resp, out, http.StatusBadRequest, "VALIDATION_ERROR", tc.wantMsg)
+				details := publicError["details"].(map[string]any)
+				if !reflect.DeepEqual(details, map[string]any{"field": tc.wantField}) {
+					t.Fatalf("validation details=%+v want field %q", details, tc.wantField)
+				}
+			})
+		}
+	})
+}

--- a/internal/mcp/todos_tools.go
+++ b/internal/mcp/todos_tools.go
@@ -341,12 +341,15 @@ func (a *Adapter) handleTodosDelete(ctx context.Context, input any) (any, map[st
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid localId", map[string]any{"field": "localId"})
 	}
 
-	pc, pcErr := a.store.GetProjectContextBySlug(ctx, in.ProjectSlug, a.storeMode())
-	if pcErr != nil {
-		return nil, nil, mapStoreError(pcErr)
+	prepared, prepareErr := a.todoDeletes.Prepare(ctx, todoapp.SlugDeleteTarget{
+		Slug: in.ProjectSlug,
+		Mode: a.storeMode(),
+	})
+	if prepareErr != nil {
+		return nil, nil, mapStoreError(prepareErr)
 	}
 
-	deleteErr := a.store.DeleteTodoByLocalID(ctx, pc.Project.ID, in.LocalID, a.storeMode())
+	deleteErr := prepared.Delete(todoapp.DeleteCommand{LocalID: in.LocalID})
 	if deleteErr != nil {
 		if errors.Is(deleteErr, store.ErrUnauthorized) {
 			return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "forbidden", nil)

--- a/internal/store/todo_deletion_contract_test.go
+++ b/internal/store/todo_deletion_contract_test.go
@@ -1,0 +1,357 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func mustCreateDeletionTodo(t *testing.T, st *Store, ctx context.Context, projectID int64, title string) Todo {
+	t.Helper()
+	todo, err := st.CreateTodo(ctx, projectID, CreateTodoInput{Title: title, ColumnKey: "backlog"}, ModeFull)
+	if err != nil {
+		t.Fatalf("CreateTodo %q: %v", title, err)
+	}
+	return todo
+}
+
+func TestDeleteTodoByLocalID_PersistenceContract(t *testing.T) {
+	st, sqlDB, cleanup := newTestStoreWithSQL(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	owner, err := st.BootstrapUser(ctx, "owner@example.com", "password", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	ownerCtx := WithUserID(ctx, owner.ID)
+	project, err := st.CreateProject(ownerCtx, "Todo deletion contract")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	assignee, err := st.CreateUser(ctx, "assignee@example.com", "password", "Assignee")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := st.AddProjectMember(ownerCtx, owner.ID, project.ID, assignee.ID, RoleViewer); err != nil {
+		t.Fatalf("AddProjectMember: %v", err)
+	}
+
+	start := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Millisecond)
+	sprint, err := st.CreateSprint(ownerCtx, project.ID, "Preserved Sprint", start, start.Add(14*24*time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSprint: %v", err)
+	}
+	priorityKey := "high"
+	target, err := st.CreateTodo(ownerCtx, project.ID, CreateTodoInput{
+		Title:       "Delete me",
+		Body:        "persistence contract",
+		Tags:        []string{"delete-contract"},
+		ColumnKey:   "backlog",
+		SprintID:    &sprint.ID,
+		PriorityKey: &priorityKey,
+	}, ModeFull)
+	if err != nil {
+		t.Fatalf("CreateTodo target: %v", err)
+	}
+	target, err = st.UpdateTodo(ownerCtx, target.ID, UpdateTodoInput{
+		Title:              target.Title,
+		Body:               target.Body,
+		Tags:               []string{"delete-contract"},
+		AssigneeUserID:     &assignee.ID,
+		SprintID:           &sprint.ID,
+		PriorityKey:        &priorityKey,
+		PriorityKeyPresent: true,
+	}, ModeFull)
+	if err != nil {
+		t.Fatalf("UpdateTodo assignment: %v", err)
+	}
+
+	outbound := mustCreateDeletionTodo(t, st, ownerCtx, project.ID, "Outbound peer")
+	inbound := mustCreateDeletionTodo(t, st, ownerCtx, project.ID, "Inbound peer")
+	unrelatedFrom := mustCreateDeletionTodo(t, st, ownerCtx, project.ID, "Unrelated from")
+	unrelatedTo := mustCreateDeletionTodo(t, st, ownerCtx, project.ID, "Unrelated to")
+	if err := st.AddLink(ownerCtx, project.ID, target.LocalID, outbound.LocalID, "blocks", ModeFull); err != nil {
+		t.Fatalf("AddLink outbound: %v", err)
+	}
+	if err := st.AddLink(ownerCtx, project.ID, inbound.LocalID, target.LocalID, "relates_to", ModeFull); err != nil {
+		t.Fatalf("AddLink inbound: %v", err)
+	}
+	if err := st.AddLink(ownerCtx, project.ID, unrelatedFrom.LocalID, unrelatedTo.LocalID, "duplicates", ModeFull); err != nil {
+		t.Fatalf("AddLink unrelated: %v", err)
+	}
+
+	var tagID int64
+	if err := sqlDB.QueryRow(`
+		SELECT tt.tag_id
+		FROM todo_tags tt
+		JOIN tags t ON t.id = tt.tag_id
+		WHERE tt.todo_id = ? AND t.name = ?`, target.ID, "delete-contract").Scan(&tagID); err != nil {
+		t.Fatalf("find target tag: %v", err)
+	}
+	var ledgerBefore int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM todo_assignee_events WHERE todo_id = ?`, target.ID).Scan(&ledgerBefore); err != nil {
+		t.Fatalf("count assignee ledger before delete: %v", err)
+	}
+	if ledgerBefore == 0 {
+		t.Fatal("assignment setup did not create assignee ledger history")
+	}
+	sprintBefore, err := st.GetSprintByID(ctx, sprint.ID)
+	if err != nil {
+		t.Fatalf("GetSprintByID before delete: %v", err)
+	}
+	prioritiesBefore, err := st.GetProjectPriorities(ctx, project.ID)
+	if err != nil {
+		t.Fatalf("GetProjectPriorities before delete: %v", err)
+	}
+
+	oldMs := time.Now().UTC().Add(-time.Hour).UnixMilli()
+	if _, err := sqlDB.Exec(`UPDATE projects SET updated_at = ?, last_activity_at = ? WHERE id = ?`, oldMs, oldMs, project.ID); err != nil {
+		t.Fatalf("seed project timestamps: %v", err)
+	}
+
+	if err := st.DeleteTodoByLocalID(ownerCtx, project.ID, target.LocalID, ModeFull); err != nil {
+		t.Fatalf("DeleteTodoByLocalID: %v", err)
+	}
+
+	var targetRows int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM todos WHERE id = ?`, target.ID).Scan(&targetRows); err != nil {
+		t.Fatalf("count target todo: %v", err)
+	}
+	if targetRows != 0 {
+		t.Fatalf("target todo rows=%d want 0", targetRows)
+	}
+
+	var incidentLinks int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM todo_links WHERE project_id = ? AND (from_local_id = ? OR to_local_id = ?)`, project.ID, target.LocalID, target.LocalID).Scan(&incidentLinks); err != nil {
+		t.Fatalf("count incident links: %v", err)
+	}
+	if incidentLinks != 0 {
+		t.Fatalf("incident links=%d want 0", incidentLinks)
+	}
+	var unrelatedLinks int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM todo_links WHERE project_id = ? AND from_local_id = ? AND to_local_id = ?`, project.ID, unrelatedFrom.LocalID, unrelatedTo.LocalID).Scan(&unrelatedLinks); err != nil {
+		t.Fatalf("count unrelated link: %v", err)
+	}
+	if unrelatedLinks != 1 {
+		t.Fatalf("unrelated links=%d want 1", unrelatedLinks)
+	}
+
+	var tagJoins, tagRows int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM todo_tags WHERE todo_id = ?`, target.ID).Scan(&tagJoins); err != nil {
+		t.Fatalf("count todo_tags: %v", err)
+	}
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM tags WHERE id = ?`, tagID).Scan(&tagRows); err != nil {
+		t.Fatalf("count underlying tag: %v", err)
+	}
+	if tagJoins != 0 || tagRows != 1 {
+		t.Fatalf("tag cleanup=(joins:%d tagRows:%d) want (0,1)", tagJoins, tagRows)
+	}
+
+	sprintAfter, err := st.GetSprintByID(ctx, sprint.ID)
+	if err != nil {
+		t.Fatalf("GetSprintByID after delete: %v", err)
+	}
+	if !reflect.DeepEqual(sprintAfter, sprintBefore) {
+		t.Fatalf("sprint changed: before=%+v after=%+v", sprintBefore, sprintAfter)
+	}
+	prioritiesAfter, err := st.GetProjectPriorities(ctx, project.ID)
+	if err != nil {
+		t.Fatalf("GetProjectPriorities after delete: %v", err)
+	}
+	if !reflect.DeepEqual(prioritiesAfter, prioritiesBefore) {
+		t.Fatalf("priority tiers changed: before=%+v after=%+v", prioritiesBefore, prioritiesAfter)
+	}
+
+	var ledgerAfter int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM todo_assignee_events WHERE todo_id = ?`, target.ID).Scan(&ledgerAfter); err != nil {
+		t.Fatalf("count assignee ledger after delete: %v", err)
+	}
+	if ledgerAfter != ledgerBefore {
+		t.Fatalf("assignee ledger rows=%d want retained %d", ledgerAfter, ledgerBefore)
+	}
+
+	var (
+		auditCount     int
+		auditProjectID int64
+		auditActor     sql.NullInt64
+		targetType     string
+		targetID       sql.NullInt64
+		metadataJSON   string
+	)
+	if err := sqlDB.QueryRow(`
+		SELECT COUNT(*), MIN(project_id), MIN(actor_user_id), MIN(target_type), MIN(target_id), MIN(metadata)
+		FROM audit_events
+		WHERE action = 'todo_deleted' AND target_type = 'todo' AND target_id = ?`, target.ID).
+		Scan(&auditCount, &auditProjectID, &auditActor, &targetType, &targetID, &metadataJSON); err != nil {
+		t.Fatalf("read delete audit: %v", err)
+	}
+	if auditCount != 1 || auditProjectID != project.ID || !auditActor.Valid || auditActor.Int64 != owner.ID || targetType != "todo" || !targetID.Valid || targetID.Int64 != target.ID {
+		t.Fatalf("delete audit mismatch count=%d project=%d actor=%+v type=%q target=%+v", auditCount, auditProjectID, auditActor, targetType, targetID)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil {
+		t.Fatalf("decode delete audit metadata: %v", err)
+	}
+	if got := int64(metadata["local_id"].(float64)); got != target.LocalID {
+		t.Fatalf("audit local_id=%d want %d", got, target.LocalID)
+	}
+	if got := metadata["column_key"]; got != target.ColumnKey {
+		t.Fatalf("audit column_key=%v want %q", got, target.ColumnKey)
+	}
+	var linkRemoved int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM audit_events WHERE action = 'link_removed' AND project_id = ?`, project.ID).Scan(&linkRemoved); err != nil {
+		t.Fatalf("count link_removed audits: %v", err)
+	}
+	if linkRemoved != 0 {
+		t.Fatalf("implicit todo deletion produced %d link_removed audits", linkRemoved)
+	}
+
+	var updatedAt, lastActivityAt int64
+	if err := sqlDB.QueryRow(`SELECT updated_at, last_activity_at FROM projects WHERE id = ?`, project.ID).Scan(&updatedAt, &lastActivityAt); err != nil {
+		t.Fatalf("read project timestamps: %v", err)
+	}
+	if updatedAt <= oldMs {
+		t.Fatalf("project updated_at=%d did not advance past %d", updatedAt, oldMs)
+	}
+	if lastActivityAt <= oldMs {
+		t.Fatalf("project last_activity_at=%d did not advance past %d", lastActivityAt, oldMs)
+	}
+}
+
+func TestDeleteTodoByLocalID_RollsBackOnDeleteFailure(t *testing.T) {
+	st, sqlDB, cleanup := newTestStoreWithSQL(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	owner, err := st.BootstrapUser(ctx, "owner@example.com", "password", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	ownerCtx := WithUserID(ctx, owner.ID)
+	project, err := st.CreateProject(ownerCtx, "Todo delete rollback")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	target := mustCreateDeletionTodo(t, st, ownerCtx, project.ID, "Delete target")
+	outbound := mustCreateDeletionTodo(t, st, ownerCtx, project.ID, "Outbound")
+	inbound := mustCreateDeletionTodo(t, st, ownerCtx, project.ID, "Inbound")
+	if err := st.AddLink(ownerCtx, project.ID, target.LocalID, outbound.LocalID, "blocks", ModeFull); err != nil {
+		t.Fatalf("AddLink outbound: %v", err)
+	}
+	if err := st.AddLink(ownerCtx, project.ID, inbound.LocalID, target.LocalID, "relates_to", ModeFull); err != nil {
+		t.Fatalf("AddLink inbound: %v", err)
+	}
+
+	oldMs := time.Now().UTC().Add(-time.Hour).UnixMilli()
+	if _, err := sqlDB.Exec(`UPDATE projects SET updated_at = ?, last_activity_at = ? WHERE id = ?`, oldMs, oldMs, project.ID); err != nil {
+		t.Fatalf("seed project timestamps: %v", err)
+	}
+	if _, err := sqlDB.Exec(`
+		CREATE TRIGGER phase21_abort_todo_delete
+		BEFORE DELETE ON todos
+		BEGIN
+			SELECT RAISE(ABORT, 'forced todo delete failure');
+		END`); err != nil {
+		t.Fatalf("create aborting trigger: %v", err)
+	}
+	defer func() {
+		if _, err := sqlDB.Exec(`DROP TRIGGER IF EXISTS phase21_abort_todo_delete`); err != nil {
+			t.Errorf("drop aborting trigger: %v", err)
+		}
+	}()
+
+	err = st.DeleteTodoByLocalID(ownerCtx, project.ID, target.LocalID, ModeFull)
+	if err == nil {
+		t.Fatal("DeleteTodoByLocalID unexpectedly succeeded")
+	}
+
+	var todoRows, linkRows, audits int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM todos WHERE id = ?`, target.ID).Scan(&todoRows); err != nil {
+		t.Fatalf("count todo: %v", err)
+	}
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM todo_links WHERE project_id = ? AND (from_local_id = ? OR to_local_id = ?)`, project.ID, target.LocalID, target.LocalID).Scan(&linkRows); err != nil {
+		t.Fatalf("count links: %v", err)
+	}
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM audit_events WHERE action = 'todo_deleted' AND target_id = ?`, target.ID).Scan(&audits); err != nil {
+		t.Fatalf("count delete audits: %v", err)
+	}
+	if todoRows != 1 || linkRows != 2 || audits != 0 {
+		t.Fatalf("rollback state todo=%d links=%d audits=%d want 1,2,0", todoRows, linkRows, audits)
+	}
+	var updatedAt, lastActivityAt int64
+	if err := sqlDB.QueryRow(`SELECT updated_at, last_activity_at FROM projects WHERE id = ?`, project.ID).Scan(&updatedAt, &lastActivityAt); err != nil {
+		t.Fatalf("read project timestamps: %v", err)
+	}
+	if updatedAt != oldMs || lastActivityAt != oldMs {
+		t.Fatalf("failed delete changed project timestamps updated_at=%d last_activity_at=%d want %d", updatedAt, lastActivityAt, oldMs)
+	}
+}
+
+func TestDeleteTodo_ActivityFailureDoesNotReverseCommittedDelete(t *testing.T) {
+	st, sqlDB, cleanup := newTestStoreWithSQL(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	owner, err := st.BootstrapUser(ctx, "owner@example.com", "password", "Owner")
+	if err != nil {
+		t.Fatalf("BootstrapUser: %v", err)
+	}
+	ownerCtx := WithUserID(ctx, owner.ID)
+	project, err := st.CreateProject(ownerCtx, "Todo activity failure")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	target := mustCreateDeletionTodo(t, st, ownerCtx, project.ID, "Delete target")
+
+	oldMs := time.Now().UTC().Add(-time.Hour).UnixMilli()
+	if _, err := sqlDB.Exec(`UPDATE projects SET updated_at = ?, last_activity_at = ? WHERE id = ?`, oldMs, oldMs, project.ID); err != nil {
+		t.Fatalf("seed project timestamps: %v", err)
+	}
+	if _, err := sqlDB.Exec(`
+		CREATE TRIGGER phase21_abort_board_activity
+		BEFORE UPDATE OF last_activity_at ON projects
+		BEGIN
+			SELECT RAISE(ABORT, 'forced board activity failure');
+		END`); err != nil {
+		t.Fatalf("create activity trigger: %v", err)
+	}
+	defer func() {
+		if _, err := sqlDB.Exec(`DROP TRIGGER IF EXISTS phase21_abort_board_activity`); err != nil {
+			t.Errorf("drop activity trigger: %v", err)
+		}
+	}()
+
+	if err := st.DeleteTodo(ownerCtx, target.ID, ModeFull); err != nil {
+		t.Fatalf("DeleteTodo returned activity failure: %v", err)
+	}
+
+	var todoRows, audits int
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM todos WHERE id = ?`, target.ID).Scan(&todoRows); err != nil {
+		t.Fatalf("count todo: %v", err)
+	}
+	if err := sqlDB.QueryRow(`SELECT COUNT(*) FROM audit_events WHERE action = 'todo_deleted' AND target_id = ?`, target.ID).Scan(&audits); err != nil {
+		t.Fatalf("count delete audits: %v", err)
+	}
+	if todoRows != 0 || audits != 1 {
+		t.Fatalf("committed delete state todo=%d audits=%d want 0,1", todoRows, audits)
+	}
+	var updatedAt, lastActivityAt int64
+	if err := sqlDB.QueryRow(`SELECT updated_at, last_activity_at FROM projects WHERE id = ?`, project.ID).Scan(&updatedAt, &lastActivityAt); err != nil {
+		t.Fatalf("read project timestamps: %v", err)
+	}
+	if updatedAt <= oldMs {
+		t.Fatalf("transactional project touch did not commit: updated_at=%d old=%d", updatedAt, oldMs)
+	}
+	if lastActivityAt != oldMs {
+		t.Fatalf("failed best-effort activity update changed last_activity_at=%d want %d", lastActivityAt, oldMs)
+	}
+
+	if _, err := st.GetTodoByLocalID(ownerCtx, project.ID, target.LocalID, ModeFull); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetTodoByLocalID after committed delete err=%v want ErrNotFound", err)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.31.1"
+const Version = "3.31.2"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
Canonical REST and MCP Todo deletion are application-service-owned; persistence/audit remain store-owned; REST refresh ownership is centralized in the REST deletion service; MCP remains realtime-silent; all remaining direct global-ID mutation orchestration will be handled in the next phase.