### PR TITLE
fix post-mutation board refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.32.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags), **3.29.0** (MCP JSON-RPC error/`board_get` identity), **3.30.0** (reversible per-project sprint capability), **3.31.0** (per-project priority tiers) - see those releases.
 
+## [3.32.1] - 2026-08-15
+
+### Fixed
+
+- **Post-mutation board refresh keeps filter context** - Todo save and delete
+  refreshes now pass assignee, sort, and priority from the URL into
+  `loadBoardBySlug`, so those board filters are no longer dropped after a
+  dialog mutation. Coverage locks the refresh argument wiring.
+
 ## [3.32.0] - 2026-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.32.0-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.32.1-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/internal/httpapi/web/app.js
+++ b/internal/httpapi/web/app.js
@@ -11,7 +11,7 @@ import { initTheme, handleThemeChange, getStoredTheme, THEME_SYSTEM, THEME_DARK,
 import { escapeHTML, showToast, showConfirmDialog } from './dist/utils.js';
 import { apiFetch } from './dist/api.js';
 import { navigate, router } from './dist/router.js';
-import { getRoute, getProjectId, getBoard, getAuthStatusAvailable, getMobileTab, getSlug, getTag, getSearch, getSprintIdFromUrl, getProjectView, getProjectsTab, getProjects, getSettingsProjectId, getEditingTodo, getAvailableTags, getAutocompleteSuggestion, getAvailableTagsMap, getTagColors, getUser, getSettingsActiveTab, getBackupImportBtn, getBackupData, getBackupPreview, getAuthStatusChecked } from './dist/state/selectors.js';
+import { getRoute, getProjectId, getBoard, getAuthStatusAvailable, getMobileTab, getSlug, getTag, getSearch, getSprintIdFromUrl, getAssigneeFromUrl, getSortFromUrl, getPriorityFromUrl, getProjectView, getProjectsTab, getProjects, getSettingsProjectId, getEditingTodo, getAvailableTags, getAutocompleteSuggestion, getAvailableTagsMap, getTagColors, getUser, getSettingsActiveTab, getBackupImportBtn, getBackupData, getBackupPreview, getAuthStatusChecked } from './dist/state/selectors.js';
 import { setProjectId, setBoard, setSlug, setTag, setMobileTab, setProjects, setProjectsTab, setProjectView, setEditingTodo, setAvailableTags, setAvailableTagsMap, setAutocompleteSuggestion, setTagColors, setSettingsProjectId, setSettingsActiveTab, setBackupImportBtn, setBackupData, setBackupPreview } from './dist/state/mutations.js';
 import { openTodoDialog, renderTagsChips, setupTagAutocomplete, removeTag, renderTagAutocomplete, getTagsFromChips, resetAssigneeSelect, getTodoFormPermissions, requestTodoDialogClose } from './dist/dialogs/todo.js';
 import { buildTodoCreatePayload, buildTodoPatchPayload, shouldSubmitSprintAssignment } from './dist/dialogs/todo-submit.js';
@@ -133,7 +133,7 @@ deleteTodoBtn.addEventListener("click", async () => {
     setEditingTodo(null);
     onTodoDialogClosed();
     await requestTodoDialogClose({ force: true, reason: "delete" });
-    await loadBoardBySlug(getSlug(), getTag(), getSearch(), getSprintIdFromUrl());
+    await loadBoardBySlug(getSlug(), getTag(), getSearch(), getSprintIdFromUrl(), getAssigneeFromUrl(), getSortFromUrl(), getPriorityFromUrl());
   } catch (err) {
     showToast(apiErrorMessage(err, { fallbackKey: "todo.deleteFailed" }));
   }
@@ -221,7 +221,7 @@ todoForm.addEventListener("submit", async (e) => {
     await requestTodoDialogClose({ force: true, reason: "save" });
     // Invalidate tags cache so Settings modal shows newly created tags
     invalidateTagsCache();
-    await loadBoardBySlug(getSlug(), getTag(), getSearch(), getSprintIdFromUrl());
+    await loadBoardBySlug(getSlug(), getTag(), getSearch(), getSprintIdFromUrl(), getAssigneeFromUrl(), getSortFromUrl(), getPriorityFromUrl());
   } catch (err) {
     showToast(apiErrorMessage(err, { fallbackKey: "todo.saveFailed" }));
   }

--- a/internal/httpapi/web/modules/app-post-mutation-refresh.test.ts
+++ b/internal/httpapi/web/modules/app-post-mutation-refresh.test.ts
@@ -1,0 +1,240 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiFetchMock, loadBoardBySlugMock, state } = vi.hoisted(() => ({
+  apiFetchMock: vi.fn().mockResolvedValue({}),
+  loadBoardBySlugMock: vi.fn().mockResolvedValue(undefined),
+  state: {
+    editingTodo: null as any,
+  },
+}));
+
+vi.mock("../dist/dom/elements.js", () => ({
+  app: document.getElementById("app"),
+  toast: document.getElementById("toast"),
+  todoDialog: document.getElementById("todoDialog"),
+  todoForm: document.getElementById("todoForm"),
+  todoDialogTitle: document.getElementById("todoDialogTitle"),
+  todoTitle: document.getElementById("todoTitle"),
+  todoBody: document.getElementById("todoBody"),
+  todoTags: document.getElementById("todoTags"),
+  todoStatus: document.getElementById("todoStatus"),
+  todoEstimationPoints: document.getElementById("todoEstimationPoints"),
+  todoPriority: document.getElementById("todoPriority"),
+  deleteTodoBtn: document.getElementById("deleteTodoBtn"),
+  closeTodoBtn: document.getElementById("closeTodoBtn"),
+  settingsDialog: document.getElementById("settingsDialog"),
+  closeSettingsBtn: document.getElementById("closeSettingsBtn"),
+}));
+
+vi.mock("../dist/theme.js", () => ({
+  initTheme: vi.fn(),
+  handleThemeChange: vi.fn(),
+  getStoredTheme: vi.fn(),
+  THEME_SYSTEM: "system",
+  THEME_DARK: "dark",
+  THEME_LIGHT: "light",
+}));
+
+vi.mock("../dist/utils.js", () => ({
+  escapeHTML: (value: string) => value,
+  showToast: vi.fn(),
+  showConfirmDialog: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../dist/api.js", () => ({ apiFetch: apiFetchMock }));
+vi.mock("../dist/router.js", () => ({
+  navigate: vi.fn(),
+  router: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../dist/state/selectors.js", () => ({
+  getRoute: vi.fn(),
+  getProjectId: vi.fn(() => 1),
+  getBoard: vi.fn(() => ({ project: { id: 1, slug: "alpha" }, columns: {} })),
+  getAuthStatusAvailable: vi.fn(() => true),
+  getMobileTab: vi.fn(() => "backlog"),
+  getSlug: vi.fn(() => "alpha"),
+  getTag: vi.fn(() => "bug"),
+  getSearch: vi.fn(() => "find"),
+  getSprintIdFromUrl: vi.fn(() => "7"),
+  getAssigneeFromUrl: vi.fn(() => "42"),
+  getSortFromUrl: vi.fn(() => "newest"),
+  getPriorityFromUrl: vi.fn(() => "high"),
+  getProjectView: vi.fn(),
+  getProjectsTab: vi.fn(),
+  getProjects: vi.fn(() => []),
+  getSettingsProjectId: vi.fn(),
+  getEditingTodo: vi.fn(() => state.editingTodo),
+  getAvailableTags: vi.fn(() => []),
+  getAutocompleteSuggestion: vi.fn(),
+  getAvailableTagsMap: vi.fn(() => new Map()),
+  getTagColors: vi.fn(() => ({})),
+  getUser: vi.fn(() => ({ id: 1 })),
+  getSettingsActiveTab: vi.fn(),
+  getBackupImportBtn: vi.fn(),
+  getBackupData: vi.fn(),
+  getBackupPreview: vi.fn(),
+  getAuthStatusChecked: vi.fn(() => true),
+}));
+
+vi.mock("../dist/state/mutations.js", () => ({
+  setProjectId: vi.fn(),
+  setBoard: vi.fn(),
+  setSlug: vi.fn(),
+  setTag: vi.fn(),
+  setMobileTab: vi.fn(),
+  setProjects: vi.fn(),
+  setProjectsTab: vi.fn(),
+  setProjectView: vi.fn(),
+  setEditingTodo: vi.fn((todo: any) => {
+    state.editingTodo = todo;
+  }),
+  setAvailableTags: vi.fn(),
+  setAvailableTagsMap: vi.fn(),
+  setAutocompleteSuggestion: vi.fn(),
+  setTagColors: vi.fn(),
+  setSettingsProjectId: vi.fn(),
+  setSettingsActiveTab: vi.fn(),
+  setBackupImportBtn: vi.fn(),
+  setBackupData: vi.fn(),
+  setBackupPreview: vi.fn(),
+}));
+
+vi.mock("../dist/dialogs/todo.js", () => ({
+  openTodoDialog: vi.fn(),
+  renderTagsChips: vi.fn(),
+  setupTagAutocomplete: vi.fn(),
+  removeTag: vi.fn(),
+  renderTagAutocomplete: vi.fn(),
+  getTagsFromChips: vi.fn(() => []),
+  resetAssigneeSelect: vi.fn(),
+  getTodoFormPermissions: vi.fn(() => ({ canSubmitTodo: true })),
+  requestTodoDialogClose: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../dist/dialogs/todo-submit.js", () => ({
+  buildTodoCreatePayload: vi.fn(() => ({})),
+  buildTodoPatchPayload: vi.fn(() => ({})),
+  shouldSubmitSprintAssignment: vi.fn(() => false),
+}));
+
+vi.mock("../dist/dialogs/settings.js", () => ({
+  renderSettingsModal: vi.fn().mockResolvedValue(undefined),
+  invalidateTagsCache: vi.fn(),
+  resumeAuthenticationMethodFlow: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../dist/features/drag-drop.js", () => ({
+  initDnD: vi.fn(),
+  columnsSpec: vi.fn(),
+  dragInProgress: false,
+  dragJustEnded: false,
+}));
+vi.mock("../dist/features/context-menu.js", () => ({ setupContextMenuCloseHandler: vi.fn() }));
+vi.mock("../dist/features/context-menu-button.js", () => ({ setupContextMenuButtonHandler: vi.fn() }));
+vi.mock("../dist/views/index.js", () => ({
+  loadBoardBySlug: loadBoardBySlugMock,
+  onTodoDialogClosed: vi.fn(),
+}));
+vi.mock("../dist/realtime/guard.js", () => ({ recordLocalMutation: vi.fn() }));
+vi.mock("../dist/pwaUpdate.js", () => ({ registerPwaGlobals: vi.fn() }));
+vi.mock("../dist/core/keybindings.js", () => ({ initKeybindings: vi.fn() }));
+vi.mock("../dist/core/modal-outside-click.js", () => ({ initModalOutsideClickClose: vi.fn() }));
+vi.mock("../dist/i18n/index.js", () => ({
+  I18N_LOCALE_CHANGED: "i18n:locale-changed",
+  apiErrorMessage: vi.fn(() => "error"),
+  hydrateI18n: vi.fn(),
+  initI18n: vi.fn().mockResolvedValue(undefined),
+  t: (key: string) => key,
+}));
+vi.mock("../dist/i18n/qa.js", () => ({ installI18nQa: vi.fn() }));
+vi.mock("../dist/sprints.js", () => ({ boardSprintsEnabled: vi.fn(() => false) }));
+
+function installDom(): void {
+  document.body.innerHTML = `
+    <div id="app"></div>
+    <div id="toast"></div>
+    <dialog id="todoDialog"></dialog>
+    <form id="todoForm">
+      <h2 id="todoDialogTitle"></h2>
+      <input id="todoTitle" value="Edited title" />
+      <textarea id="todoBody"></textarea>
+      <input id="todoTags" />
+      <select id="todoStatus"><option value="backlog" selected>Backlog</option></select>
+      <select id="todoEstimationPoints"><option value="" selected></option></select>
+      <select id="todoPriority"><option value="low" selected>Low</option></select>
+      <select id="todoAssignee"><option value="99" selected>User 99</option></select>
+      <select id="todoSprint"><option value="7" selected>Sprint 7</option></select>
+      <div id="todoSprintField"></div>
+      <button id="deleteTodoBtn" type="button">Delete</button>
+      <button id="closeTodoBtn" type="button">Close</button>
+    </form>
+    <dialog id="settingsDialog"></dialog>
+    <button id="closeSettingsBtn" type="button">Close settings</button>
+  `;
+}
+
+async function loadApp(): Promise<void> {
+  await import("../app.js");
+}
+
+async function expectContextCompleteReload(): Promise<void> {
+  await vi.waitFor(() => expect(loadBoardBySlugMock).toHaveBeenCalledTimes(1));
+  expect(loadBoardBySlugMock).toHaveBeenCalledWith(
+    "alpha",
+    "bug",
+    "find",
+    "7",
+    "42",
+    "newest",
+    "high",
+  );
+}
+
+describe("app post-mutation board refresh context", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    installDom();
+    window.history.replaceState({}, "", "/alpha?assignee=42&sort=newest&priority=high");
+    state.editingTodo = {
+      localId: 4,
+      columnKey: "backlog",
+      status: "Backlog",
+      sprintId: null,
+    };
+  });
+
+  it("preserves active board filters after saving and deleting a todo", async () => {
+    await loadApp();
+
+    document.getElementById("todoForm")!.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+    await expectContextCompleteReload();
+    const todoSubmit = await import("../dist/dialogs/todo-submit.js");
+    expect(todoSubmit.buildTodoPatchPayload).toHaveBeenCalledWith(expect.objectContaining({
+      assigneeUserId: 99,
+      priorityKey: "low",
+    }));
+
+    // Creation changes the visible order under newest/oldest sorting, so it
+    // must use the same context-complete follow-up load as edits and moves.
+    loadBoardBySlugMock.mockClear();
+    state.editingTodo = null;
+    document.getElementById("todoForm")!.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    await expectContextCompleteReload();
+
+    loadBoardBySlugMock.mockClear();
+    state.editingTodo = {
+      localId: 4,
+      columnKey: "backlog",
+      status: "Backlog",
+      sprintId: null,
+    };
+
+    (document.getElementById("deleteTodoBtn") as HTMLButtonElement).click();
+
+    await expectContextCompleteReload();
+  });
+});

--- a/internal/httpapi/web/modules/views/board-realtime.test.ts
+++ b/internal/httpapi/web/modules/views/board-realtime.test.ts
@@ -211,6 +211,24 @@ describe("board-realtime drag refresh guards", () => {
     expect(invalidateBoardMock).toHaveBeenCalledWith("alpha", "bug", "login", "7", null, null, null);
   });
 
+  it("cancels a filter-complete realtime recovery when a manual board load starts", async () => {
+    const mod = await loadBoardRealtimeModule();
+    selectorState.assignee = "42";
+    selectorState.sort = "newest";
+    selectorState.priority = "high";
+    guardState.lastLocalMutationTimestamp = Date.now();
+    guardState.lastBoardInteractionTimestamp = Date.now();
+
+    mod.__queuePendingRealtimeRefreshForTest("alpha");
+    expect(mod.__getPendingRealtimeRefreshSlugForTest()).toBe("alpha");
+
+    mod.clearPendingRealtimeRefresh();
+    vi.advanceTimersByTime(mod.__getMaxRefreshDelayMsForTest() + 500);
+
+    expect(mod.__getPendingRealtimeRefreshSlugForTest()).toBeNull();
+    expect(invalidateBoardMock).not.toHaveBeenCalled();
+  });
+
   it("does not turn a private creator activity toast into a board refresh", async () => {
     const mod = await loadBoardRealtimeModule();
     selectorState.authStatusAvailable = true;

--- a/internal/httpapi/web/modules/views/board-rendering.test.ts
+++ b/internal/httpapi/web/modules/views/board-rendering.test.ts
@@ -1,8 +1,11 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Board } from '../types.js';
-import { buildTopbarHtml, renderTodoCard } from './board-rendering.js';
-import { buildTopbarHtml as buildTopbarHtmlDist } from '../../dist/views/board-rendering.js';
+import { buildBoardColumnsHtml, buildTopbarHtml, renderTodoCard } from './board-rendering.js';
+import {
+  buildBoardColumnsHtml as buildBoardColumnsHtmlDist,
+  buildTopbarHtml as buildTopbarHtmlDist,
+} from '../../dist/views/board-rendering.js';
 import enCatalog from '../i18n/locales/en.json';
 import pseudoCatalog from '../i18n/locales/pseudo.json';
 
@@ -35,10 +38,35 @@ function renderTopbar(showVoiceCommands: boolean): string {
   });
 }
 
+function renderMobileColumns(render: typeof buildBoardColumnsHtml, value: Board): HTMLElement {
+  const boardCols = [
+    { key: 'backlog', title: 'Backlog', isDone: false },
+    { key: 'done', title: 'Done', isDone: true },
+  ];
+  const host = document.createElement('div');
+  host.innerHTML = render({
+    boardCols,
+    board: value,
+    activeMobileTab: 'backlog',
+    laneMetaByKey: {},
+    laneDisplayCount: (key) => value.columns[key]?.length ?? 0,
+    membersByUserId: {},
+    cardOpts: {
+      priorityTiers: {
+        normal: { name: 'Normal', color: '#6B7280' },
+        high: { name: 'High', color: '#EF4444' },
+      },
+    },
+  });
+  return host;
+}
+
 describe('board topbar rendering', () => {
   afterEach(async () => {
     const i18n = await import('../i18n/index.js');
+    const distI18n = await import('../../dist/i18n/index.js');
     i18n.resetI18nForTests();
+    distI18n.resetI18nForTests();
   });
 
   it('renders the voice command trigger only when explicitly enabled', () => {
@@ -172,5 +200,52 @@ describe('board topbar rendering', () => {
     });
 
     expect(html).not.toContain('card__priority');
+  });
+
+  it.each([
+    ['maintained source', buildBoardColumnsHtml],
+    ['committed runtime', buildBoardColumnsHtmlDist],
+  ])('keeps Backlog active while a todo moved to Done disappears from that mobile lane (%s)', (_label, render) => {
+    const value = board();
+    value.columnOrder = [
+      { key: 'backlog', name: 'Backlog', isDone: false },
+      { key: 'done', name: 'Done', isDone: true },
+    ];
+    value.columns = {
+      backlog: [],
+      done: [{ id: 11, localId: 4, title: 'Moved', status: 'DONE', tags: [] }],
+    };
+
+    const host = renderMobileColumns(render, value);
+
+    expect(host.querySelector('[data-column="backlog"]')?.classList.contains('col--mobile-active')).toBe(true);
+    expect(host.querySelector('[data-column="backlog"] .card')).toBeNull();
+    expect(host.querySelector('[data-column="done"]')?.classList.contains('col--mobile-active')).toBe(false);
+    expect(host.querySelector('[data-column="done"] .card')?.textContent).toContain('Moved');
+  });
+
+  it.each([
+    ['maintained source', buildBoardColumnsHtml],
+    ['committed runtime', buildBoardColumnsHtmlDist],
+  ])('renders the refreshed High badge on an ordinary unfiltered mobile board (%s)', async (_label, render) => {
+    const i18n = await import('../i18n/index.js');
+    const distI18n = await import('../../dist/i18n/index.js');
+    await i18n.initI18n({ locale: 'en', loadLocale: vi.fn(async () => enCatalog) });
+    await distI18n.initI18n({ locale: 'en', loadLocale: vi.fn(async () => enCatalog) });
+    const value = board();
+    value.columnOrder = [
+      { key: 'backlog', name: 'Backlog', isDone: false },
+      { key: 'done', name: 'Done', isDone: true },
+    ];
+    value.columns = {
+      backlog: [{ id: 12, localId: 5, title: 'Escalated', status: 'BACKLOG', tags: [], priorityKey: 'high' }],
+      done: [],
+    };
+
+    const host = renderMobileColumns(render, value);
+
+    expect(host.querySelector('[data-column="backlog"]')?.classList.contains('col--mobile-active')).toBe(true);
+    expect(host.querySelector('[data-column="backlog"] .card__priority')?.textContent).toBe('High');
+    expect(host.querySelector('[data-column="backlog"] .card')?.textContent).not.toContain('Normal');
   });
 });

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.32.0"
+const Version = "3.32.1"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
fixes a post-mutation board refresh bug that could leave filtered boards showing stale data after editing, creating, moving, or deleting todos. The manual refresh path was not preserving the active assignee, sort, and priority context, causing otherwise valid board responses to be rejected by the existing request-identity guard. The fix passes the full board filter/sort context through post-mutation reloads, aligning them with the rest of the refresh infrastructure, and adds regression coverage for filtered refresh behavior, realtime cancellation interaction, and rendering of updated lane and priority state.
