### PR TITLE
Refactor/legacy todo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.31.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags), **3.29.0** (MCP JSON-RPC error/`board_get` identity), **3.30.0** (reversible per-project sprint capability), **3.31.0** (per-project priority tiers) - see those releases.
 
+## [3.31.5] - 2026-08-13
+
+### Changed
+
+- **Legacy todo mutations move behind application services** - Numeric
+  compatibility REST routes for todo update, move, and delete now share
+  `internal/application/todo` command boundaries (`LegacyUpdateService`,
+  `LegacyMoveService`, `LegacyDeleteService`) instead of owning call logic in
+  the HTTP transport. Adapters stay thin wrappers; permissions, validation,
+  response shapes, and board-refresh side effects are preserved. Contract tests
+  lock the migrated legacy mutation paths.
+
 ## [3.31.4] - 2026-08-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.31.4-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.31.5-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/internal/application/todo/legacy_delete.go
+++ b/internal/application/todo/legacy_delete.go
@@ -1,0 +1,95 @@
+package todo
+
+import (
+	"context"
+
+	"scrumboy/internal/store"
+)
+
+// LegacyDeleteProjectStore is the project lookup capability required by the
+// numeric compatibility DELETE route. TodoID is the global todos.id identity.
+type LegacyDeleteProjectStore interface {
+	GetProjectIDForTodo(ctx context.Context, todoID int64) (int64, error)
+}
+
+// LegacyGlobalDeleteStore is the persistence capability required by the
+// numeric compatibility DELETE route. TodoID is the global todos.id identity.
+type LegacyGlobalDeleteStore interface {
+	DeleteTodo(ctx context.Context, todoID int64, mode store.Mode) error
+}
+
+// LegacyDeleteServiceDependencies names the pre-delete project lookup,
+// global-ID deletion, and REST refresh capabilities used by the numeric
+// DELETE compatibility use case.
+type LegacyDeleteServiceDependencies struct {
+	Projects LegacyDeleteProjectStore
+	Delete   LegacyGlobalDeleteStore
+	Refresh  BoardRefreshPublisher
+}
+
+// LegacyDeleteService preserves the numeric DELETE route's existing
+// project-lookup, global-ID deletion, and post-commit refresh sequence.
+// Authorization and durable side effects remain store-owned.
+type LegacyDeleteService struct {
+	projects LegacyDeleteProjectStore
+	delete   LegacyGlobalDeleteStore
+	refresh  BoardRefreshPublisher
+}
+
+func NewLegacyDeleteService(deps LegacyDeleteServiceDependencies) *LegacyDeleteService {
+	refresh := deps.Refresh
+	if refresh == nil {
+		refresh = nopBoardRefreshPublisher{}
+	}
+	return &LegacyDeleteService{
+		projects: deps.Projects,
+		delete:   deps.Delete,
+		refresh:  refresh,
+	}
+}
+
+// LegacyDeleteTarget carries the global Todo identity and store mode already
+// selected by the numeric REST adapter. TodoID is the global todos.id identity.
+type LegacyDeleteTarget struct {
+	TodoID int64
+	Mode   store.Mode
+}
+
+// PreparedLegacyDelete binds the request context, global Todo ID, pre-read
+// project ID, and mode for the subsequent deletion.
+type PreparedLegacyDelete struct {
+	ctx       context.Context
+	service   *LegacyDeleteService
+	todoID    int64
+	projectID int64
+	mode      store.Mode
+}
+
+// Prepare resolves the project ID exactly once before deletion, preserving
+// the compatibility route's existing two-step sequence. It performs no
+// authorization, validation, deletion, or identity translation.
+func (s *LegacyDeleteService) Prepare(ctx context.Context, target LegacyDeleteTarget) (*PreparedLegacyDelete, error) {
+	projectID, err := s.projects.GetProjectIDForTodo(ctx, target.TodoID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PreparedLegacyDelete{
+		ctx:       ctx,
+		service:   s,
+		todoID:    target.TodoID,
+		projectID: projectID,
+		mode:      target.Mode,
+	}, nil
+}
+
+// Delete performs exactly one global-ID deletion and publishes one board
+// refresh using the project ID captured before the Todo is removed.
+func (d *PreparedLegacyDelete) Delete() error {
+	if err := d.service.delete.DeleteTodo(d.ctx, d.todoID, d.mode); err != nil {
+		return err
+	}
+
+	d.service.refresh.PublishBoardRefresh(d.ctx, d.projectID, RefreshReasonTodoDeleted)
+	return nil
+}

--- a/internal/application/todo/legacy_delete_test.go
+++ b/internal/application/todo/legacy_delete_test.go
@@ -1,0 +1,303 @@
+package todo
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+var (
+	_ LegacyDeleteProjectStore = (*store.Store)(nil)
+	_ LegacyGlobalDeleteStore  = (*store.Store)(nil)
+)
+
+type legacyDeleteProjectLookupCall struct {
+	ctx    context.Context
+	todoID int64
+}
+
+type legacyDeleteProjectLookupFake struct {
+	calls     []legacyDeleteProjectLookupCall
+	projectID int64
+	err       error
+	trace     *[]string
+}
+
+func (f *legacyDeleteProjectLookupFake) GetProjectIDForTodo(ctx context.Context, todoID int64) (int64, error) {
+	f.calls = append(f.calls, legacyDeleteProjectLookupCall{ctx: ctx, todoID: todoID})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "lookup")
+	}
+	if f.err != nil {
+		return 0, f.err
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	return f.projectID, nil
+}
+
+type legacyDeleteStoreCall struct {
+	ctx    context.Context
+	todoID int64
+	mode   store.Mode
+}
+
+type legacyDeleteStoreFake struct {
+	calls []legacyDeleteStoreCall
+	err   error
+	trace *[]string
+}
+
+func (f *legacyDeleteStoreFake) DeleteTodo(ctx context.Context, todoID int64, mode store.Mode) error {
+	f.calls = append(f.calls, legacyDeleteStoreCall{ctx: ctx, todoID: todoID, mode: mode})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "delete")
+	}
+	if f.err != nil {
+		return f.err
+	}
+	return ctx.Err()
+}
+
+type legacyDeleteRefreshCall struct {
+	ctx       context.Context
+	projectID int64
+	reason    string
+}
+
+type legacyDeleteRefreshFake struct {
+	calls []legacyDeleteRefreshCall
+	trace *[]string
+}
+
+func (f *legacyDeleteRefreshFake) PublishBoardRefresh(ctx context.Context, projectID int64, reason string) {
+	f.calls = append(f.calls, legacyDeleteRefreshCall{ctx: ctx, projectID: projectID, reason: reason})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "refresh")
+	}
+}
+
+func TestLegacyDeleteServicePrepareBindsGlobalIDProjectMode(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx := context.WithValue(context.Background(), key, "bound")
+	projects := &legacyDeleteProjectLookupFake{projectID: 17}
+	deletes := &legacyDeleteStoreFake{}
+	refresh := &legacyDeleteRefreshFake{}
+	service := NewLegacyDeleteService(LegacyDeleteServiceDependencies{
+		Projects: projects,
+		Delete:   deletes,
+		Refresh:  refresh,
+	})
+	target := LegacyDeleteTarget{TodoID: 0, Mode: store.ModeAnonymous}
+
+	prepared, err := service.Prepare(ctx, target)
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if len(projects.calls) != 1 {
+		t.Fatalf("project lookup calls = %d, want 1", len(projects.calls))
+	}
+	lookup := projects.calls[0]
+	if lookup.ctx != ctx || lookup.ctx.Value(key) != "bound" || lookup.todoID != 0 {
+		t.Fatalf("project lookup = %+v, want bound context and unvalidated global Todo ID 0", lookup)
+	}
+	if len(deletes.calls) != 0 || len(refresh.calls) != 0 {
+		t.Fatalf("Prepare calls = delete %d refresh %d, want 0 each", len(deletes.calls), len(refresh.calls))
+	}
+
+	target.TodoID = 91
+	target.Mode = store.ModeFull
+	if err := prepared.Delete(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(deletes.calls) != 1 {
+		t.Fatalf("delete calls = %d, want 1", len(deletes.calls))
+	}
+	deleteCall := deletes.calls[0]
+	if deleteCall.ctx != ctx || deleteCall.ctx.Value(key) != "bound" || deleteCall.todoID != 0 || deleteCall.mode != store.ModeAnonymous {
+		t.Fatalf("delete call = %+v, want bound context, global Todo ID 0, mode %q", deleteCall, store.ModeAnonymous)
+	}
+	if len(refresh.calls) != 1 || refresh.calls[0].projectID != 17 {
+		t.Fatalf("refresh calls = %+v, want pre-read project 17", refresh.calls)
+	}
+}
+
+func TestLegacyDeleteServiceLookupFailureStopsBeforeDelete(t *testing.T) {
+	wantErr := errors.New("legacy delete project lookup failed")
+	projects := &legacyDeleteProjectLookupFake{err: wantErr}
+	deletes := &legacyDeleteStoreFake{}
+	refresh := &legacyDeleteRefreshFake{}
+	service := NewLegacyDeleteService(LegacyDeleteServiceDependencies{
+		Projects: projects,
+		Delete:   deletes,
+		Refresh:  refresh,
+	})
+
+	prepared, err := service.Prepare(context.Background(), LegacyDeleteTarget{TodoID: 7001, Mode: store.ModeFull})
+	if err != wantErr {
+		t.Fatalf("Prepare error = %v, want identical %v", err, wantErr)
+	}
+	if prepared != nil {
+		t.Fatalf("prepared = %#v, want nil", prepared)
+	}
+	if len(projects.calls) != 1 || len(deletes.calls) != 0 || len(refresh.calls) != 0 {
+		t.Fatalf("calls = lookup %d delete %d refresh %d, want 1, 0, 0", len(projects.calls), len(deletes.calls), len(refresh.calls))
+	}
+}
+
+func TestLegacyDeleteServiceSuccessSequencesLookupDeleteRefresh(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx := context.WithValue(context.Background(), key, "bound")
+	trace := []string{}
+	projects := &legacyDeleteProjectLookupFake{projectID: 17, trace: &trace}
+	deletes := &legacyDeleteStoreFake{trace: &trace}
+	refresh := &legacyDeleteRefreshFake{trace: &trace}
+	service := NewLegacyDeleteService(LegacyDeleteServiceDependencies{
+		Projects: projects,
+		Delete:   deletes,
+		Refresh:  refresh,
+	})
+
+	prepared, err := service.Prepare(ctx, LegacyDeleteTarget{TodoID: 7001, Mode: store.ModeFull})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if err := prepared.Delete(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if !reflect.DeepEqual(trace, []string{"lookup", "delete", "refresh"}) {
+		t.Fatalf("trace = %#v, want lookup, delete, refresh", trace)
+	}
+	if len(projects.calls) != 1 || len(deletes.calls) != 1 || len(refresh.calls) != 1 {
+		t.Fatalf("calls = lookup %d delete %d refresh %d, want 1 each", len(projects.calls), len(deletes.calls), len(refresh.calls))
+	}
+	if projects.calls[0].ctx != ctx || deletes.calls[0].ctx != ctx || refresh.calls[0].ctx != ctx {
+		t.Fatal("lookup, delete, and refresh did not receive the bound context")
+	}
+	if projects.calls[0].todoID != 7001 || deletes.calls[0].todoID != 7001 || deletes.calls[0].mode != store.ModeFull {
+		t.Fatalf("global identity/mode = lookup %+v delete %+v, want Todo 7001 mode %q", projects.calls[0], deletes.calls[0], store.ModeFull)
+	}
+	if got := refresh.calls[0]; got.ctx.Value(key) != "bound" || got.projectID != 17 || got.reason != RefreshReasonTodoDeleted {
+		t.Fatalf("refresh = %+v, want bound context, pre-read project 17, reason %q", got, RefreshReasonTodoDeleted)
+	}
+}
+
+func TestLegacyDeleteServiceDeleteFailureReturnsSameErrorAndSkipsRefresh(t *testing.T) {
+	wantErr := errors.New("legacy global delete failed")
+	trace := []string{}
+	projects := &legacyDeleteProjectLookupFake{projectID: 17, trace: &trace}
+	deletes := &legacyDeleteStoreFake{err: wantErr, trace: &trace}
+	refresh := &legacyDeleteRefreshFake{trace: &trace}
+	service := NewLegacyDeleteService(LegacyDeleteServiceDependencies{
+		Projects: projects,
+		Delete:   deletes,
+		Refresh:  refresh,
+	})
+
+	prepared, err := service.Prepare(context.Background(), LegacyDeleteTarget{TodoID: 7001, Mode: store.ModeFull})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	err = prepared.Delete()
+	if err != wantErr {
+		t.Fatalf("Delete error = %v, want identical %v", err, wantErr)
+	}
+	if !reflect.DeepEqual(trace, []string{"lookup", "delete"}) {
+		t.Fatalf("trace = %#v, want lookup then delete", trace)
+	}
+	if len(projects.calls) != 1 || len(deletes.calls) != 1 || len(refresh.calls) != 0 {
+		t.Fatalf("calls = lookup %d delete %d refresh %d, want 1, 1, 0", len(projects.calls), len(deletes.calls), len(refresh.calls))
+	}
+}
+
+func TestLegacyDeleteServiceCancellationBeforePrepareLookup(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), key, "bound"))
+	cancel()
+	projects := &legacyDeleteProjectLookupFake{projectID: 17}
+	deletes := &legacyDeleteStoreFake{}
+	refresh := &legacyDeleteRefreshFake{}
+	service := NewLegacyDeleteService(LegacyDeleteServiceDependencies{
+		Projects: projects,
+		Delete:   deletes,
+		Refresh:  refresh,
+	})
+
+	prepared, err := service.Prepare(ctx, LegacyDeleteTarget{TodoID: 7001, Mode: store.ModeFull})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Prepare error = %v, want context canceled", err)
+	}
+	if prepared != nil {
+		t.Fatalf("prepared = %#v, want nil", prepared)
+	}
+	if len(projects.calls) != 1 {
+		t.Fatalf("project lookup calls = %d, want 1", len(projects.calls))
+	}
+	if got := projects.calls[0].ctx; got != ctx || got.Value(key) != "bound" || !errors.Is(got.Err(), context.Canceled) {
+		t.Fatalf("lookup context = %v, want bound cancelled context", got)
+	}
+	if len(deletes.calls) != 0 || len(refresh.calls) != 0 {
+		t.Fatalf("calls = delete %d refresh %d, want 0 each", len(deletes.calls), len(refresh.calls))
+	}
+}
+
+func TestLegacyDeleteServiceCancellationAfterPrepareBeforeDelete(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), key, "bound"))
+	projects := &legacyDeleteProjectLookupFake{projectID: 17}
+	deletes := &legacyDeleteStoreFake{}
+	refresh := &legacyDeleteRefreshFake{}
+	service := NewLegacyDeleteService(LegacyDeleteServiceDependencies{
+		Projects: projects,
+		Delete:   deletes,
+		Refresh:  refresh,
+	})
+
+	prepared, err := service.Prepare(ctx, LegacyDeleteTarget{TodoID: 7001, Mode: store.ModeFull})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	cancel()
+
+	err = prepared.Delete()
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Delete error = %v, want context canceled", err)
+	}
+	if len(projects.calls) != 1 || len(deletes.calls) != 1 {
+		t.Fatalf("calls = lookup %d delete %d, want 1 each", len(projects.calls), len(deletes.calls))
+	}
+	if got := deletes.calls[0].ctx; got != ctx || got.Value(key) != "bound" || !errors.Is(got.Err(), context.Canceled) {
+		t.Fatalf("delete context = %v, want bound cancelled context", got)
+	}
+	if len(refresh.calls) != 0 {
+		t.Fatalf("refresh calls = %d, want 0", len(refresh.calls))
+	}
+}
+
+func TestLegacyDeleteServiceNilRefreshIsSafe(t *testing.T) {
+	projects := &legacyDeleteProjectLookupFake{projectID: 17}
+	deletes := &legacyDeleteStoreFake{}
+	service := NewLegacyDeleteService(LegacyDeleteServiceDependencies{
+		Projects: projects,
+		Delete:   deletes,
+	})
+
+	prepared, err := service.Prepare(context.Background(), LegacyDeleteTarget{TodoID: 7001, Mode: store.ModeFull})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if err := prepared.Delete(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(projects.calls) != 1 || len(deletes.calls) != 1 {
+		t.Fatalf("calls = lookup %d delete %d, want 1 each", len(projects.calls), len(deletes.calls))
+	}
+}

--- a/internal/application/todo/legacy_move.go
+++ b/internal/application/todo/legacy_move.go
@@ -1,0 +1,103 @@
+package todo
+
+import (
+	"context"
+
+	"scrumboy/internal/store"
+)
+
+// LegacyMoveStore is the persistence capability required by the numeric
+// compatibility MOVE route. TodoID, afterID, and beforeID are global todos.id
+// identities.
+type LegacyMoveStore interface {
+	MoveTodo(
+		ctx context.Context,
+		todoID int64,
+		toColumnKey string,
+		afterID *int64,
+		beforeID *int64,
+		mode store.Mode,
+	) (store.Todo, error)
+}
+
+// LegacyMoveCommand preserves the numeric MOVE vocabulary. TodoID is the
+// global ID of the moving Todo; AfterTodoID and BeforeTodoID are global IDs
+// of the optional anchors.
+type LegacyMoveCommand struct {
+	TodoID       int64
+	ToColumnKey  string
+	AfterTodoID  *int64
+	BeforeTodoID *int64
+}
+
+// LegacyMoveResult returns only the persisted domain value needed by the
+// numeric HTTP adapter's existing projection.
+type LegacyMoveResult struct {
+	Todo store.Todo
+}
+
+// LegacyMoveServiceDependencies names the global move and REST refresh
+// capabilities used by the numeric MOVE compatibility use case.
+type LegacyMoveServiceDependencies struct {
+	Move    LegacyMoveStore
+	Refresh BoardRefreshPublisher
+}
+
+// LegacyMoveService owns global-ID move persistence and post-commit refresh
+// sequencing. Validation, authorization, anchor resolution, and projection
+// remain in the HTTP adapter or store.
+type LegacyMoveService struct {
+	move    LegacyMoveStore
+	refresh BoardRefreshPublisher
+}
+
+func NewLegacyMoveService(deps LegacyMoveServiceDependencies) *LegacyMoveService {
+	refresh := deps.Refresh
+	if refresh == nil {
+		refresh = nopBoardRefreshPublisher{}
+	}
+	return &LegacyMoveService{move: deps.Move, refresh: refresh}
+}
+
+// LegacyMoveTarget carries only the store mode already selected by the
+// numeric REST adapter. The compatibility route has no resolved project
+// context before its authoritative global-ID mutation.
+type LegacyMoveTarget struct {
+	Mode store.Mode
+}
+
+// PreparedLegacyMove binds the request context and mode without performing
+// lookup, validation, authorization, or identity translation.
+type PreparedLegacyMove struct {
+	ctx     context.Context
+	service *LegacyMoveService
+	mode    store.Mode
+}
+
+// Prepare performs no persistence or access resolution.
+func (s *LegacyMoveService) Prepare(ctx context.Context, target LegacyMoveTarget) *PreparedLegacyMove {
+	return &PreparedLegacyMove{
+		ctx:     ctx,
+		service: s,
+		mode:    target.Mode,
+	}
+}
+
+// Move forwards the global Todo and anchor identities to the authoritative
+// store mutation exactly once, then publishes one board refresh on success.
+func (m *PreparedLegacyMove) Move(command LegacyMoveCommand) (LegacyMoveResult, error) {
+	moved, err := m.service.move.MoveTodo(
+		m.ctx,
+		command.TodoID,
+		command.ToColumnKey,
+		command.AfterTodoID,
+		command.BeforeTodoID,
+		m.mode,
+	)
+	if err != nil {
+		return LegacyMoveResult{}, err
+	}
+
+	m.service.refresh.PublishBoardRefresh(m.ctx, moved.ProjectID, RefreshReasonTodoMoved)
+	return LegacyMoveResult{Todo: moved}, nil
+}

--- a/internal/application/todo/legacy_move_test.go
+++ b/internal/application/todo/legacy_move_test.go
@@ -1,0 +1,293 @@
+package todo
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+var _ LegacyMoveStore = (*store.Store)(nil)
+
+type legacyMoveStoreCall struct {
+	ctx          context.Context
+	todoID       int64
+	toColumnKey  string
+	afterTodoID  *int64
+	beforeTodoID *int64
+	mode         store.Mode
+}
+
+type legacyMoveStoreFake struct {
+	calls []legacyMoveStoreCall
+	todo  store.Todo
+	err   error
+	trace *[]string
+}
+
+func (f *legacyMoveStoreFake) MoveTodo(
+	ctx context.Context,
+	todoID int64,
+	toColumnKey string,
+	afterTodoID *int64,
+	beforeTodoID *int64,
+	mode store.Mode,
+) (store.Todo, error) {
+	f.calls = append(f.calls, legacyMoveStoreCall{
+		ctx:          ctx,
+		todoID:       todoID,
+		toColumnKey:  toColumnKey,
+		afterTodoID:  afterTodoID,
+		beforeTodoID: beforeTodoID,
+		mode:         mode,
+	})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "move")
+	}
+	if f.err != nil {
+		return store.Todo{}, f.err
+	}
+	if err := ctx.Err(); err != nil {
+		return store.Todo{}, err
+	}
+	return f.todo, nil
+}
+
+type legacyMoveRefreshCall struct {
+	ctx       context.Context
+	projectID int64
+	reason    string
+}
+
+type legacyMoveRefreshFake struct {
+	calls []legacyMoveRefreshCall
+	trace *[]string
+}
+
+func (f *legacyMoveRefreshFake) PublishBoardRefresh(ctx context.Context, projectID int64, reason string) {
+	f.calls = append(f.calls, legacyMoveRefreshCall{ctx: ctx, projectID: projectID, reason: reason})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "refresh")
+	}
+}
+
+func legacyMoveInt64(value int64) *int64 {
+	return &value
+}
+
+func TestLegacyMoveServicePrepareBindsContextModeWithoutPersistence(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx := context.WithValue(context.Background(), key, "bound")
+	moves := &legacyMoveStoreFake{todo: store.Todo{ID: 71, ProjectID: 9}}
+	service := NewLegacyMoveService(LegacyMoveServiceDependencies{Move: moves})
+	target := LegacyMoveTarget{Mode: store.ModeAnonymous}
+
+	prepared := service.Prepare(ctx, target)
+	if len(moves.calls) != 0 {
+		t.Fatalf("Prepare made %d persistence calls, want 0", len(moves.calls))
+	}
+	target.Mode = store.ModeFull
+
+	result, err := prepared.Move(LegacyMoveCommand{TodoID: 0})
+	if err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	if len(moves.calls) != 1 {
+		t.Fatalf("move calls = %d, want 1", len(moves.calls))
+	}
+	call := moves.calls[0]
+	if call.ctx != ctx || call.ctx.Value(key) != "bound" {
+		t.Fatalf("store context = %v, want prepared context", call.ctx)
+	}
+	if call.todoID != 0 {
+		t.Fatalf("global Todo ID = %d, want unvalidated 0", call.todoID)
+	}
+	if call.mode != store.ModeAnonymous {
+		t.Fatalf("store mode = %q, want bound %q", call.mode, store.ModeAnonymous)
+	}
+	if result.Todo.ID != 71 {
+		t.Fatalf("result = %+v, want moved Todo", result)
+	}
+}
+
+func TestLegacyMoveServiceForwardsGlobalAnchorsWithoutTranslationOrPrevalidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		command      LegacyMoveCommand
+		wantTodoID   int64
+		wantColumn   string
+		wantAfterID  *int64
+		wantBeforeID *int64
+	}{
+		{
+			name:        "after_global_id_only",
+			command:     LegacyMoveCommand{TodoID: 7001, ToColumnKey: "doing", AfterTodoID: legacyMoveInt64(9103)},
+			wantTodoID:  7001,
+			wantColumn:  "doing",
+			wantAfterID: legacyMoveInt64(9103),
+		},
+		{
+			name:         "before_global_id_only",
+			command:      LegacyMoveCommand{TodoID: 7001, ToColumnKey: "doing", BeforeTodoID: legacyMoveInt64(12107)},
+			wantTodoID:   7001,
+			wantColumn:   "doing",
+			wantBeforeID: legacyMoveInt64(12107),
+		},
+		{
+			name:         "both_global_ids",
+			command:      LegacyMoveCommand{TodoID: 7001, ToColumnKey: "doing", AfterTodoID: legacyMoveInt64(9103), BeforeTodoID: legacyMoveInt64(12107)},
+			wantTodoID:   7001,
+			wantColumn:   "doing",
+			wantAfterID:  legacyMoveInt64(9103),
+			wantBeforeID: legacyMoveInt64(12107),
+		},
+		{
+			name:        "self_anchor_forwarded",
+			command:     LegacyMoveCommand{TodoID: 7001, ToColumnKey: "doing", AfterTodoID: legacyMoveInt64(7001)},
+			wantTodoID:  7001,
+			wantColumn:  "doing",
+			wantAfterID: legacyMoveInt64(7001),
+		},
+		{
+			name:         "reversed_global_ids_forwarded",
+			command:      LegacyMoveCommand{TodoID: 7001, ToColumnKey: "doing", AfterTodoID: legacyMoveInt64(12107), BeforeTodoID: legacyMoveInt64(9103)},
+			wantTodoID:   7001,
+			wantColumn:   "doing",
+			wantAfterID:  legacyMoveInt64(12107),
+			wantBeforeID: legacyMoveInt64(9103),
+		},
+		{
+			name:         "empty_destination_and_unvalidated_anchors_forwarded",
+			command:      LegacyMoveCommand{TodoID: 0, AfterTodoID: legacyMoveInt64(-9), BeforeTodoID: legacyMoveInt64(0)},
+			wantTodoID:   0,
+			wantAfterID:  legacyMoveInt64(-9),
+			wantBeforeID: legacyMoveInt64(0),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			moves := &legacyMoveStoreFake{todo: store.Todo{ID: tt.wantTodoID, ProjectID: 17}}
+			prepared := NewLegacyMoveService(LegacyMoveServiceDependencies{Move: moves}).Prepare(
+				context.Background(),
+				LegacyMoveTarget{Mode: store.ModeFull},
+			)
+
+			if _, err := prepared.Move(tt.command); err != nil {
+				t.Fatalf("Move: %v", err)
+			}
+			if len(moves.calls) != 1 {
+				t.Fatalf("move calls = %d, want 1", len(moves.calls))
+			}
+			call := moves.calls[0]
+			if call.todoID != tt.wantTodoID || call.toColumnKey != tt.wantColumn || call.mode != store.ModeFull {
+				t.Fatalf("move call = %+v, want global Todo %d column %q mode %q", call, tt.wantTodoID, tt.wantColumn, store.ModeFull)
+			}
+			if !reflect.DeepEqual(call.afterTodoID, tt.wantAfterID) || !reflect.DeepEqual(call.beforeTodoID, tt.wantBeforeID) {
+				t.Fatalf("global anchors = after %v before %v, want after %v before %v", call.afterTodoID, call.beforeTodoID, tt.wantAfterID, tt.wantBeforeID)
+			}
+		})
+	}
+}
+
+func TestLegacyMoveServiceSuccessSequencesMoveBeforeRefresh(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx := context.WithValue(context.Background(), key, "bound")
+	trace := []string{}
+	moved := store.Todo{ID: 7001, ProjectID: 17, LocalID: 4, ColumnKey: "doing"}
+	moves := &legacyMoveStoreFake{todo: moved, trace: &trace}
+	refresh := &legacyMoveRefreshFake{trace: &trace}
+	prepared := NewLegacyMoveService(LegacyMoveServiceDependencies{Move: moves, Refresh: refresh}).Prepare(
+		ctx,
+		LegacyMoveTarget{Mode: store.ModeFull},
+	)
+
+	result, err := prepared.Move(LegacyMoveCommand{TodoID: 7001, ToColumnKey: "doing"})
+	if err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	if !reflect.DeepEqual(trace, []string{"move", "refresh"}) {
+		t.Fatalf("trace = %#v, want move then refresh", trace)
+	}
+	if len(moves.calls) != 1 || len(refresh.calls) != 1 {
+		t.Fatalf("calls = move %d refresh %d, want 1 each", len(moves.calls), len(refresh.calls))
+	}
+	if got := refresh.calls[0]; got.ctx != ctx || got.ctx.Value(key) != "bound" || got.projectID != moved.ProjectID || got.reason != RefreshReasonTodoMoved {
+		t.Fatalf("refresh call = %+v, want bound context, project %d, reason %q", got, moved.ProjectID, RefreshReasonTodoMoved)
+	}
+	if !reflect.DeepEqual(result, LegacyMoveResult{Todo: moved}) {
+		t.Fatalf("result = %+v, want moved Todo %+v", result, moved)
+	}
+}
+
+func TestLegacyMoveServiceStoreFailureReturnsSameErrorAndSkipsRefresh(t *testing.T) {
+	wantErr := errors.New("legacy move failed")
+	moves := &legacyMoveStoreFake{err: wantErr}
+	refresh := &legacyMoveRefreshFake{}
+	prepared := NewLegacyMoveService(LegacyMoveServiceDependencies{Move: moves, Refresh: refresh}).Prepare(
+		context.Background(),
+		LegacyMoveTarget{Mode: store.ModeFull},
+	)
+
+	result, err := prepared.Move(LegacyMoveCommand{TodoID: 7001, ToColumnKey: "doing"})
+	if err != wantErr {
+		t.Fatalf("Move error = %v, want identical %v", err, wantErr)
+	}
+	if !reflect.DeepEqual(result, LegacyMoveResult{}) {
+		t.Fatalf("result = %+v, want zero value", result)
+	}
+	if len(moves.calls) != 1 || len(refresh.calls) != 0 {
+		t.Fatalf("calls = move %d refresh %d, want 1 and 0", len(moves.calls), len(refresh.calls))
+	}
+}
+
+func TestLegacyMoveServiceCancellationAfterPrepareUsesBoundContext(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), key, "bound"))
+	moves := &legacyMoveStoreFake{}
+	refresh := &legacyMoveRefreshFake{}
+	prepared := NewLegacyMoveService(LegacyMoveServiceDependencies{Move: moves, Refresh: refresh}).Prepare(
+		ctx,
+		LegacyMoveTarget{Mode: store.ModeFull},
+	)
+	cancel()
+
+	_, err := prepared.Move(LegacyMoveCommand{TodoID: 7001, ToColumnKey: "doing"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Move error = %v, want context canceled", err)
+	}
+	if len(moves.calls) != 1 {
+		t.Fatalf("move calls = %d, want 1", len(moves.calls))
+	}
+	if got := moves.calls[0].ctx; got != ctx || got.Value(key) != "bound" || !errors.Is(got.Err(), context.Canceled) {
+		t.Fatalf("store context = %v, want bound cancelled context", got)
+	}
+	if len(refresh.calls) != 0 {
+		t.Fatalf("refresh calls = %d, want 0", len(refresh.calls))
+	}
+}
+
+func TestLegacyMoveServiceNilRefreshIsSafe(t *testing.T) {
+	moved := store.Todo{ID: 7001, ProjectID: 17, LocalID: 4, ColumnKey: "doing"}
+	moves := &legacyMoveStoreFake{todo: moved}
+	prepared := NewLegacyMoveService(LegacyMoveServiceDependencies{Move: moves}).Prepare(
+		context.Background(),
+		LegacyMoveTarget{Mode: store.ModeFull},
+	)
+
+	result, err := prepared.Move(LegacyMoveCommand{TodoID: 7001, ToColumnKey: "doing"})
+	if err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	if len(moves.calls) != 1 {
+		t.Fatalf("move calls = %d, want 1", len(moves.calls))
+	}
+	if !reflect.DeepEqual(result, LegacyMoveResult{Todo: moved}) {
+		t.Fatalf("result = %+v, want moved Todo %+v", result, moved)
+	}
+}

--- a/internal/application/todo/legacy_update.go
+++ b/internal/application/todo/legacy_update.go
@@ -1,0 +1,116 @@
+package todo
+
+import (
+	"context"
+
+	"scrumboy/internal/store"
+)
+
+// LegacyUpdateStore is the persistence capability required by the numeric
+// compatibility PATCH route. TodoID is the global todos.id identity.
+type LegacyUpdateStore interface {
+	UpdateTodo(
+		ctx context.Context,
+		todoID int64,
+		input store.UpdateTodoInput,
+		mode store.Mode,
+	) (store.Todo, error)
+}
+
+// LegacyUpdateCommand preserves the numeric PATCH vocabulary. TodoID is a
+// global Todo ID; the ordinary fields are replacement values, while
+// PriorityKey retains omitted/clear/set presence. Sprint mutation is
+// deliberately absent from this compatibility command.
+type LegacyUpdateCommand struct {
+	TodoID int64
+
+	Title            string
+	Body             string
+	Tags             []string
+	EstimationPoints *int64
+	AssigneeUserID   *int64
+	PriorityKey      Field[*string]
+}
+
+// LegacyUpdateResult returns only the persisted domain value needed by the
+// numeric HTTP adapter's existing projection.
+type LegacyUpdateResult struct {
+	Todo store.Todo
+}
+
+// LegacyUpdateServiceDependencies names the global update and REST refresh
+// capabilities used by the numeric PATCH compatibility use case.
+type LegacyUpdateServiceDependencies struct {
+	Update  LegacyUpdateStore
+	Refresh BoardRefreshPublisher
+}
+
+// LegacyUpdateService owns global-ID update persistence and post-commit
+// direct-refresh gating. Authorization and assignment publication remain in
+// the store; HTTP validation, error mapping, and projection remain adapters.
+type LegacyUpdateService struct {
+	update  LegacyUpdateStore
+	refresh BoardRefreshPublisher
+}
+
+func NewLegacyUpdateService(deps LegacyUpdateServiceDependencies) *LegacyUpdateService {
+	refresh := deps.Refresh
+	if refresh == nil {
+		refresh = nopBoardRefreshPublisher{}
+	}
+	return &LegacyUpdateService{update: deps.Update, refresh: refresh}
+}
+
+// LegacyUpdateTarget carries only the store mode already selected by the
+// numeric REST adapter. The compatibility route has no resolved project
+// context before its authoritative global-ID mutation.
+type LegacyUpdateTarget struct {
+	Mode store.Mode
+}
+
+// PreparedLegacyUpdate binds the request context and mode without performing
+// lookup, validation, or authorization.
+type PreparedLegacyUpdate struct {
+	ctx     context.Context
+	service *LegacyUpdateService
+	mode    store.Mode
+}
+
+// Prepare performs no persistence or access resolution.
+func (s *LegacyUpdateService) Prepare(ctx context.Context, target LegacyUpdateTarget) *PreparedLegacyUpdate {
+	return &PreparedLegacyUpdate{
+		ctx:     ctx,
+		service: s,
+		mode:    target.Mode,
+	}
+}
+
+// Update forwards the global Todo identity and replacement input to the
+// authoritative store mutation exactly once. A successful assignment change
+// relies on the store-owned assignment event; all other successes publish one
+// direct todo_updated board refresh.
+func (u *PreparedLegacyUpdate) Update(command LegacyUpdateCommand) (LegacyUpdateResult, error) {
+	var priorityKey *string
+	if command.PriorityKey.Present {
+		priorityKey = cloneUpdateStringPtr(command.PriorityKey.Value)
+	}
+	input := store.UpdateTodoInput{
+		Title:              command.Title,
+		Body:               command.Body,
+		Tags:               cloneUpdateStrings(command.Tags),
+		EstimationPoints:   cloneUpdateInt64Ptr(command.EstimationPoints),
+		AssigneeUserID:     cloneUpdateInt64Ptr(command.AssigneeUserID),
+		PriorityKey:        priorityKey,
+		PriorityKeyPresent: command.PriorityKey.Present,
+	}
+	updated, err := u.service.update.UpdateTodo(u.ctx, command.TodoID, input, u.mode)
+	if err != nil {
+		return LegacyUpdateResult{}, err
+	}
+
+	if !updated.AssignmentChanged {
+		u.service.refresh.PublishBoardRefresh(u.ctx, updated.ProjectID, RefreshReasonTodoUpdated)
+	}
+
+	return LegacyUpdateResult{Todo: updated}, nil
+}

--- a/internal/application/todo/legacy_update_test.go
+++ b/internal/application/todo/legacy_update_test.go
@@ -1,0 +1,294 @@
+package todo
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+var _ LegacyUpdateStore = (*store.Store)(nil)
+
+type legacyUpdateStoreCall struct {
+	ctx    context.Context
+	todoID int64
+	input  store.UpdateTodoInput
+	mode   store.Mode
+}
+
+type legacyUpdateStoreFake struct {
+	calls []legacyUpdateStoreCall
+	todo  store.Todo
+	err   error
+	trace *[]string
+}
+
+func (f *legacyUpdateStoreFake) UpdateTodo(
+	ctx context.Context,
+	todoID int64,
+	input store.UpdateTodoInput,
+	mode store.Mode,
+) (store.Todo, error) {
+	f.calls = append(f.calls, legacyUpdateStoreCall{ctx: ctx, todoID: todoID, input: input, mode: mode})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "update")
+	}
+	if f.err != nil {
+		return store.Todo{}, f.err
+	}
+	if err := ctx.Err(); err != nil {
+		return store.Todo{}, err
+	}
+	return f.todo, nil
+}
+
+type legacyUpdateRefreshCall struct {
+	ctx       context.Context
+	projectID int64
+	reason    string
+}
+
+type legacyUpdateRefreshFake struct {
+	calls []legacyUpdateRefreshCall
+	trace *[]string
+}
+
+func (f *legacyUpdateRefreshFake) PublishBoardRefresh(ctx context.Context, projectID int64, reason string) {
+	f.calls = append(f.calls, legacyUpdateRefreshCall{ctx: ctx, projectID: projectID, reason: reason})
+	if f.trace != nil {
+		*f.trace = append(*f.trace, "refresh")
+	}
+}
+
+func TestLegacyUpdateServicePrepareBindsContextModeAndForwardsGlobalID(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx := context.WithValue(context.Background(), key, "bound")
+	updates := &legacyUpdateStoreFake{todo: store.Todo{ID: 71, ProjectID: 9}}
+	service := NewLegacyUpdateService(LegacyUpdateServiceDependencies{Update: updates})
+	target := LegacyUpdateTarget{Mode: store.ModeAnonymous}
+
+	prepared := service.Prepare(ctx, target)
+	if len(updates.calls) != 0 {
+		t.Fatalf("Prepare made %d persistence calls, want 0", len(updates.calls))
+	}
+	target.Mode = store.ModeFull
+
+	result, err := prepared.Update(LegacyUpdateCommand{TodoID: 0, Title: "replacement"})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(updates.calls) != 1 {
+		t.Fatalf("update calls = %d, want 1", len(updates.calls))
+	}
+	call := updates.calls[0]
+	if call.ctx != ctx || call.ctx.Value(key) != "bound" {
+		t.Fatalf("store context = %v, want prepared context", call.ctx)
+	}
+	if call.todoID != 0 {
+		t.Fatalf("global Todo ID = %d, want unvalidated 0", call.todoID)
+	}
+	if call.mode != store.ModeAnonymous {
+		t.Fatalf("store mode = %q, want bound %q", call.mode, store.ModeAnonymous)
+	}
+	if result.Todo.ID != 71 {
+		t.Fatalf("result = %+v, want updated Todo", result)
+	}
+}
+
+func TestLegacyUpdateServiceMaterializesReplacementFields(t *testing.T) {
+	estimation := int64(8)
+	assignee := int64(42)
+	tags := []string{"legacy", "replacement"}
+	updates := &legacyUpdateStoreFake{todo: store.Todo{ProjectID: 5, AssignmentChanged: true}}
+	prepared := NewLegacyUpdateService(LegacyUpdateServiceDependencies{Update: updates}).Prepare(
+		context.Background(),
+		LegacyUpdateTarget{Mode: store.ModeFull},
+	)
+
+	_, err := prepared.Update(LegacyUpdateCommand{
+		TodoID:           7001,
+		Title:            "replacement title",
+		Body:             "replacement body",
+		Tags:             tags,
+		EstimationPoints: &estimation,
+		AssigneeUserID:   &assignee,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(updates.calls) != 1 {
+		t.Fatalf("update calls = %d, want 1", len(updates.calls))
+	}
+	input := updates.calls[0].input
+	if input.Title != "replacement title" || input.Body != "replacement body" {
+		t.Fatalf("replacement strings = title %q body %q", input.Title, input.Body)
+	}
+	if !reflect.DeepEqual(input.Tags, []string{"legacy", "replacement"}) {
+		t.Fatalf("replacement tags = %#v", input.Tags)
+	}
+	if input.EstimationPoints == nil || *input.EstimationPoints != 8 || input.AssigneeUserID == nil || *input.AssigneeUserID != 42 {
+		t.Fatalf("replacement pointers = estimation %v assignee %v", input.EstimationPoints, input.AssigneeUserID)
+	}
+	if input.SprintID != nil || input.ClearSprint {
+		t.Fatalf("legacy input acquired Sprint mutation: SprintID=%v ClearSprint=%v", input.SprintID, input.ClearSprint)
+	}
+	if input.Tags[0] == "" || &input.Tags[0] == &tags[0] || input.EstimationPoints == &estimation || input.AssigneeUserID == &assignee {
+		t.Fatal("materialized replacement values alias the command")
+	}
+	tags[0] = "mutated"
+	estimation = 13
+	assignee = 99
+	if !reflect.DeepEqual(input.Tags, []string{"legacy", "replacement"}) || *input.EstimationPoints != 8 || *input.AssigneeUserID != 42 {
+		t.Fatalf("store input changed after command mutation: %+v", input)
+	}
+}
+
+func TestLegacyUpdateServiceMaterializesPriorityPresence(t *testing.T) {
+	key := "urgent"
+	tests := []struct {
+		name        string
+		field       Field[*string]
+		wantPresent bool
+		wantKey     *string
+	}{
+		{name: "omitted", field: Field[*string]{Value: &key}},
+		{name: "clear", field: Field[*string]{Present: true}, wantPresent: true},
+		{name: "set", field: Field[*string]{Present: true, Value: &key}, wantPresent: true, wantKey: &key},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updates := &legacyUpdateStoreFake{todo: store.Todo{ProjectID: 5, AssignmentChanged: true}}
+			prepared := NewLegacyUpdateService(LegacyUpdateServiceDependencies{Update: updates}).Prepare(
+				context.Background(),
+				LegacyUpdateTarget{Mode: store.ModeFull},
+			)
+
+			if _, err := prepared.Update(LegacyUpdateCommand{TodoID: 7, Title: "title", PriorityKey: tt.field}); err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+			input := updates.calls[0].input
+			if input.PriorityKeyPresent != tt.wantPresent {
+				t.Fatalf("PriorityKeyPresent = %v, want %v", input.PriorityKeyPresent, tt.wantPresent)
+			}
+			if tt.wantKey == nil {
+				if input.PriorityKey != nil {
+					t.Fatalf("PriorityKey = %q, want nil", *input.PriorityKey)
+				}
+			} else {
+				if input.PriorityKey == nil || *input.PriorityKey != *tt.wantKey {
+					t.Fatalf("PriorityKey = %v, want %q", input.PriorityKey, *tt.wantKey)
+				}
+				if input.PriorityKey == tt.field.Value {
+					t.Fatal("materialized priority aliases the command")
+				}
+			}
+			if input.SprintID != nil || input.ClearSprint {
+				t.Fatalf("priority materialization acquired Sprint mutation: %+v", input)
+			}
+		})
+	}
+}
+
+func TestLegacyUpdateServiceSuccessSequencesUpdateBeforeRefresh(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx := context.WithValue(context.Background(), key, "bound")
+	trace := []string{}
+	updated := store.Todo{ID: 80, ProjectID: 17, LocalID: 4}
+	updates := &legacyUpdateStoreFake{todo: updated, trace: &trace}
+	refresh := &legacyUpdateRefreshFake{trace: &trace}
+	prepared := NewLegacyUpdateService(LegacyUpdateServiceDependencies{Update: updates, Refresh: refresh}).Prepare(
+		ctx,
+		LegacyUpdateTarget{Mode: store.ModeFull},
+	)
+
+	result, err := prepared.Update(LegacyUpdateCommand{TodoID: 80, Title: "updated"})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if !reflect.DeepEqual(trace, []string{"update", "refresh"}) {
+		t.Fatalf("trace = %#v, want update then refresh", trace)
+	}
+	if len(updates.calls) != 1 || len(refresh.calls) != 1 {
+		t.Fatalf("calls = update %d refresh %d, want 1 each", len(updates.calls), len(refresh.calls))
+	}
+	if got := refresh.calls[0]; got.ctx != ctx || got.ctx.Value(key) != "bound" || got.projectID != updated.ProjectID || got.reason != RefreshReasonTodoUpdated {
+		t.Fatalf("refresh call = %+v, want bound context, project %d, reason %q", got, updated.ProjectID, RefreshReasonTodoUpdated)
+	}
+	if result.Todo.ID != updated.ID {
+		t.Fatalf("result = %+v, want Todo %d", result, updated.ID)
+	}
+}
+
+func TestLegacyUpdateServiceAssignmentChangeSuppressesDirectRefresh(t *testing.T) {
+	updated := store.Todo{ID: 81, ProjectID: 17, AssignmentChanged: true}
+	updates := &legacyUpdateStoreFake{todo: updated}
+	refresh := &legacyUpdateRefreshFake{}
+	prepared := NewLegacyUpdateService(LegacyUpdateServiceDependencies{Update: updates, Refresh: refresh}).Prepare(
+		context.Background(),
+		LegacyUpdateTarget{Mode: store.ModeFull},
+	)
+
+	result, err := prepared.Update(LegacyUpdateCommand{TodoID: 81, Title: "assignment change"})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(updates.calls) != 1 || len(refresh.calls) != 0 {
+		t.Fatalf("calls = update %d refresh %d, want 1 and 0", len(updates.calls), len(refresh.calls))
+	}
+	if result.Todo.ID != updated.ID || !result.Todo.AssignmentChanged {
+		t.Fatalf("result = %+v, want successful assignment update", result)
+	}
+}
+
+func TestLegacyUpdateServiceStoreFailureReturnsSameErrorAndSkipsRefresh(t *testing.T) {
+	wantErr := errors.New("legacy update failed")
+	updates := &legacyUpdateStoreFake{err: wantErr}
+	refresh := &legacyUpdateRefreshFake{}
+	prepared := NewLegacyUpdateService(LegacyUpdateServiceDependencies{Update: updates, Refresh: refresh}).Prepare(
+		context.Background(),
+		LegacyUpdateTarget{Mode: store.ModeFull},
+	)
+
+	result, err := prepared.Update(LegacyUpdateCommand{TodoID: 91, Title: "failure"})
+	if err != wantErr {
+		t.Fatalf("Update error = %v, want identical %v", err, wantErr)
+	}
+	if !reflect.DeepEqual(result, LegacyUpdateResult{}) {
+		t.Fatalf("result = %+v, want zero value", result)
+	}
+	if len(updates.calls) != 1 || len(refresh.calls) != 0 {
+		t.Fatalf("calls = update %d refresh %d, want 1 and 0", len(updates.calls), len(refresh.calls))
+	}
+}
+
+func TestLegacyUpdateServiceCancellationAfterPrepareUsesBoundContext(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request"
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), key, "bound"))
+	updates := &legacyUpdateStoreFake{}
+	refresh := &legacyUpdateRefreshFake{}
+	prepared := NewLegacyUpdateService(LegacyUpdateServiceDependencies{Update: updates, Refresh: refresh}).Prepare(
+		ctx,
+		LegacyUpdateTarget{Mode: store.ModeFull},
+	)
+	cancel()
+
+	_, err := prepared.Update(LegacyUpdateCommand{TodoID: 101, Title: "cancelled"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Update error = %v, want context canceled", err)
+	}
+	if len(updates.calls) != 1 {
+		t.Fatalf("update calls = %d, want 1", len(updates.calls))
+	}
+	if got := updates.calls[0].ctx; got != ctx || got.Value(key) != "bound" || !errors.Is(got.Err(), context.Canceled) {
+		t.Fatalf("store context = %v, want bound cancelled context", got)
+	}
+	if len(refresh.calls) != 0 {
+		t.Fatalf("refresh calls = %d, want 0", len(refresh.calls))
+	}
+}

--- a/internal/httpapi/routing_todos.go
+++ b/internal/httpapi/routing_todos.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	todoapp "scrumboy/internal/application/todo"
 	"scrumboy/internal/store"
 )
 
@@ -64,23 +65,26 @@ func (s *Server) handleTodosPatchOrDelete(w http.ResponseWriter, r *http.Request
 			writeValidationError(w, "invalid json payload", "invalid_json", nil)
 			return true
 		}
-		todo, err := s.store.UpdateTodo(s.requestContext(r), todoID, store.UpdateTodoInput{
-			Title:              in.Title,
-			Body:               in.Body,
-			Tags:               in.Tags,
-			EstimationPoints:   in.EstimationPoints,
-			AssigneeUserID:     in.AssigneeUserID,
-			PriorityKey:        in.PriorityKey,
-			PriorityKeyPresent: raw["priorityKey"] != nil,
-		}, s.storeMode())
+		prepared := s.todoLegacyUpdates.Prepare(s.requestContext(r), todoapp.LegacyUpdateTarget{
+			Mode: s.storeMode(),
+		})
+		result, err := prepared.Update(todoapp.LegacyUpdateCommand{
+			TodoID:           todoID,
+			Title:            in.Title,
+			Body:             in.Body,
+			Tags:             in.Tags,
+			EstimationPoints: in.EstimationPoints,
+			AssigneeUserID:   in.AssigneeUserID,
+			PriorityKey: todoapp.Field[*string]{
+				Present: raw["priorityKey"] != nil,
+				Value:   in.PriorityKey,
+			},
+		})
 		if err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}
-		if !todo.AssignmentChanged {
-			s.emitRefreshNeeded(s.requestContext(r), todo.ProjectID, "todo_updated")
-		}
-		writeJSON(w, http.StatusOK, s.legacyTodoMutationJSON(s.requestContext(r), todo))
+		writeJSON(w, http.StatusOK, s.legacyTodoMutationJSON(s.requestContext(r), result.Todo))
 		return true
 
 	case http.MethodDelete:

--- a/internal/httpapi/routing_todos.go
+++ b/internal/httpapi/routing_todos.go
@@ -130,13 +130,20 @@ func (s *Server) handleTodosMove(w http.ResponseWriter, r *http.Request, rest []
 		writeValidationError(w, "missing toColumnKey", "missing_to_column_key", map[string]any{"field": "toColumnKey"})
 		return true
 	}
-	todo, err := s.store.MoveTodo(s.requestContext(r), todoID, toColumnKey, in.AfterID, in.BeforeID, s.storeMode())
+	prepared := s.todoLegacyMoves.Prepare(s.requestContext(r), todoapp.LegacyMoveTarget{
+		Mode: s.storeMode(),
+	})
+	result, err := prepared.Move(todoapp.LegacyMoveCommand{
+		TodoID:       todoID,
+		ToColumnKey:  toColumnKey,
+		AfterTodoID:  in.AfterID,
+		BeforeTodoID: in.BeforeID,
+	})
 	if err != nil {
 		writeStoreErr(w, err, true)
 		return true
 	}
-	s.emitRefreshNeeded(s.requestContext(r), todo.ProjectID, "todo_moved")
-	writeJSON(w, http.StatusOK, s.legacyTodoMutationJSON(s.requestContext(r), todo))
+	writeJSON(w, http.StatusOK, s.legacyTodoMutationJSON(s.requestContext(r), result.Todo))
 	return true
 }
 

--- a/internal/httpapi/routing_todos.go
+++ b/internal/httpapi/routing_todos.go
@@ -88,16 +88,18 @@ func (s *Server) handleTodosPatchOrDelete(w http.ResponseWriter, r *http.Request
 		return true
 
 	case http.MethodDelete:
-		projectID, err := s.store.GetProjectIDForTodo(s.requestContext(r), todoID)
+		prepared, err := s.todoLegacyDeletes.Prepare(s.requestContext(r), todoapp.LegacyDeleteTarget{
+			TodoID: todoID,
+			Mode:   s.storeMode(),
+		})
 		if err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}
-		if err := s.store.DeleteTodo(s.requestContext(r), todoID, s.storeMode()); err != nil {
+		if err := prepared.Delete(); err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}
-		s.emitRefreshNeeded(s.requestContext(r), projectID, "todo_deleted")
 		w.WriteHeader(http.StatusNoContent)
 		return true
 

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -104,6 +104,7 @@ type Server struct {
 	todoDeletes         *todoapp.DeleteService
 	todoMoves           *todoapp.MoveService
 	todoUpdates         *todoapp.UpdateService
+	todoLegacyDeletes   *todoapp.LegacyDeleteService
 	todoLegacyMoves     *todoapp.LegacyMoveService
 	todoLegacyUpdates   *todoapp.LegacyUpdateService
 	todoLinkMutations   *todolinkapp.RESTMutationService
@@ -609,6 +610,11 @@ func NewServer(st storeAPI, opts Options) *Server {
 	server.todoUpdates = todoapp.NewUpdateService(todoapp.UpdateServiceDependencies{
 		Update:  st,
 		Refresh: boardRefreshPublisher,
+	})
+	server.todoLegacyDeletes = todoapp.NewLegacyDeleteService(todoapp.LegacyDeleteServiceDependencies{
+		Projects: st,
+		Delete:   st,
+		Refresh:  boardRefreshPublisher,
 	})
 	server.todoLegacyMoves = todoapp.NewLegacyMoveService(todoapp.LegacyMoveServiceDependencies{
 		Move:    st,

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -104,6 +104,7 @@ type Server struct {
 	todoDeletes         *todoapp.DeleteService
 	todoMoves           *todoapp.MoveService
 	todoUpdates         *todoapp.UpdateService
+	todoLegacyMoves     *todoapp.LegacyMoveService
 	todoLegacyUpdates   *todoapp.LegacyUpdateService
 	todoLinkMutations   *todolinkapp.RESTMutationService
 	sprintDefinitions   *sprintapp.RESTDefinitionService
@@ -607,6 +608,10 @@ func NewServer(st storeAPI, opts Options) *Server {
 	})
 	server.todoUpdates = todoapp.NewUpdateService(todoapp.UpdateServiceDependencies{
 		Update:  st,
+		Refresh: boardRefreshPublisher,
+	})
+	server.todoLegacyMoves = todoapp.NewLegacyMoveService(todoapp.LegacyMoveServiceDependencies{
+		Move:    st,
 		Refresh: boardRefreshPublisher,
 	})
 	server.todoLegacyUpdates = todoapp.NewLegacyUpdateService(todoapp.LegacyUpdateServiceDependencies{

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -104,6 +104,7 @@ type Server struct {
 	todoDeletes         *todoapp.DeleteService
 	todoMoves           *todoapp.MoveService
 	todoUpdates         *todoapp.UpdateService
+	todoLegacyUpdates   *todoapp.LegacyUpdateService
 	todoLinkMutations   *todolinkapp.RESTMutationService
 	sprintDefinitions   *sprintapp.RESTDefinitionService
 	sprintLifecycle     *sprintapp.RESTLifecycleService
@@ -605,6 +606,10 @@ func NewServer(st storeAPI, opts Options) *Server {
 		Refresh: boardRefreshPublisher,
 	})
 	server.todoUpdates = todoapp.NewUpdateService(todoapp.UpdateServiceDependencies{
+		Update:  st,
+		Refresh: boardRefreshPublisher,
+	})
+	server.todoLegacyUpdates = todoapp.NewLegacyUpdateService(todoapp.LegacyUpdateServiceDependencies{
 		Update:  st,
 		Refresh: boardRefreshPublisher,
 	})

--- a/internal/httpapi/todo_legacy_delete_contract_test.go
+++ b/internal/httpapi/todo_legacy_delete_contract_test.go
@@ -1,0 +1,158 @@
+package httpapi
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"scrumboy/internal/store"
+)
+
+func TestLegacyTodoDeleteSuccessAndRealtimeContract(t *testing.T) {
+	fixture := newLegacyTodoMutationFixture(t, "full")
+	owner, ownerCtx, _ := legacyTodoBootstrapOwner(t, fixture)
+	legacyTodoSeedGlobalIdentity(t, fixture, ownerCtx, store.ModeFull)
+	project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy DELETE success")
+	maintainer := legacyTodoCreateUser(t, fixture, "delete-maintainer@example.com")
+	legacyTodoAddMember(t, fixture, owner, ownerCtx, project.ID, maintainer.ID, store.RoleMaintainer)
+	todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Delete target", ColumnKey: store.DefaultColumnTesting})
+	if todo.ID == todo.LocalID {
+		t.Fatalf("fixture identity did not diverge: %+v", todo)
+	}
+	client := legacyTodoClientForUser(t, fixture, maintainer.ID)
+	legacyTodoResetEvents(fixture)
+	stream := subscribeTodoUpdateEvents(t, client, fixture.ts.URL+"/api/board/"+project.Slug+"/events")
+
+	response, body := doJSON(t, client, http.MethodDelete, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), nil, nil)
+	if response.StatusCode != http.StatusNoContent || len(body) != 0 {
+		t.Fatalf("DELETE status=%d body=%q, want empty 204", response.StatusCode, body)
+	}
+	if legacyTodoRowCount(t, fixture, todo.ID) != 0 {
+		t.Fatal("successful DELETE retained Todo")
+	}
+	audits := legacyTodoAudits(t, fixture, "todo_deleted", todo.ID)
+	if len(audits) != 1 || audits[0].ProjectID != project.ID || !audits[0].ActorID.Valid || audits[0].ActorID.Int64 != maintainer.ID || audits[0].TargetType != "todo" || !audits[0].TargetID.Valid || audits[0].TargetID.Int64 != todo.ID {
+		t.Fatalf("delete audits=%+v", audits)
+	}
+	if int64(audits[0].Metadata["local_id"].(float64)) != todo.LocalID || audits[0].Metadata["column_key"] != store.DefaultColumnTesting {
+		t.Fatalf("delete audit metadata=%+v", audits[0].Metadata)
+	}
+	legacyTodoAssertOneRefresh(t, fixture, project.ID, "todo_deleted", maintainer.ID)
+	if gotAssigned := legacyTodoCountEvents(t, fixture, project.ID, "todo.assigned"); gotAssigned != 0 {
+		t.Fatalf("delete assignment events=%d, want 0", gotAssigned)
+	}
+	assertTodoUpdateRefreshes(t, collectTodoUpdateEvents(t, stream), project.ID, "todo_deleted", 0)
+}
+
+func TestLegacyTodoDeleteAccessAndModeContracts(t *testing.T) {
+	cases := []struct {
+		name string
+		role store.ProjectRole
+		kind string
+	}{
+		{name: "viewer_hidden", role: store.RoleViewer},
+		{name: "non_member_hidden", kind: "nonmember"},
+		{name: "no_session_hidden", kind: "anonymous"},
+		{name: "missing_todo", kind: "missing"},
+	}
+	for index, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newLegacyTodoMutationFixture(t, "full")
+			owner, ownerCtx, ownerClient := legacyTodoBootstrapOwner(t, fixture)
+			project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy DELETE hidden")
+			todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Hidden delete"})
+			client := ownerClient
+			todoID := todo.ID
+			switch tc.kind {
+			case "anonymous":
+				client = legacyTodoAnonymousClient(t, fixture)
+			case "missing":
+				todoID += 100000
+			default:
+				actor := legacyTodoCreateUser(t, fixture, fmt.Sprintf("delete-hidden-%d@example.com", index))
+				if tc.kind != "nonmember" {
+					legacyTodoAddMember(t, fixture, owner, ownerCtx, project.ID, actor.ID, tc.role)
+				}
+				client = legacyTodoClientForUser(t, fixture, actor.ID)
+			}
+			legacyTodoResetEvents(fixture)
+			response, body := doJSON(t, client, http.MethodDelete, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todoID), nil, nil)
+			legacyTodoAssertError(t, response, body, http.StatusNotFound, "NOT_FOUND", "not found", "", "")
+			if legacyTodoRowCount(t, fixture, todo.ID) != 1 || len(legacyTodoAudits(t, fixture, "todo_deleted", todo.ID)) != 0 {
+				t.Fatal("failed DELETE removed Todo or wrote delete audit")
+			}
+			legacyTodoAssertNoEvents(t, fixture, project.ID)
+		})
+	}
+
+	t.Run("temporary_link_holder_success", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		_, ownerCtx, _ := legacyTodoBootstrapOwner(t, fixture)
+		project := legacyTodoCreateTemporaryProject(t, fixture, ownerCtx)
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Temporary delete"})
+		legacyTodoResetEvents(fixture)
+		response, body := doJSON(t, legacyTodoAnonymousClient(t, fixture), http.MethodDelete, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), nil, nil)
+		if response.StatusCode != http.StatusNoContent || len(body) != 0 {
+			t.Fatalf("temporary DELETE status=%d body=%q, want empty 204", response.StatusCode, body)
+		}
+		if legacyTodoRowCount(t, fixture, todo.ID) != 0 {
+			t.Fatal("temporary DELETE retained Todo")
+		}
+		legacyTodoAssertAnonymousAuditActor(t, fixture, "todo_deleted", todo.ID)
+		legacyTodoAssertOneRefresh(t, fixture, project.ID, "todo_deleted", 0)
+	})
+
+	t.Run("expired_temporary_rejected", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		_, ownerCtx, _ := legacyTodoBootstrapOwner(t, fixture)
+		project := legacyTodoCreateTemporaryProject(t, fixture, ownerCtx)
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Expired delete"})
+		if _, err := fixture.db.Exec(`UPDATE projects SET expires_at = ? WHERE id = ?`, time.Now().UTC().Add(-time.Hour).UnixMilli(), project.ID); err != nil {
+			t.Fatalf("expire temporary project: %v", err)
+		}
+		legacyTodoResetEvents(fixture)
+		response, body := doJSON(t, legacyTodoAnonymousClient(t, fixture), http.MethodDelete, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), nil, nil)
+		legacyTodoAssertError(t, response, body, http.StatusNotFound, "NOT_FOUND", "not found", "", "")
+		if legacyTodoRowCount(t, fixture, todo.ID) != 1 || len(legacyTodoAudits(t, fixture, "todo_deleted", todo.ID)) != 0 {
+			t.Fatal("expired temporary DELETE changed persistence")
+		}
+		legacyTodoAssertNoEvents(t, fixture, project.ID)
+	})
+}
+
+func TestLegacyTodoDeleteFailureIsRealtimeSilent(t *testing.T) {
+	fixture := newLegacyTodoMutationFixture(t, "full")
+	_, ownerCtx, client := legacyTodoBootstrapOwner(t, fixture)
+	project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy DELETE failure")
+	todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Retained after failure"})
+	if _, err := fixture.db.Exec(`
+		CREATE TRIGGER phase22_legacy_abort_todo_delete
+		BEFORE DELETE ON todos
+		WHEN OLD.id = ` + fmt.Sprintf("%d", todo.ID) + `
+		BEGIN
+			SELECT RAISE(ABORT, 'forced legacy todo delete failure');
+		END`); err != nil {
+		t.Fatalf("create delete failure trigger: %v", err)
+	}
+	defer func() {
+		if _, err := fixture.db.Exec(`DROP TRIGGER IF EXISTS phase22_legacy_abort_todo_delete`); err != nil {
+			t.Errorf("drop delete failure trigger: %v", err)
+		}
+	}()
+	legacyTodoResetEvents(fixture)
+	stream := subscribeTodoUpdateEvents(t, client, fixture.ts.URL+"/api/board/"+project.Slug+"/events")
+
+	response, body := doJSON(t, client, http.MethodDelete, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), nil, nil)
+	legacyTodoAssertError(t, response, body, http.StatusInternalServerError, "INTERNAL", "internal error", "", "")
+	if legacyTodoRowCount(t, fixture, todo.ID) != 1 {
+		t.Fatal("failed DELETE removed Todo")
+	}
+	if len(legacyTodoAudits(t, fixture, "todo_deleted", todo.ID)) != 0 {
+		t.Fatal("failed DELETE committed delete audit")
+	}
+	legacyTodoAssertNoEvents(t, fixture, project.ID)
+	if events := collectTodoUpdateEvents(t, stream); len(events) != 0 {
+		t.Fatalf("failed DELETE emitted SSE events: %+v", events)
+	}
+}

--- a/internal/httpapi/todo_legacy_move_contract_test.go
+++ b/internal/httpapi/todo_legacy_move_contract_test.go
@@ -1,0 +1,329 @@
+package httpapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"scrumboy/internal/store"
+)
+
+func legacyTodoMoveDurableSetup(t *testing.T, name string) (*legacyTodoMutationFixture, store.User, context.Context, *http.Client, store.Project) {
+	t.Helper()
+	fixture := newLegacyTodoMutationFixture(t, "full")
+	owner, ownerCtx, client := legacyTodoBootstrapOwner(t, fixture)
+	legacyTodoSeedGlobalIdentity(t, fixture, ownerCtx, store.ModeFull)
+	project := legacyTodoCreateProject(t, fixture, ownerCtx, name)
+	return fixture, owner, ownerCtx, client, project
+}
+
+func legacyTodoMoveRequest(t *testing.T, fixture *legacyTodoMutationFixture, client *http.Client, todoID int64, payload map[string]any, out any) (*http.Response, []byte) {
+	t.Helper()
+	return doJSON(t, client, http.MethodPost, fmt.Sprintf("%s/api/todos/%d/move", fixture.ts.URL, todoID), payload, out)
+}
+
+func legacyTodoAssertMoveFailureUnchanged(t *testing.T, fixture *legacyTodoMutationFixture, projectID int64, before store.Todo) {
+	t.Helper()
+	after := legacyTodoRead(t, fixture, before.ID)
+	if after.ColumnKey != before.ColumnKey || after.Rank != before.Rank {
+		t.Fatalf("failed move changed Todo from column=%q rank=%d to column=%q rank=%d", before.ColumnKey, before.Rank, after.ColumnKey, after.Rank)
+	}
+	if len(legacyTodoAudits(t, fixture, "todo_moved", before.ID)) != 0 {
+		t.Fatal("failed move wrote todo_moved audit")
+	}
+	legacyTodoAssertNoEvents(t, fixture, projectID)
+}
+
+func TestLegacyTodoMoveAccessAndModeContracts(t *testing.T) {
+	t.Run("maintainer_success", func(t *testing.T) {
+		fixture, owner, ownerCtx, _, project := legacyTodoMoveDurableSetup(t, "Legacy MOVE maintainer")
+		maintainer := legacyTodoCreateUser(t, fixture, "move-maintainer@example.com")
+		legacyTodoAddMember(t, fixture, owner, ownerCtx, project.ID, maintainer.ID, store.RoleMaintainer)
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Move maintainer"})
+		legacyTodoResetEvents(fixture)
+		response, body := legacyTodoMoveRequest(t, fixture, legacyTodoClientForUser(t, fixture, maintainer.ID), todo.ID, map[string]any{"toColumnKey": store.DefaultColumnDoing}, nil)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("maintainer MOVE status=%d body=%s", response.StatusCode, body)
+		}
+		if got := legacyTodoRead(t, fixture, todo.ID); got.ColumnKey != store.DefaultColumnDoing {
+			t.Fatalf("maintainer MOVE persisted column=%q", got.ColumnKey)
+		}
+	})
+
+	cases := []struct {
+		name string
+		role store.ProjectRole
+		kind string
+	}{
+		{name: "contributor_hidden", role: store.RoleContributor},
+		{name: "viewer_hidden", role: store.RoleViewer},
+		{name: "non_member_hidden", kind: "nonmember"},
+		{name: "no_session_hidden", kind: "anonymous"},
+		{name: "missing_todo", kind: "missing"},
+	}
+	for index, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture, owner, ownerCtx, ownerClient, project := legacyTodoMoveDurableSetup(t, "Legacy MOVE hidden")
+			todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Hidden move"})
+			client := ownerClient
+			todoID := todo.ID
+			switch tc.kind {
+			case "anonymous":
+				client = legacyTodoAnonymousClient(t, fixture)
+			case "missing":
+				todoID += 100000
+			default:
+				actor := legacyTodoCreateUser(t, fixture, fmt.Sprintf("move-hidden-%d@example.com", index))
+				if tc.kind != "nonmember" {
+					legacyTodoAddMember(t, fixture, owner, ownerCtx, project.ID, actor.ID, tc.role)
+				}
+				client = legacyTodoClientForUser(t, fixture, actor.ID)
+			}
+			legacyTodoResetEvents(fixture)
+			response, body := legacyTodoMoveRequest(t, fixture, client, todoID, map[string]any{"toColumnKey": store.DefaultColumnDoing}, nil)
+			legacyTodoAssertError(t, response, body, http.StatusNotFound, "NOT_FOUND", "not found", "", "")
+			legacyTodoAssertMoveFailureUnchanged(t, fixture, project.ID, todo)
+		})
+	}
+
+	t.Run("temporary_link_holder_success", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		_, ownerCtx, _ := legacyTodoBootstrapOwner(t, fixture)
+		project := legacyTodoCreateTemporaryProject(t, fixture, ownerCtx)
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Temporary move"})
+		legacyTodoResetEvents(fixture)
+		response, body := legacyTodoMoveRequest(t, fixture, legacyTodoAnonymousClient(t, fixture), todo.ID, map[string]any{"toColumnKey": store.DefaultColumnDoing}, nil)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("temporary MOVE status=%d body=%s", response.StatusCode, body)
+		}
+		legacyTodoAssertAnonymousAuditActor(t, fixture, "todo_moved", todo.ID)
+		legacyTodoAssertOneRefresh(t, fixture, project.ID, "todo_moved", 0)
+	})
+
+	t.Run("expired_temporary_currently_succeeds", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		_, ownerCtx, _ := legacyTodoBootstrapOwner(t, fixture)
+		project := legacyTodoCreateTemporaryProject(t, fixture, ownerCtx)
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Expired temporary move"})
+		if _, err := fixture.db.Exec(`UPDATE projects SET expires_at = ? WHERE id = ?`, time.Now().UTC().Add(-time.Hour).UnixMilli(), project.ID); err != nil {
+			t.Fatalf("expire temporary project: %v", err)
+		}
+		legacyTodoResetEvents(fixture)
+
+		// This freezes existing compatibility behavior for refactor safety. It is
+		// deliberately not a statement that mutating an expired board is desirable.
+		response, body := legacyTodoMoveRequest(t, fixture, legacyTodoAnonymousClient(t, fixture), todo.ID, map[string]any{"toColumnKey": store.DefaultColumnDoing}, nil)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("expired temporary MOVE status=%d body=%s, want current 200", response.StatusCode, body)
+		}
+		if got := legacyTodoRead(t, fixture, todo.ID); got.ColumnKey != store.DefaultColumnDoing {
+			t.Fatalf("expired temporary MOVE did not persist: %+v", got)
+		}
+		legacyTodoAssertAnonymousAuditActor(t, fixture, "todo_moved", todo.ID)
+		legacyTodoAssertOneRefresh(t, fixture, project.ID, "todo_moved", 0)
+	})
+}
+
+func TestLegacyTodoMoveGlobalAnchorAndValidationContracts(t *testing.T) {
+	t.Run("to_column_key", func(t *testing.T) {
+		fixture, _, ownerCtx, client, project := legacyTodoMoveDurableSetup(t, "Legacy MOVE column")
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Column target"})
+		response, body := legacyTodoMoveRequest(t, fixture, client, todo.ID, map[string]any{"toColumnKey": store.DefaultColumnTesting}, nil)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("MOVE status=%d body=%s", response.StatusCode, body)
+		}
+		if got := legacyTodoRead(t, fixture, todo.ID); got.ColumnKey != store.DefaultColumnTesting {
+			t.Fatalf("column=%q, want %q", got.ColumnKey, store.DefaultColumnTesting)
+		}
+	})
+
+	t.Run("legacy_to_status", func(t *testing.T) {
+		fixture, _, ownerCtx, client, project := legacyTodoMoveDurableSetup(t, "Legacy MOVE status")
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Status target"})
+		var got todoJSON
+		response, body := legacyTodoMoveRequest(t, fixture, client, todo.ID, map[string]any{"toStatus": "IN_PROGRESS"}, &got)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("MOVE toStatus status=%d body=%s", response.StatusCode, body)
+		}
+		if got.ColumnKey != store.DefaultColumnDoing || got.Status != "DOING" {
+			t.Fatalf("legacy toStatus projection=%+v", got)
+		}
+	})
+
+	t.Run("missing_destination_precedes_missing_todo", func(t *testing.T) {
+		fixture, _, ownerCtx, client, project := legacyTodoMoveDurableSetup(t, "Legacy MOVE destination precedence")
+		control := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Destination control"})
+		legacyTodoResetEvents(fixture)
+		response, body := legacyTodoMoveRequest(t, fixture, client, control.ID+100000, map[string]any{}, nil)
+		legacyTodoAssertError(t, response, body, http.StatusBadRequest, "VALIDATION_ERROR", "missing toColumnKey", "missing_to_column_key", "toColumnKey")
+		legacyTodoAssertNoEvents(t, fixture, project.ID)
+	})
+
+	t.Run("after_id_is_global", func(t *testing.T) {
+		fixture, _, ownerCtx, client, project := legacyTodoMoveDurableSetup(t, "Legacy MOVE global after")
+		target := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "After target"})
+		anchor := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "After anchor", ColumnKey: store.DefaultColumnDoing})
+		if anchor.ID == anchor.LocalID {
+			t.Fatalf("anchor identity did not diverge: %+v", anchor)
+		}
+		response, body := legacyTodoMoveRequest(t, fixture, client, target.ID, map[string]any{"toColumnKey": store.DefaultColumnDoing, "afterId": anchor.ID}, nil)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("global afterId MOVE status=%d body=%s", response.StatusCode, body)
+		}
+		moved := legacyTodoRead(t, fixture, target.ID)
+		if moved.ColumnKey != store.DefaultColumnDoing || moved.Rank <= legacyTodoRead(t, fixture, anchor.ID).Rank {
+			t.Fatalf("moved=%+v anchor=%+v", moved, legacyTodoRead(t, fixture, anchor.ID))
+		}
+	})
+
+	t.Run("before_id_is_global", func(t *testing.T) {
+		fixture, _, ownerCtx, client, project := legacyTodoMoveDurableSetup(t, "Legacy MOVE global before")
+		target := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Before target"})
+		anchor := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Before anchor", ColumnKey: store.DefaultColumnDoing})
+		if anchor.ID == anchor.LocalID {
+			t.Fatalf("anchor identity did not diverge: %+v", anchor)
+		}
+		response, body := legacyTodoMoveRequest(t, fixture, client, target.ID, map[string]any{"toColumnKey": store.DefaultColumnDoing, "beforeId": anchor.ID}, nil)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("global beforeId MOVE status=%d body=%s", response.StatusCode, body)
+		}
+		moved := legacyTodoRead(t, fixture, target.ID)
+		if moved.ColumnKey != store.DefaultColumnDoing || moved.Rank >= legacyTodoRead(t, fixture, anchor.ID).Rank {
+			t.Fatalf("moved=%+v anchor=%+v", moved, legacyTodoRead(t, fixture, anchor.ID))
+		}
+	})
+
+	t.Run("both_anchors_supported", func(t *testing.T) {
+		fixture, _, ownerCtx, client, project := legacyTodoMoveDurableSetup(t, "Legacy MOVE both anchors")
+		target := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Both target"})
+		after := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Both after", ColumnKey: store.DefaultColumnDoing})
+		before := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Both before", ColumnKey: store.DefaultColumnDoing})
+		response, body := legacyTodoMoveRequest(t, fixture, client, target.ID, map[string]any{"toColumnKey": store.DefaultColumnDoing, "afterId": after.ID, "beforeId": before.ID}, nil)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("both-anchor MOVE status=%d body=%s", response.StatusCode, body)
+		}
+		moved := legacyTodoRead(t, fixture, target.ID)
+		afterRow := legacyTodoRead(t, fixture, after.ID)
+		beforeRow := legacyTodoRead(t, fixture, before.ID)
+		if !(afterRow.Rank < moved.Rank && moved.Rank < beforeRow.Rank) {
+			t.Fatalf("ranks after=%d moved=%d before=%d", afterRow.Rank, moved.Rank, beforeRow.Rank)
+		}
+	})
+
+	t.Run("reversed_anchors_conflict", func(t *testing.T) {
+		fixture, _, ownerCtx, client, project := legacyTodoMoveDurableSetup(t, "Legacy MOVE reversed anchors")
+		target := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Reversed target"})
+		before := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Earlier", ColumnKey: store.DefaultColumnDoing})
+		after := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Later", ColumnKey: store.DefaultColumnDoing})
+		legacyTodoResetEvents(fixture)
+		response, body := legacyTodoMoveRequest(t, fixture, client, target.ID, map[string]any{"toColumnKey": store.DefaultColumnDoing, "afterId": after.ID, "beforeId": before.ID}, nil)
+		if response.StatusCode != http.StatusConflict {
+			t.Fatalf("reversed anchors status=%d body=%s, want 409", response.StatusCode, body)
+		}
+		got := legacyTodoDecodeError(t, body)
+		if got.Error.Code != "CONFLICT" || !strings.Contains(got.Error.Message, "afterId must come before beforeId") {
+			t.Fatalf("reversed anchor error=%+v", got.Error)
+		}
+		legacyTodoAssertMoveFailureUnchanged(t, fixture, project.ID, target)
+	})
+
+	t.Run("self_after_rejected", func(t *testing.T) {
+		fixture, _, ownerCtx, client, project := legacyTodoMoveDurableSetup(t, "Legacy MOVE self anchor")
+		target := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Self target"})
+		legacyTodoResetEvents(fixture)
+		response, body := legacyTodoMoveRequest(t, fixture, client, target.ID, map[string]any{"toColumnKey": store.DefaultColumnDoing, "afterId": target.ID}, nil)
+		if response.StatusCode != http.StatusBadRequest {
+			t.Fatalf("self anchor status=%d body=%s, want 400", response.StatusCode, body)
+		}
+		got := legacyTodoDecodeError(t, body)
+		if got.Error.Code != "VALIDATION_ERROR" || !strings.Contains(got.Error.Message, "afterId cannot equal todoId") {
+			t.Fatalf("self anchor error=%+v", got.Error)
+		}
+		legacyTodoAssertMoveFailureUnchanged(t, fixture, project.ID, target)
+	})
+
+	failureCases := []struct {
+		name        string
+		anchorSetup func(*testing.T, *legacyTodoMutationFixture, context.Context, store.Project) int64
+	}{
+		{
+			name: "missing_anchor_hidden",
+			anchorSetup: func(_ *testing.T, _ *legacyTodoMutationFixture, _ context.Context, _ store.Project) int64 {
+				return 999999
+			},
+		},
+		{
+			name: "cross_project_anchor_hidden",
+			anchorSetup: func(t *testing.T, fixture *legacyTodoMutationFixture, ownerCtx context.Context, _ store.Project) int64 {
+				other := legacyTodoCreateProject(t, fixture, ownerCtx, "Other anchor project")
+				return legacyTodoCreateTodo(t, fixture, ownerCtx, other.ID, store.ModeFull, store.CreateTodoInput{Title: "Cross anchor", ColumnKey: store.DefaultColumnDoing}).ID
+			},
+		},
+		{
+			name: "destination_column_mismatch_hidden",
+			anchorSetup: func(t *testing.T, fixture *legacyTodoMutationFixture, ownerCtx context.Context, project store.Project) int64 {
+				return legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Wrong lane anchor", ColumnKey: store.DefaultColumnBacklog}).ID
+			},
+		},
+	}
+	for _, tc := range failureCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture, _, ownerCtx, client, project := legacyTodoMoveDurableSetup(t, "Legacy MOVE hidden anchor")
+			target := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Anchor failure target"})
+			anchorID := tc.anchorSetup(t, fixture, ownerCtx, project)
+			legacyTodoResetEvents(fixture)
+			response, body := legacyTodoMoveRequest(t, fixture, client, target.ID, map[string]any{"toColumnKey": store.DefaultColumnDoing, "afterId": anchorID}, nil)
+			legacyTodoAssertError(t, response, body, http.StatusNotFound, "NOT_FOUND", "not found", "", "")
+			legacyTodoAssertMoveFailureUnchanged(t, fixture, project.ID, target)
+		})
+	}
+}
+
+func TestLegacyTodoMoveRealtimeAuditAndProjectionContract(t *testing.T) {
+	fixture, owner, ownerCtx, client, project := legacyTodoMoveDurableSetup(t, "Legacy MOVE side effects")
+	now := time.Now().UTC()
+	sprint, err := fixture.store.CreateSprint(ownerCtx, project.ID, "Move sprint", now, now.Add(7*24*time.Hour))
+	if err != nil {
+		t.Fatalf("create sprint: %v", err)
+	}
+	points := int64(5)
+	priority := "urgent"
+	todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{
+		Title:            "Move projection",
+		Body:             "unchanged body",
+		Tags:             []string{"move-tag"},
+		EstimationPoints: &points,
+		SprintID:         &sprint.ID,
+		PriorityKey:      &priority,
+	})
+	if todo.ID == todo.LocalID {
+		t.Fatalf("fixture identity did not diverge: %+v", todo)
+	}
+	legacyTodoResetEvents(fixture)
+	stream := subscribeTodoUpdateEvents(t, client, fixture.ts.URL+"/api/board/"+project.Slug+"/events")
+	var got todoJSON
+	response, body := legacyTodoMoveRequest(t, fixture, client, todo.ID, map[string]any{"toColumnKey": store.DefaultColumnDoing}, &got)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("MOVE status=%d body=%s", response.StatusCode, body)
+	}
+	legacyTodoAssertProjectionIdentity(t, got, todo)
+	if got.ColumnKey != store.DefaultColumnDoing || got.Status != "DOING" || got.Title != todo.Title || got.Body != todo.Body || got.EstimationPoints == nil || *got.EstimationPoints != points || got.PriorityKey == nil || *got.PriorityKey != priority || got.SprintId == nil || *got.SprintId != sprint.ID || !reflect.DeepEqual(got.Tags, []string{"move-tag"}) {
+		t.Fatalf("legacy move projection=%+v", got)
+	}
+	audits := legacyTodoAudits(t, fixture, "todo_moved", todo.ID)
+	if len(audits) != 1 || audits[0].ProjectID != project.ID || !audits[0].ActorID.Valid || audits[0].ActorID.Int64 != owner.ID || !audits[0].TargetID.Valid || audits[0].TargetID.Int64 != todo.ID {
+		t.Fatalf("move audits=%+v", audits)
+	}
+	if audits[0].Metadata["from_column"] != store.DefaultColumnBacklog || audits[0].Metadata["to_column"] != store.DefaultColumnDoing || int64(audits[0].Metadata["local_id"].(float64)) != todo.LocalID {
+		t.Fatalf("move audit metadata=%+v", audits[0].Metadata)
+	}
+	legacyTodoAssertOneRefresh(t, fixture, project.ID, "todo_moved", owner.ID)
+	if gotAssigned := legacyTodoCountEvents(t, fixture, project.ID, "todo.assigned"); gotAssigned != 0 {
+		t.Fatalf("move assignment events=%d, want 0", gotAssigned)
+	}
+	assertTodoUpdateRefreshes(t, collectTodoUpdateEvents(t, stream), project.ID, "todo_moved", 0)
+}

--- a/internal/httpapi/todo_legacy_mutation_contract_test.go
+++ b/internal/httpapi/todo_legacy_mutation_contract_test.go
@@ -1,0 +1,484 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"scrumboy/internal/db"
+	"scrumboy/internal/eventbus"
+	"scrumboy/internal/migrate"
+	"scrumboy/internal/store"
+)
+
+type legacyTodoMutationFixture struct {
+	ts        *httptest.Server
+	db        *sql.DB
+	store     *store.Store
+	server    *Server
+	collector *collectingConsumer
+}
+
+func newLegacyTodoMutationFixture(t *testing.T, mode string) *legacyTodoMutationFixture {
+	t.Helper()
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "legacy-todo.db"), db.Options{
+		BusyTimeout: 5000,
+		JournalMode: "WAL",
+		Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	if err := migrate.Apply(context.Background(), sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	st := store.New(sqlDB, nil)
+	collector := &collectingConsumer{}
+	srv := NewServer(st, Options{MaxRequestBody: 1 << 20, ScrumboyMode: mode})
+	srv.fanout = eventbus.NewFanout(newSSEBridge(srv.hub), collector)
+	st.SetTodoAssignedPublisher(srv.PublishTodoAssigned)
+	ts := httptest.NewServer(srv)
+
+	fixture := &legacyTodoMutationFixture{
+		ts:        ts,
+		db:        sqlDB,
+		store:     st,
+		server:    srv,
+		collector: collector,
+	}
+	t.Cleanup(func() {
+		ts.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		srv.Close(ctx)
+		_ = sqlDB.Close()
+	})
+	return fixture
+}
+
+func legacyTodoClientForUser(t *testing.T, fixture *legacyTodoMutationFixture, userID int64) *http.Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("create cookie jar: %v", err)
+	}
+	client := &http.Client{Transport: fixture.ts.Client().Transport, Jar: jar}
+	token, expiresAt, err := fixture.store.CreateSession(context.Background(), userID, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	baseURL, err := url.Parse(fixture.ts.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	jar.SetCookies(baseURL, []*http.Cookie{{
+		Name:    "scrumboy_session",
+		Value:   token,
+		Path:    "/",
+		Expires: expiresAt,
+	}})
+	return client
+}
+
+func legacyTodoAnonymousClient(t *testing.T, fixture *legacyTodoMutationFixture) *http.Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("create anonymous cookie jar: %v", err)
+	}
+	return &http.Client{Transport: fixture.ts.Client().Transport, Jar: jar}
+}
+
+func legacyTodoBootstrapOwner(t *testing.T, fixture *legacyTodoMutationFixture) (store.User, context.Context, *http.Client) {
+	t.Helper()
+	owner, err := fixture.store.BootstrapUser(context.Background(), "legacy-owner@example.com", "password123", "Legacy Owner")
+	if err != nil {
+		t.Fatalf("bootstrap owner: %v", err)
+	}
+	ctx := store.WithUserID(context.Background(), owner.ID)
+	return owner, ctx, legacyTodoClientForUser(t, fixture, owner.ID)
+}
+
+func legacyTodoCreateUser(t *testing.T, fixture *legacyTodoMutationFixture, email string) store.User {
+	t.Helper()
+	user, err := fixture.store.CreateUser(context.Background(), email, "password123", email)
+	if err != nil {
+		t.Fatalf("create user %q: %v", email, err)
+	}
+	return user
+}
+
+func legacyTodoAddMember(t *testing.T, fixture *legacyTodoMutationFixture, owner store.User, ownerCtx context.Context, projectID, userID int64, role store.ProjectRole) {
+	t.Helper()
+	if err := fixture.store.AddProjectMember(ownerCtx, owner.ID, projectID, userID, role); err != nil {
+		t.Fatalf("add project member role=%s: %v", role, err)
+	}
+}
+
+func legacyTodoCreateProject(t *testing.T, fixture *legacyTodoMutationFixture, ctx context.Context, name string) store.Project {
+	t.Helper()
+	project, err := fixture.store.CreateProject(ctx, name)
+	if err != nil {
+		t.Fatalf("create project %q: %v", name, err)
+	}
+	return project
+}
+
+func legacyTodoCreateTemporaryProject(t *testing.T, fixture *legacyTodoMutationFixture, ctx context.Context) store.Project {
+	t.Helper()
+	project, err := fixture.store.CreateAnonymousBoard(ctx)
+	if err != nil {
+		t.Fatalf("create temporary project: %v", err)
+	}
+	return project
+}
+
+func legacyTodoCreateTodo(t *testing.T, fixture *legacyTodoMutationFixture, ctx context.Context, projectID int64, mode store.Mode, input store.CreateTodoInput) store.Todo {
+	t.Helper()
+	if input.Title == "" {
+		input.Title = "Legacy target"
+	}
+	if input.ColumnKey == "" {
+		input.ColumnKey = store.DefaultColumnBacklog
+	}
+	todo, err := fixture.store.CreateTodo(ctx, projectID, input, mode)
+	if err != nil {
+		t.Fatalf("create todo %q: %v", input.Title, err)
+	}
+	return todo
+}
+
+func legacyTodoSeedGlobalIdentity(t *testing.T, fixture *legacyTodoMutationFixture, ctx context.Context, mode store.Mode) {
+	t.Helper()
+	seedProject := legacyTodoCreateTemporaryProject(t, fixture, ctx)
+	legacyTodoCreateTodo(t, fixture, ctx, seedProject.ID, mode, store.CreateTodoInput{Title: "Global identity seed"})
+}
+
+func legacyTodoResetEvents(fixture *legacyTodoMutationFixture) {
+	fixture.collector.events = nil
+}
+
+func legacyTodoEventsForProject(fixture *legacyTodoMutationFixture, projectID int64) []eventbus.Event {
+	var events []eventbus.Event
+	for _, event := range fixture.collector.events {
+		if event.ProjectID == projectID {
+			events = append(events, event)
+		}
+	}
+	return events
+}
+
+type legacyTodoRefreshPayload struct {
+	Reason      string `json:"reason"`
+	ActorUserID int64  `json:"actorUserId"`
+}
+
+func legacyTodoAssertOneRefresh(t *testing.T, fixture *legacyTodoMutationFixture, projectID int64, reason string, actorID int64) {
+	t.Helper()
+	events := legacyTodoEventsForProject(fixture, projectID)
+	if len(events) != 1 || events[0].Type != "board.refresh_needed" {
+		t.Fatalf("events=%+v, want exactly one board.refresh_needed", events)
+	}
+	var payload legacyTodoRefreshPayload
+	if err := json.Unmarshal(events[0].Payload, &payload); err != nil {
+		t.Fatalf("decode refresh payload: %v", err)
+	}
+	if payload.Reason != reason || payload.ActorUserID != actorID {
+		t.Fatalf("refresh payload=%+v, want reason=%q actor=%d", payload, reason, actorID)
+	}
+}
+
+func legacyTodoAssertNoEvents(t *testing.T, fixture *legacyTodoMutationFixture, projectID int64) {
+	t.Helper()
+	if events := legacyTodoEventsForProject(fixture, projectID); len(events) != 0 {
+		t.Fatalf("unexpected events: %+v", events)
+	}
+}
+
+func legacyTodoCountEvents(t *testing.T, fixture *legacyTodoMutationFixture, projectID int64, eventType string) int {
+	t.Helper()
+	count := 0
+	for _, event := range legacyTodoEventsForProject(fixture, projectID) {
+		if event.Type == eventType {
+			count++
+		}
+	}
+	return count
+}
+
+func legacyTodoDoRawJSON(t *testing.T, client *http.Client, method, requestURL, raw string) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(method, requestURL, bytes.NewBufferString(raw))
+	if err != nil {
+		t.Fatalf("create raw request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Scrumboy", "1")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("perform raw request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read raw response: %v", err)
+	}
+	return resp, body
+}
+
+func legacyTodoDecodeError(t *testing.T, body []byte) apiErrorEnvelope {
+	t.Helper()
+	var got apiErrorEnvelope
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode API error: %v, body=%q", err, body)
+	}
+	return got
+}
+
+func legacyTodoAssertError(t *testing.T, response *http.Response, body []byte, status int, code, message, reason, field string) {
+	t.Helper()
+	if response.StatusCode != status {
+		t.Fatalf("status=%d body=%s, want %d", response.StatusCode, body, status)
+	}
+	got := legacyTodoDecodeError(t, body)
+	if got.Error.Code != code || (message != "" && got.Error.Message != message) {
+		t.Fatalf("error=%+v, want code=%q message=%q", got.Error, code, message)
+	}
+	if reason != "" {
+		gotReason, _ := got.Error.Details["reason"].(string)
+		if gotReason != reason {
+			t.Fatalf("error reason=%q details=%+v, want %q", gotReason, got.Error.Details, reason)
+		}
+	}
+	if field != "" {
+		gotField, _ := got.Error.Details["field"].(string)
+		if gotField != field {
+			t.Fatalf("error field=%q details=%+v, want %q", gotField, got.Error.Details, field)
+		}
+	}
+}
+
+func legacyTodoFullPatch(todo store.Todo) map[string]any {
+	return map[string]any{
+		"title":            todo.Title,
+		"body":             todo.Body,
+		"tags":             todo.Tags,
+		"estimationPoints": todo.EstimationPoints,
+		"assigneeUserId":   todo.AssigneeUserID,
+	}
+}
+
+type legacyTodoAuditRow struct {
+	ProjectID  int64
+	ActorID    sql.NullInt64
+	TargetType string
+	TargetID   sql.NullInt64
+	Metadata   map[string]any
+}
+
+func legacyTodoAudits(t *testing.T, fixture *legacyTodoMutationFixture, action string, todoID int64) []legacyTodoAuditRow {
+	t.Helper()
+	rows, err := fixture.db.Query(`
+		SELECT project_id, actor_user_id, target_type, target_id, metadata
+		FROM audit_events
+		WHERE action = ? AND target_type = 'todo' AND target_id = ?
+		ORDER BY id`, action, todoID)
+	if err != nil {
+		t.Fatalf("query %s audits: %v", action, err)
+	}
+	defer rows.Close()
+	var out []legacyTodoAuditRow
+	for rows.Next() {
+		var row legacyTodoAuditRow
+		var metadata sql.NullString
+		if err := rows.Scan(&row.ProjectID, &row.ActorID, &row.TargetType, &row.TargetID, &metadata); err != nil {
+			t.Fatalf("scan %s audit: %v", action, err)
+		}
+		if metadata.Valid && metadata.String != "" {
+			if err := json.Unmarshal([]byte(metadata.String), &row.Metadata); err != nil {
+				t.Fatalf("decode %s metadata %q: %v", action, metadata.String, err)
+			}
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate %s audits: %v", action, err)
+	}
+	return out
+}
+
+func legacyTodoAssignmentCount(t *testing.T, fixture *legacyTodoMutationFixture, todoID int64) int {
+	t.Helper()
+	var count int
+	if err := fixture.db.QueryRow(`SELECT COUNT(*) FROM todo_assignee_events WHERE todo_id = ?`, todoID).Scan(&count); err != nil {
+		t.Fatalf("count assignee ledger: %v", err)
+	}
+	return count
+}
+
+func legacyTodoRead(t *testing.T, fixture *legacyTodoMutationFixture, todoID int64) store.Todo {
+	t.Helper()
+	var todo store.Todo
+	var estimation, assignee, sprint sql.NullInt64
+	var priority sql.NullString
+	var createdAt, updatedAt int64
+	err := fixture.db.QueryRow(`
+		SELECT id, project_id, local_id, title, body, column_key, rank,
+		       estimation_points, assignee_user_id, sprint_id, priority_key,
+		       created_at, updated_at
+		FROM todos WHERE id = ?`, todoID).Scan(
+		&todo.ID, &todo.ProjectID, &todo.LocalID, &todo.Title, &todo.Body, &todo.ColumnKey, &todo.Rank,
+		&estimation, &assignee, &sprint, &priority, &createdAt, &updatedAt,
+	)
+	if err != nil {
+		t.Fatalf("read todo %d: %v", todoID, err)
+	}
+	if estimation.Valid {
+		value := estimation.Int64
+		todo.EstimationPoints = &value
+	}
+	if assignee.Valid {
+		value := assignee.Int64
+		todo.AssigneeUserID = &value
+	}
+	if sprint.Valid {
+		value := sprint.Int64
+		todo.SprintID = &value
+	}
+	if priority.Valid {
+		value := priority.String
+		todo.PriorityKey = &value
+	}
+	todo.CreatedAt = time.UnixMilli(createdAt).UTC()
+	todo.UpdatedAt = time.UnixMilli(updatedAt).UTC()
+	tagRows, err := fixture.db.Query(`
+		SELECT tags.name
+		FROM todo_tags JOIN tags ON tags.id = todo_tags.tag_id
+		WHERE todo_tags.todo_id = ? ORDER BY tags.name`, todoID)
+	if err != nil {
+		t.Fatalf("query todo tags: %v", err)
+	}
+	defer tagRows.Close()
+	for tagRows.Next() {
+		var tag string
+		if err := tagRows.Scan(&tag); err != nil {
+			t.Fatalf("scan todo tag: %v", err)
+		}
+		todo.Tags = append(todo.Tags, tag)
+	}
+	return todo
+}
+
+func legacyTodoRowCount(t *testing.T, fixture *legacyTodoMutationFixture, todoID int64) int {
+	t.Helper()
+	var count int
+	if err := fixture.db.QueryRow(`SELECT COUNT(*) FROM todos WHERE id = ?`, todoID).Scan(&count); err != nil {
+		t.Fatalf("count todo row: %v", err)
+	}
+	return count
+}
+
+func legacyTodoAssertProjectionIdentity(t *testing.T, got todoJSON, want store.Todo) {
+	t.Helper()
+	if got.ID != want.ID || got.ProjectID != want.ProjectID || got.LocalID != want.LocalID {
+		t.Fatalf("projection identity=%+v, want global=%d project=%d local=%d", got, want.ID, want.ProjectID, want.LocalID)
+	}
+}
+
+func legacyTodoAssertAnonymousAuditActor(t *testing.T, fixture *legacyTodoMutationFixture, action string, todoID int64) {
+	t.Helper()
+	audits := legacyTodoAudits(t, fixture, action, todoID)
+	if len(audits) != 1 || audits[0].ActorID.Valid {
+		t.Fatalf("%s audits=%+v, want one with NULL actor", action, audits)
+	}
+}
+
+func TestLegacyTodoMutationGlobalIDValidationContract(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		pathID string
+		suffix string
+		body   any
+	}{
+		{name: "malformed_patch", method: http.MethodPatch, pathID: "not-a-number", body: map[string]any{"assigneeUserId": nil}},
+		{name: "zero_move", method: http.MethodPost, pathID: "0", suffix: "/move", body: map[string]any{"toColumnKey": store.DefaultColumnDoing}},
+		{name: "negative_delete", method: http.MethodDelete, pathID: "-7"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newLegacyTodoMutationFixture(t, "full")
+			_, ownerCtx, client := legacyTodoBootstrapOwner(t, fixture)
+			project := legacyTodoCreateProject(t, fixture, ownerCtx, "Global ID validation")
+			control := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Control"})
+			legacyTodoResetEvents(fixture)
+
+			response, body := doJSON(t, client, tc.method, fmt.Sprintf("%s/api/todos/%s%s", fixture.ts.URL, tc.pathID, tc.suffix), tc.body, nil)
+			legacyTodoAssertError(t, response, body, http.StatusBadRequest, "VALIDATION_ERROR", "invalid todo id", "invalid_todo_id", "todoId")
+			if legacyTodoRowCount(t, fixture, control.ID) != 1 || len(legacyTodoAudits(t, fixture, "todo_updated", control.ID))+len(legacyTodoAudits(t, fixture, "todo_moved", control.ID))+len(legacyTodoAudits(t, fixture, "todo_deleted", control.ID)) != 0 {
+				t.Fatal("invalid global ID changed the control Todo or wrote a mutation audit")
+			}
+			legacyTodoAssertNoEvents(t, fixture, project.ID)
+		})
+	}
+}
+
+func TestLegacyTodoMutationsAnonymousModeContract(t *testing.T) {
+	fixture := newLegacyTodoMutationFixture(t, "anonymous")
+	client := legacyTodoAnonymousClient(t, fixture)
+	legacyTodoSeedGlobalIdentity(t, fixture, context.Background(), store.ModeAnonymous)
+	project := legacyTodoCreateTemporaryProject(t, fixture, context.Background())
+	patchTodo := legacyTodoCreateTodo(t, fixture, context.Background(), project.ID, store.ModeAnonymous, store.CreateTodoInput{Title: "Anonymous patch", Body: "before"})
+	moveTodo := legacyTodoCreateTodo(t, fixture, context.Background(), project.ID, store.ModeAnonymous, store.CreateTodoInput{Title: "Anonymous move"})
+	deleteTodo := legacyTodoCreateTodo(t, fixture, context.Background(), project.ID, store.ModeAnonymous, store.CreateTodoInput{Title: "Anonymous delete"})
+	if patchTodo.ID == patchTodo.LocalID || moveTodo.ID == moveTodo.LocalID || deleteTodo.ID == deleteTodo.LocalID {
+		t.Fatalf("fixture identity did not diverge: patch=%+v move=%+v delete=%+v", patchTodo, moveTodo, deleteTodo)
+	}
+
+	legacyTodoResetEvents(fixture)
+	patchBody := legacyTodoFullPatch(patchTodo)
+	patchBody["body"] = "anonymous body"
+	response, body := doJSON(t, client, http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, patchTodo.ID), patchBody, nil)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("anonymous PATCH status=%d body=%s", response.StatusCode, body)
+	}
+	if got := legacyTodoRead(t, fixture, patchTodo.ID); got.Body != "anonymous body" || got.AssigneeUserID != nil {
+		t.Fatalf("anonymous PATCH persisted=%+v", got)
+	}
+	legacyTodoAssertAnonymousAuditActor(t, fixture, "todo_updated", patchTodo.ID)
+	legacyTodoAssertOneRefresh(t, fixture, project.ID, "todo_updated", 0)
+
+	legacyTodoResetEvents(fixture)
+	response, body = doJSON(t, client, http.MethodPost, fmt.Sprintf("%s/api/todos/%d/move", fixture.ts.URL, moveTodo.ID), map[string]any{"toColumnKey": store.DefaultColumnDoing}, nil)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("anonymous MOVE status=%d body=%s", response.StatusCode, body)
+	}
+	if got := legacyTodoRead(t, fixture, moveTodo.ID); got.ColumnKey != store.DefaultColumnDoing {
+		t.Fatalf("anonymous MOVE column=%q", got.ColumnKey)
+	}
+	legacyTodoAssertAnonymousAuditActor(t, fixture, "todo_moved", moveTodo.ID)
+	legacyTodoAssertOneRefresh(t, fixture, project.ID, "todo_moved", 0)
+
+	legacyTodoResetEvents(fixture)
+	response, body = doJSON(t, client, http.MethodDelete, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, deleteTodo.ID), nil, nil)
+	if response.StatusCode != http.StatusNoContent || len(body) != 0 {
+		t.Fatalf("anonymous DELETE status=%d body=%q, want empty 204", response.StatusCode, body)
+	}
+	if legacyTodoRowCount(t, fixture, deleteTodo.ID) != 0 {
+		t.Fatal("anonymous DELETE retained Todo")
+	}
+	legacyTodoAssertAnonymousAuditActor(t, fixture, "todo_deleted", deleteTodo.ID)
+	legacyTodoAssertOneRefresh(t, fixture, project.ID, "todo_deleted", 0)
+}

--- a/internal/httpapi/todo_legacy_update_contract_test.go
+++ b/internal/httpapi/todo_legacy_update_contract_test.go
@@ -1,0 +1,382 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"scrumboy/internal/eventbus"
+	"scrumboy/internal/store"
+)
+
+func TestLegacyTodoPatchAccessAndValidationContracts(t *testing.T) {
+	t.Run("maintainer_success", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		owner, ownerCtx, _ := legacyTodoBootstrapOwner(t, fixture)
+		legacyTodoSeedGlobalIdentity(t, fixture, ownerCtx, store.ModeFull)
+		project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy PATCH maintainer")
+		maintainer := legacyTodoCreateUser(t, fixture, "patch-maintainer@example.com")
+		legacyTodoAddMember(t, fixture, owner, ownerCtx, project.ID, maintainer.ID, store.RoleMaintainer)
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Before", Body: "before"})
+		legacyTodoResetEvents(fixture)
+
+		payload := legacyTodoFullPatch(todo)
+		payload["title"] = "After"
+		payload["body"] = "after"
+		var got todoJSON
+		response, body := doJSON(t, legacyTodoClientForUser(t, fixture, maintainer.ID), http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), payload, &got)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("PATCH status=%d body=%s", response.StatusCode, body)
+		}
+		legacyTodoAssertProjectionIdentity(t, got, todo)
+		if persisted := legacyTodoRead(t, fixture, todo.ID); persisted.Title != "After" || persisted.Body != "after" {
+			t.Fatalf("persisted Todo=%+v", persisted)
+		}
+	})
+
+	t.Run("assigned_contributor_body_only", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		owner, ownerCtx, _ := legacyTodoBootstrapOwner(t, fixture)
+		project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy PATCH assigned contributor")
+		contributor := legacyTodoCreateUser(t, fixture, "patch-assigned-contributor@example.com")
+		legacyTodoAddMember(t, fixture, owner, ownerCtx, project.ID, contributor.ID, store.RoleContributor)
+		points := int64(3)
+		priority := "medium"
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{
+			Title:            "Original title",
+			Body:             "Original body",
+			Tags:             []string{"original"},
+			EstimationPoints: &points,
+			AssigneeUserID:   &contributor.ID,
+			PriorityKey:      &priority,
+		})
+		ledgerBefore := legacyTodoAssignmentCount(t, fixture, todo.ID)
+		legacyTodoResetEvents(fixture)
+		changedPoints := int64(8)
+		payload := map[string]any{
+			"title":            "Attempted title",
+			"body":             "Contributor body",
+			"tags":             []string{"attempted"},
+			"estimationPoints": changedPoints,
+			"assigneeUserId":   contributor.ID,
+			"priorityKey":      "high",
+		}
+		response, body := doJSON(t, legacyTodoClientForUser(t, fixture, contributor.ID), http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), payload, nil)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("assigned contributor PATCH status=%d body=%s", response.StatusCode, body)
+		}
+		persisted := legacyTodoRead(t, fixture, todo.ID)
+		if persisted.Body != "Contributor body" || persisted.Title != todo.Title || !reflect.DeepEqual(persisted.Tags, []string{"original"}) || persisted.EstimationPoints == nil || *persisted.EstimationPoints != points || persisted.PriorityKey == nil || *persisted.PriorityKey != priority {
+			t.Fatalf("body-only scope drifted, persisted=%+v", persisted)
+		}
+		if got := len(legacyTodoAudits(t, fixture, "todo_updated", todo.ID)); got != 0 {
+			t.Fatalf("body-only update audits=%d, want 0", got)
+		}
+		if got := legacyTodoAssignmentCount(t, fixture, todo.ID); got != ledgerBefore {
+			t.Fatalf("assignment rows=%d, want unchanged %d", got, ledgerBefore)
+		}
+		legacyTodoAssertOneRefresh(t, fixture, project.ID, "todo_updated", contributor.ID)
+	})
+
+	failureCases := []struct {
+		name string
+		role store.ProjectRole
+		kind string
+	}{
+		{name: "unassigned_contributor_hidden", role: store.RoleContributor},
+		{name: "viewer_hidden", role: store.RoleViewer},
+		{name: "non_member_hidden", kind: "nonmember"},
+		{name: "no_session_hidden", kind: "anonymous"},
+		{name: "missing_todo", kind: "missing"},
+	}
+	for index, tc := range failureCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newLegacyTodoMutationFixture(t, "full")
+			owner, ownerCtx, ownerClient := legacyTodoBootstrapOwner(t, fixture)
+			project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy PATCH hidden")
+			todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Hidden target", Body: "before"})
+			client := ownerClient
+			todoID := todo.ID
+			switch tc.kind {
+			case "anonymous":
+				client = legacyTodoAnonymousClient(t, fixture)
+			case "missing":
+				todoID += 100000
+			default:
+				actor := legacyTodoCreateUser(t, fixture, fmt.Sprintf("patch-hidden-%d@example.com", index))
+				if tc.kind != "nonmember" {
+					legacyTodoAddMember(t, fixture, owner, ownerCtx, project.ID, actor.ID, tc.role)
+				}
+				client = legacyTodoClientForUser(t, fixture, actor.ID)
+			}
+			legacyTodoResetEvents(fixture)
+			payload := legacyTodoFullPatch(todo)
+			payload["body"] = "forbidden change"
+			response, body := doJSON(t, client, http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todoID), payload, nil)
+			legacyTodoAssertError(t, response, body, http.StatusNotFound, "NOT_FOUND", "not found", "", "")
+			if persisted := legacyTodoRead(t, fixture, todo.ID); persisted.Body != "before" {
+				t.Fatalf("failed PATCH changed body to %q", persisted.Body)
+			}
+			if len(legacyTodoAudits(t, fixture, "todo_updated", todo.ID)) != 0 {
+				t.Fatal("failed PATCH wrote update audit")
+			}
+			legacyTodoAssertNoEvents(t, fixture, project.ID)
+		})
+	}
+
+	t.Run("malformed_json_precedes_required_field", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		_, ownerCtx, client := legacyTodoBootstrapOwner(t, fixture)
+		project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy PATCH malformed")
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Malformed target"})
+		legacyTodoResetEvents(fixture)
+		response, body := legacyTodoDoRawJSON(t, client, http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), `{"title":`)
+		legacyTodoAssertError(t, response, body, http.StatusBadRequest, "VALIDATION_ERROR", "invalid json", "invalid_json", "")
+		if legacyTodoRead(t, fixture, todo.ID).Title != todo.Title {
+			t.Fatal("malformed JSON changed Todo")
+		}
+		legacyTodoAssertNoEvents(t, fixture, project.ID)
+	})
+
+	t.Run("missing_assignee_precedes_missing_todo", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		_, ownerCtx, client := legacyTodoBootstrapOwner(t, fixture)
+		project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy PATCH presence")
+		control := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Presence control"})
+		legacyTodoResetEvents(fixture)
+		response, body := doJSON(t, client, http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, control.ID+100000), map[string]any{"title": "Complete enough to parse"}, nil)
+		legacyTodoAssertError(t, response, body, http.StatusBadRequest, "VALIDATION_ERROR", "missing assigneeUserId", "missing_assignee_user_id", "assigneeUserId")
+		legacyTodoAssertNoEvents(t, fixture, project.ID)
+	})
+
+	t.Run("typed_decode_failure_after_presence", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		_, ownerCtx, client := legacyTodoBootstrapOwner(t, fixture)
+		project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy PATCH typed decode")
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Typed target"})
+		legacyTodoResetEvents(fixture)
+		response, body := doJSON(t, client, http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), map[string]any{"assigneeUserId": nil, "title": []string{"wrong"}}, nil)
+		legacyTodoAssertError(t, response, body, http.StatusBadRequest, "VALIDATION_ERROR", "invalid json payload", "invalid_json", "")
+		if legacyTodoRead(t, fixture, todo.ID).Title != todo.Title {
+			t.Fatal("typed decode failure changed Todo")
+		}
+		legacyTodoAssertNoEvents(t, fixture, project.ID)
+	})
+}
+
+func TestLegacyTodoPatchRealtimeAssignmentAndNoOpContracts(t *testing.T) {
+	t.Run("non_assignment_change", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		owner, ownerCtx, client := legacyTodoBootstrapOwner(t, fixture)
+		project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy PATCH refresh")
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Before", Body: "same"})
+		legacyTodoResetEvents(fixture)
+		stream := subscribeTodoUpdateEvents(t, client, fixture.ts.URL+"/api/board/"+project.Slug+"/events")
+		payload := legacyTodoFullPatch(todo)
+		payload["title"] = "After"
+		response, body := doJSON(t, client, http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), payload, nil)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("PATCH status=%d body=%s", response.StatusCode, body)
+		}
+		if got := len(legacyTodoAudits(t, fixture, "todo_updated", todo.ID)); got != 1 {
+			t.Fatalf("update audit count=%d, want 1", got)
+		}
+		if got := legacyTodoAssignmentCount(t, fixture, todo.ID); got != 0 {
+			t.Fatalf("assignment rows=%d, want 0", got)
+		}
+		legacyTodoAssertOneRefresh(t, fixture, project.ID, "todo_updated", owner.ID)
+		assertTodoUpdateRefreshes(t, collectTodoUpdateEvents(t, stream), project.ID, "todo_updated", 0)
+	})
+
+	t.Run("semantic_no_op", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		owner, ownerCtx, client := legacyTodoBootstrapOwner(t, fixture)
+		project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy PATCH no-op")
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Same", Body: "same"})
+		if _, err := fixture.db.Exec(`UPDATE todos SET updated_at = 1 WHERE id = ?`, todo.ID); err != nil {
+			t.Fatalf("seed updated_at sentinel: %v", err)
+		}
+		legacyTodoResetEvents(fixture)
+		response, body := doJSON(t, client, http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), legacyTodoFullPatch(todo), nil)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("no-op PATCH status=%d body=%s", response.StatusCode, body)
+		}
+		if persisted := legacyTodoRead(t, fixture, todo.ID); persisted.UpdatedAt.UnixMilli() <= 1 {
+			t.Fatalf("no-op did not execute update path: updatedAt=%v", persisted.UpdatedAt)
+		}
+		if len(legacyTodoAudits(t, fixture, "todo_updated", todo.ID)) != 0 || legacyTodoAssignmentCount(t, fixture, todo.ID) != 0 {
+			t.Fatal("semantic no-op wrote audit or assignee ledger")
+		}
+		legacyTodoAssertOneRefresh(t, fixture, project.ID, "todo_updated", owner.ID)
+	})
+
+	t.Run("assignment_set", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		owner, ownerCtx, client := legacyTodoBootstrapOwner(t, fixture)
+		project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy PATCH assignment set")
+		assignee := legacyTodoCreateUser(t, fixture, "patch-set-assignee@example.com")
+		legacyTodoAddMember(t, fixture, owner, ownerCtx, project.ID, assignee.ID, store.RoleContributor)
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Assign me", Body: "same"})
+		legacyTodoResetEvents(fixture)
+		stream := subscribeTodoUpdateEvents(t, client, fixture.ts.URL+"/api/board/"+project.Slug+"/events")
+		payload := legacyTodoFullPatch(todo)
+		payload["assigneeUserId"] = assignee.ID
+		response, body := doJSON(t, client, http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), payload, nil)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("assignment PATCH status=%d body=%s", response.StatusCode, body)
+		}
+		persisted := legacyTodoRead(t, fixture, todo.ID)
+		if persisted.AssigneeUserID == nil || *persisted.AssigneeUserID != assignee.ID || legacyTodoAssignmentCount(t, fixture, todo.ID) != 1 {
+			t.Fatalf("assignment persistence=%+v ledger=%d", persisted, legacyTodoAssignmentCount(t, fixture, todo.ID))
+		}
+		if len(legacyTodoAudits(t, fixture, "todo_updated", todo.ID)) != 0 {
+			t.Fatal("assignment-only PATCH wrote todo_updated audit")
+		}
+		events := legacyTodoEventsForProject(fixture, project.ID)
+		if len(events) != 1 || events[0].Type != "todo.assigned" {
+			t.Fatalf("internal events=%+v, want one todo.assigned and no direct refresh", events)
+		}
+		var domain eventbus.TodoAssignedPayload
+		if err := json.Unmarshal(events[0].Payload, &domain); err != nil {
+			t.Fatalf("decode todo.assigned: %v", err)
+		}
+		if domain.TodoID != todo.ID || domain.LocalID != todo.LocalID || domain.ProjectSlug != project.Slug || domain.ActorUserID != owner.ID || domain.ToAssigneeUID == nil || *domain.ToAssigneeUID != assignee.ID {
+			t.Fatalf("todo.assigned payload=%+v", domain)
+		}
+		assertTodoUpdateRefreshes(t, collectTodoUpdateEvents(t, stream), project.ID, "todo_assigned", 1)
+	})
+
+	t.Run("assignment_clear", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		owner, ownerCtx, client := legacyTodoBootstrapOwner(t, fixture)
+		project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy PATCH assignment clear")
+		assignee := legacyTodoCreateUser(t, fixture, "patch-clear-assignee@example.com")
+		legacyTodoAddMember(t, fixture, owner, ownerCtx, project.ID, assignee.ID, store.RoleContributor)
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Clear me", Body: "same", AssigneeUserID: &assignee.ID})
+		ledgerBefore := legacyTodoAssignmentCount(t, fixture, todo.ID)
+		legacyTodoResetEvents(fixture)
+		stream := subscribeTodoUpdateEvents(t, client, fixture.ts.URL+"/api/board/"+project.Slug+"/events")
+		payload := legacyTodoFullPatch(todo)
+		payload["assigneeUserId"] = nil
+		response, body := doJSON(t, client, http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), payload, nil)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("clear PATCH status=%d body=%s", response.StatusCode, body)
+		}
+		if persisted := legacyTodoRead(t, fixture, todo.ID); persisted.AssigneeUserID != nil {
+			t.Fatalf("assignment was not cleared: %+v", persisted)
+		}
+		if got := legacyTodoAssignmentCount(t, fixture, todo.ID); got != ledgerBefore+1 {
+			t.Fatalf("assignment rows=%d, want %d", got, ledgerBefore+1)
+		}
+		events := legacyTodoEventsForProject(fixture, project.ID)
+		if len(events) != 1 || events[0].Type != "todo.assigned" {
+			t.Fatalf("internal events=%+v, want one todo.assigned", events)
+		}
+		assertTodoUpdateRefreshes(t, collectTodoUpdateEvents(t, stream), project.ID, "todo_assigned", 0)
+	})
+
+	t.Run("assignment_unchanged", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		owner, ownerCtx, client := legacyTodoBootstrapOwner(t, fixture)
+		project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy PATCH assignment unchanged")
+		assignee := legacyTodoCreateUser(t, fixture, "patch-unchanged-assignee@example.com")
+		legacyTodoAddMember(t, fixture, owner, ownerCtx, project.ID, assignee.ID, store.RoleContributor)
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Same assignment", Body: "same", AssigneeUserID: &assignee.ID})
+		ledgerBefore := legacyTodoAssignmentCount(t, fixture, todo.ID)
+		legacyTodoResetEvents(fixture)
+		response, body := doJSON(t, client, http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), legacyTodoFullPatch(todo), nil)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("unchanged assignment PATCH status=%d body=%s", response.StatusCode, body)
+		}
+		if legacyTodoAssignmentCount(t, fixture, todo.ID) != ledgerBefore || len(legacyTodoAudits(t, fixture, "todo_updated", todo.ID)) != 0 {
+			t.Fatal("unchanged assignment wrote ledger or update audit")
+		}
+		legacyTodoAssertOneRefresh(t, fixture, project.ID, "todo_updated", owner.ID)
+	})
+}
+
+func TestLegacyTodoPatchCompatibilityPayloadAndProjectionContracts(t *testing.T) {
+	t.Run("replacement_fields_are_not_sparse", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		_, ownerCtx, client := legacyTodoBootstrapOwner(t, fixture)
+		project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy PATCH replacement")
+		points := int64(5)
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Required title", Body: "before", Tags: []string{"stable"}, EstimationPoints: &points})
+		legacyTodoResetEvents(fixture)
+		response, body := doJSON(t, client, http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), map[string]any{"body": "attempted", "assigneeUserId": nil}, nil)
+		legacyTodoAssertError(t, response, body, http.StatusBadRequest, "VALIDATION_ERROR", "validation: invalid title", "invalid_title", "")
+		persisted := legacyTodoRead(t, fixture, todo.ID)
+		if persisted.Title != todo.Title || persisted.Body != todo.Body || !reflect.DeepEqual(persisted.Tags, []string{"stable"}) || persisted.EstimationPoints == nil || *persisted.EstimationPoints != points {
+			t.Fatalf("failed replacement PATCH changed Todo: %+v", persisted)
+		}
+		legacyTodoAssertNoEvents(t, fixture, project.ID)
+	})
+
+	t.Run("sprint_id_is_ignored", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		_, ownerCtx, client := legacyTodoBootstrapOwner(t, fixture)
+		legacyTodoSeedGlobalIdentity(t, fixture, ownerCtx, store.ModeFull)
+		project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy PATCH ignored sprint")
+		now := time.Now().UTC()
+		originalSprint, err := fixture.store.CreateSprint(ownerCtx, project.ID, "Original sprint", now, now.Add(7*24*time.Hour))
+		if err != nil {
+			t.Fatalf("create original sprint: %v", err)
+		}
+		otherSprint, err := fixture.store.CreateSprint(ownerCtx, project.ID, "Other sprint", now.Add(8*24*time.Hour), now.Add(15*24*time.Hour))
+		if err != nil {
+			t.Fatalf("create other sprint: %v", err)
+		}
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Sprint target", Body: "same", SprintID: &originalSprint.ID})
+		for _, supplied := range []any{nil, otherSprint.ID} {
+			payload := legacyTodoFullPatch(legacyTodoRead(t, fixture, todo.ID))
+			payload["sprintId"] = supplied
+			var got todoJSON
+			response, body := doJSON(t, client, http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), payload, &got)
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("PATCH sprintId=%v status=%d body=%s", supplied, response.StatusCode, body)
+			}
+			persisted := legacyTodoRead(t, fixture, todo.ID)
+			if persisted.SprintID == nil || *persisted.SprintID != originalSprint.ID || got.SprintId == nil || *got.SprintId != originalSprint.ID {
+				t.Fatalf("supplied sprintId=%v changed/suppressed original: persisted=%+v response=%+v", supplied, persisted, got)
+			}
+		}
+	})
+
+	t.Run("legacy_success_projection", func(t *testing.T) {
+		fixture := newLegacyTodoMutationFixture(t, "full")
+		_, ownerCtx, client := legacyTodoBootstrapOwner(t, fixture)
+		legacyTodoSeedGlobalIdentity(t, fixture, ownerCtx, store.ModeFull)
+		project := legacyTodoCreateProject(t, fixture, ownerCtx, "Legacy PATCH projection")
+		now := time.Now().UTC()
+		sprint, err := fixture.store.CreateSprint(ownerCtx, project.ID, "Projection sprint", now, now.Add(7*24*time.Hour))
+		if err != nil {
+			t.Fatalf("create projection sprint: %v", err)
+		}
+		medium := "medium"
+		todo := legacyTodoCreateTodo(t, fixture, ownerCtx, project.ID, store.ModeFull, store.CreateTodoInput{Title: "Projection before", Body: "before", Tags: []string{"old"}, SprintID: &sprint.ID, PriorityKey: &medium})
+		if todo.ID == todo.LocalID {
+			t.Fatalf("fixture identity did not diverge: %+v", todo)
+		}
+		points := int64(8)
+		payload := map[string]any{
+			"title":            "Projection after",
+			"body":             "after body",
+			"tags":             []string{"alpha", "beta"},
+			"estimationPoints": points,
+			"assigneeUserId":   nil,
+			"priorityKey":      "high",
+		}
+		var got todoJSON
+		response, body := doJSON(t, client, http.MethodPatch, fmt.Sprintf("%s/api/todos/%d", fixture.ts.URL, todo.ID), payload, &got)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("projection PATCH status=%d body=%s", response.StatusCode, body)
+		}
+		legacyTodoAssertProjectionIdentity(t, got, todo)
+		if got.Title != "Projection after" || got.Body != "after body" || got.Status != "BACKLOG" || got.ColumnKey != store.DefaultColumnBacklog || got.EstimationPoints == nil || *got.EstimationPoints != points || got.PriorityKey == nil || *got.PriorityKey != "high" || got.SprintId == nil || *got.SprintId != sprint.ID || !reflect.DeepEqual(got.Tags, []string{"alpha", "beta"}) {
+			t.Fatalf("legacy projection=%+v", got)
+		}
+	})
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.31.4"
+const Version = "3.31.5"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
Work completed:

Refactored the legacy numeric To Do mutation paths to use the application service layer, completing the migration of update, move, and delete operations away from transport-owned business logic. The refactor preserves the existing legacy API contracts, including global numeric ID semantics, authorization and validation precedence, event and refresh behavior, projection handling, and anonymous/temporary board behavior, while consolidating mutation orchestration behind prepared services. Characterization and service-level regression tests lock down the legacy behavior throughout the migration, reducing duplication and bringing the legacy endpoints in line with Scrumboy’s modern read/write architecture without intentionally changing externally observable behavior.

Deferred items:

@tungstendev9 Numeric MOVE currently permits mutation on an expired temporary board. Phase 22 deliberately preserved this pre-existing behavior. It should be addressed separately as an explicitly behavior-changing correctness/security task with dedicated policy and compatibility review