### PR TITLE
fix(board): persist sort preference and dedupe assignee filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.32.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags), **3.29.0** (MCP JSON-RPC error/`board_get` identity), **3.30.0** (reversible per-project sprint capability), **3.31.0** (per-project priority tiers) - see those releases.
 
+## [3.32.2] - 2026-08-17
+
+### Changed
+
+- **Board filter assignee list** - When signed in, **Assigned to me** is the
+  canonical current-user option; the duplicate named member entry is omitted.
+  Bookmarked numeric assignee IDs still highlight **Assigned to me**. Anonymous
+  boards are unchanged.
+
+### Added
+
+- **Remembered board sort** - Signed-in users persist Default / Newest / Oldest
+  through the existing user-preferences API. Entering a board without `?sort=`
+  applies the saved preference; an explicit `?sort=newest` or `?sort=oldest`
+  still wins for that navigation and does not overwrite the stored preference.
+
 ## [3.32.1] - 2026-08-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.32.1-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.32.2-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/internal/httpapi/web/dist/core/board-sort-preferences.js
+++ b/internal/httpapi/web/dist/core/board-sort-preferences.js
@@ -1,0 +1,51 @@
+import { apiFetch } from '../api.js';
+import { getUser } from '../state/selectors.js';
+export const BOARD_TODO_SORT_DEFAULT = 'default';
+export const BOARD_TODO_SORT_STORAGE_KEY = 'scrumboy.boardTodoSort';
+export const BOARD_TODO_SORT_PREFERENCE_KEY = 'boardTodoSort';
+export function isBoardTodoSortUrlParam(value) {
+    return value === 'newest' || value === 'oldest';
+}
+export function normalizeBoardTodoSort(value) {
+    return isBoardTodoSortUrlParam(value) ? value : BOARD_TODO_SORT_DEFAULT;
+}
+export function boardTodoSortUrlParam(preference) {
+    return isBoardTodoSortUrlParam(preference) ? preference : null;
+}
+export function getBoardTodoSortPreference() {
+    try {
+        return normalizeBoardTodoSort(localStorage.getItem(BOARD_TODO_SORT_STORAGE_KEY));
+    }
+    catch {
+        return BOARD_TODO_SORT_DEFAULT;
+    }
+}
+export function setBoardTodoSortPreference(value, opts) {
+    const next = normalizeBoardTodoSort(value);
+    if (!opts?.skipRemote && !getUser())
+        return;
+    try {
+        localStorage.setItem(BOARD_TODO_SORT_STORAGE_KEY, next);
+    }
+    catch {
+    }
+    if (opts?.skipRemote || !getUser())
+        return;
+    void apiFetch('/api/user/preferences', {
+        method: 'PUT',
+        body: JSON.stringify({ key: BOARD_TODO_SORT_PREFERENCE_KEY, value: next }),
+    }).catch(() => { });
+}
+export function hydrateBoardTodoSortFromServer(value) {
+    setBoardTodoSortPreference(normalizeBoardTodoSort(value), { skipRemote: true });
+}
+export async function loadBoardTodoSortPreferenceFromServer(fetchPreference) {
+    hydrateBoardTodoSortFromServer(BOARD_TODO_SORT_DEFAULT);
+    try {
+        const response = await fetchPreference();
+        hydrateBoardTodoSortFromServer(response?.value ?? BOARD_TODO_SORT_DEFAULT);
+    }
+    catch {
+        // Keep default when signed-in hydration fails.
+    }
+}

--- a/internal/httpapi/web/dist/router.js
+++ b/internal/httpapi/web/dist/router.js
@@ -11,6 +11,7 @@ import { hydrateVoiceFlowEnabledFromServer, hydrateVoiceFlowHandsFreeConfirmatio
 import { loadUserEmailNotifyPref } from './core/email-notify-preferences.js';
 import { setDefaultCardsPerLane, CARDS_PER_LANE_PREFERENCE_KEY } from './orchestration/board-refresh.js';
 import { loadWrapLanesPreferenceFromServer, WRAP_LANES_PREFERENCE_KEY, } from './core/wrap-lanes-preferences.js';
+import { BOARD_TODO_SORT_PREFERENCE_KEY, boardTodoSortUrlParam, getBoardTodoSortPreference, isBoardTodoSortUrlParam, loadBoardTodoSortPreferenceFromServer, } from './core/board-sort-preferences.js';
 // Attach foreground listeners once at module load (idempotent guard lives in initForegroundLifecycle).
 initForegroundLifecycle();
 let isRouting = false;
@@ -209,6 +210,7 @@ async function routeOnceBody() {
                 // Ignore errors
             }
             await loadWrapLanesPreferenceFromServer(() => apiFetch(`/api/user/preferences?key=${WRAP_LANES_PREFERENCE_KEY}`));
+            await loadBoardTodoSortPreferenceFromServer(() => apiFetch(`/api/user/preferences?key=${BOARD_TODO_SORT_PREFERENCE_KEY}`));
             // Load email notification preferences
             await loadUserEmailNotifyPref();
         }
@@ -238,13 +240,22 @@ async function routeOnceBody() {
             hydrateNotificationsForUser(null);
         }
     }
-    const r = parseRoute();
+    let r = parseRoute();
     const authMethodReturn = new URL(window.location.href).searchParams.get("auth_method");
     if (authMethodReturn && getUser()) {
         const cleanURL = new URL(window.location.href);
         cleanURL.searchParams.delete("auth_method");
         window.history.replaceState({}, "", cleanURL.pathname + cleanURL.search + cleanURL.hash);
         window.setTimeout(() => window.dispatchEvent(new CustomEvent("scrumboy:auth-method-return", { detail: authMethodReturn })), 0);
+    }
+    if (r.name === "boardBySlug" && getUser() && !isBoardTodoSortUrlParam(r.sort)) {
+        const applied = boardTodoSortUrlParam(getBoardTodoSortPreference());
+        if (applied) {
+            const url = new URL(window.location.href);
+            url.searchParams.set("sort", applied);
+            history.replaceState({}, "", url.pathname + url.search + url.hash);
+            r = parseRoute();
+        }
     }
     console.log("Router: parsed route:", r);
     setRoute(r.name);

--- a/internal/httpapi/web/dist/views/board-filters.js
+++ b/internal/httpapi/web/dist/views/board-filters.js
@@ -1,6 +1,7 @@
 import { on } from '../events.js';
 import { apiErrorMessage, t } from '../i18n/index.js';
-import { getAssigneeFromUrl, getBoard, getPriorityFromUrl, getSearch, getSlug, getSortFromUrl, getSprintIdFromUrl, getTag, getTagColors, } from '../state/selectors.js';
+import { normalizeBoardTodoSort, setBoardTodoSortPreference } from '../core/board-sort-preferences.js';
+import { getAssigneeFromUrl, getBoard, getPriorityFromUrl, getSearch, getSlug, getSortFromUrl, getSprintIdFromUrl, getTag, getTagColors, getUser, } from '../state/selectors.js';
 import { boardSprintsEnabled } from '../sprints.js';
 import { isAnonymousBoard, showToast } from '../utils.js';
 import { buildChipsHTML, getCombinedChipData, isBoardFilterActive, } from './board-rendering.js';
@@ -244,6 +245,9 @@ function handleFilterPanelDocumentClick(e) {
         }
         else if (kind === "sort") {
             setSortParam(value);
+            if (getUser()) {
+                setBoardTodoSortPreference(normalizeBoardTodoSort(value));
+            }
             panel.querySelectorAll("[data-sort-option]").forEach((el) => el.classList.remove("is-active"));
         }
         else {

--- a/internal/httpapi/web/dist/views/board-rendering.js
+++ b/internal/httpapi/web/dist/views/board-rendering.js
@@ -320,11 +320,14 @@ function assigneeFilterOptionsHtml(assignee, boardMembers, user) {
     const allAssigneesLabel = escapeHTML(t("board.filters.allAssignees"));
     const unassignedLabel = escapeHTML(t("board.filters.unassigned"));
     const assignedToMeLabel = escapeHTML(t("board.filters.assignedToMe"));
-    const optionClass = (value) => `search-filter-option${current === value ? " is-active" : ""}`;
+    const currentUserId = user && typeof user.id === "number" ? user.id : null;
+    const meIsActive = current === "me" || (currentUserId != null && current === String(currentUserId));
+    const optionClass = (value, active = current === value) => `search-filter-option${active ? " is-active" : ""}`;
     const meOption = user
-        ? `<button type="button" class="${optionClass("me")}" data-assignee-option="me" data-i18n-text="board.filters.assignedToMe">${assignedToMeLabel}</button>`
+        ? `<button type="button" class="${optionClass("me", meIsActive)}" data-assignee-option="me" data-i18n-text="board.filters.assignedToMe">${assignedToMeLabel}</button>`
         : "";
     const memberOptions = boardMembers
+        .filter((m) => currentUserId == null || m.userId !== currentUserId)
         .map((m) => {
         const value = String(m.userId);
         return `<button type="button" class="${optionClass(value)}" data-assignee-option="${escapeHTML(value)}">${escapeHTML(memberDisplayName(m))}</button>`;

--- a/internal/httpapi/web/modules/core/board-sort-preferences.test.ts
+++ b/internal/httpapi/web/modules/core/board-sort-preferences.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setUser } from '../state/mutations.js';
+import {
+  BOARD_TODO_SORT_STORAGE_KEY,
+  boardTodoSortUrlParam,
+  getBoardTodoSortPreference,
+  hydrateBoardTodoSortFromServer,
+  isBoardTodoSortUrlParam,
+  loadBoardTodoSortPreferenceFromServer,
+  normalizeBoardTodoSort,
+  setBoardTodoSortPreference,
+} from './board-sort-preferences.js';
+
+beforeEach(() => {
+  localStorage.clear();
+  setUser(null);
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  setUser(null);
+  vi.unstubAllGlobals();
+});
+
+describe('board todo sort preferences', () => {
+  it('defaults missing values to default and persists locally', () => {
+    expect(getBoardTodoSortPreference()).toBe('default');
+    setBoardTodoSortPreference('newest', { skipRemote: true });
+    expect(localStorage.getItem(BOARD_TODO_SORT_STORAGE_KEY)).toBe('newest');
+    expect(getBoardTodoSortPreference()).toBe('newest');
+  });
+
+  it('normalizes missing and invalid values to default', () => {
+    expect(normalizeBoardTodoSort(undefined)).toBe('default');
+    expect(normalizeBoardTodoSort(null)).toBe('default');
+    expect(normalizeBoardTodoSort('')).toBe('default');
+    expect(normalizeBoardTodoSort('unexpected')).toBe('default');
+    expect(normalizeBoardTodoSort('newest')).toBe('newest');
+    expect(normalizeBoardTodoSort('oldest')).toBe('oldest');
+    expect(normalizeBoardTodoSort('default')).toBe('default');
+  });
+
+  it('hydrates invalid server values back to default', () => {
+    setBoardTodoSortPreference('newest', { skipRemote: true });
+    hydrateBoardTodoSortFromServer('unexpected');
+    expect(getBoardTodoSortPreference()).toBe('default');
+  });
+
+  it('loadBoardTodoSortPreferenceFromServer resets stale local newest when server preference is missing', async () => {
+    setBoardTodoSortPreference('newest', { skipRemote: true });
+    await loadBoardTodoSortPreferenceFromServer(async () => ({ value: '' }));
+    expect(getBoardTodoSortPreference()).toBe('default');
+  });
+
+  it('loadBoardTodoSortPreferenceFromServer keeps default when fetch fails after reset', async () => {
+    setBoardTodoSortPreference('oldest', { skipRemote: true });
+    await loadBoardTodoSortPreferenceFromServer(async () => {
+      throw new Error('network');
+    });
+    expect(getBoardTodoSortPreference()).toBe('default');
+  });
+
+  it('loadBoardTodoSortPreferenceFromServer applies server newest after reset', async () => {
+    setBoardTodoSortPreference('oldest', { skipRemote: true });
+    await loadBoardTodoSortPreferenceFromServer(async () => ({ value: 'newest' }));
+    expect(getBoardTodoSortPreference()).toBe('newest');
+  });
+
+  it('loadBoardTodoSortPreferenceFromServer applies server oldest after reset', async () => {
+    await loadBoardTodoSortPreferenceFromServer(async () => ({ value: 'oldest' }));
+    expect(getBoardTodoSortPreference()).toBe('oldest');
+  });
+
+  it('saves the board sort preference through the existing user preference endpoint when signed in', () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    setUser({ id: 1, name: 'Ada' });
+
+    setBoardTodoSortPreference('newest');
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/user/preferences', expect.objectContaining({
+      method: 'PUT',
+      body: JSON.stringify({ key: 'boardTodoSort', value: 'newest' }),
+    }));
+  });
+
+  it('does not PUT when skipRemote is set', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    setUser({ id: 1, name: 'Ada' });
+
+    setBoardTodoSortPreference('oldest', { skipRemote: true });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not write local or remote preference state when user is not signed in', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    setUser(null);
+
+    setBoardTodoSortPreference('newest');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem(BOARD_TODO_SORT_STORAGE_KEY)).toBeNull();
+    expect(getBoardTodoSortPreference()).toBe('default');
+  });
+
+  it('treats only newest and oldest as valid URL sort overrides', () => {
+    expect(isBoardTodoSortUrlParam('newest')).toBe(true);
+    expect(isBoardTodoSortUrlParam('oldest')).toBe(true);
+    expect(isBoardTodoSortUrlParam('default')).toBe(false);
+    expect(isBoardTodoSortUrlParam('')).toBe(false);
+    expect(isBoardTodoSortUrlParam(null)).toBe(false);
+    expect(isBoardTodoSortUrlParam('bogus')).toBe(false);
+  });
+
+  it('maps a saved preference to a URL sort param only for newest and oldest', () => {
+    expect(boardTodoSortUrlParam('newest')).toBe('newest');
+    expect(boardTodoSortUrlParam('oldest')).toBe('oldest');
+    expect(boardTodoSortUrlParam('default')).toBeNull();
+  });
+});

--- a/internal/httpapi/web/modules/core/board-sort-preferences.ts
+++ b/internal/httpapi/web/modules/core/board-sort-preferences.ts
@@ -1,0 +1,59 @@
+import { apiFetch } from '../api.js';
+import { getUser } from '../state/selectors.js';
+
+export const BOARD_TODO_SORT_DEFAULT = 'default';
+export const BOARD_TODO_SORT_STORAGE_KEY = 'scrumboy.boardTodoSort';
+export const BOARD_TODO_SORT_PREFERENCE_KEY = 'boardTodoSort';
+
+export type BoardTodoSortUrlParam = 'newest' | 'oldest';
+export type BoardTodoSort = 'default' | BoardTodoSortUrlParam;
+
+export function isBoardTodoSortUrlParam(value: unknown): value is BoardTodoSortUrlParam {
+  return value === 'newest' || value === 'oldest';
+}
+
+export function normalizeBoardTodoSort(value: unknown): BoardTodoSort {
+  return isBoardTodoSortUrlParam(value) ? value : BOARD_TODO_SORT_DEFAULT;
+}
+
+export function boardTodoSortUrlParam(preference: BoardTodoSort): BoardTodoSortUrlParam | null {
+  return isBoardTodoSortUrlParam(preference) ? preference : null;
+}
+
+export function getBoardTodoSortPreference(): BoardTodoSort {
+  try {
+    return normalizeBoardTodoSort(localStorage.getItem(BOARD_TODO_SORT_STORAGE_KEY));
+  } catch {
+    return BOARD_TODO_SORT_DEFAULT;
+  }
+}
+
+export function setBoardTodoSortPreference(value: unknown, opts?: { skipRemote?: boolean }): void {
+  const next = normalizeBoardTodoSort(value);
+  if (!opts?.skipRemote && !getUser()) return;
+  try {
+    localStorage.setItem(BOARD_TODO_SORT_STORAGE_KEY, next);
+  } catch {
+  }
+  if (opts?.skipRemote || !getUser()) return;
+  void apiFetch('/api/user/preferences', {
+    method: 'PUT',
+    body: JSON.stringify({ key: BOARD_TODO_SORT_PREFERENCE_KEY, value: next }),
+  }).catch(() => {});
+}
+
+export function hydrateBoardTodoSortFromServer(value: unknown): void {
+  setBoardTodoSortPreference(normalizeBoardTodoSort(value), { skipRemote: true });
+}
+
+export async function loadBoardTodoSortPreferenceFromServer(
+  fetchPreference: () => Promise<{ value?: string } | null | undefined>,
+): Promise<void> {
+  hydrateBoardTodoSortFromServer(BOARD_TODO_SORT_DEFAULT);
+  try {
+    const response = await fetchPreference();
+    hydrateBoardTodoSortFromServer(response?.value ?? BOARD_TODO_SORT_DEFAULT);
+  } catch {
+    // Keep default when signed-in hydration fails.
+  }
+}

--- a/internal/httpapi/web/modules/router.test.ts
+++ b/internal/httpapi/web/modules/router.test.ts
@@ -470,3 +470,194 @@ describe('router wrap lanes hydration', () => {
     expect(prefs.getWrapLanesPreference()).toBe(false);
   });
 });
+
+describe('router board todo sort hydration', () => {
+  function userBob() {
+    return {
+      id: 8,
+      email: 'bob@example.com',
+      name: 'Bob',
+      isBootstrap: false,
+      systemRole: 'user',
+      twoFactorEnabled: false,
+    };
+  }
+
+  function installSignedInAuth(user: ReturnType<typeof userStatus>, boardTodoSortValue: string): void {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/auth/status') {
+        return {
+          user,
+          bootstrapAvailable: false,
+          mode: 'full',
+          pushConfigured: false,
+          selfServicePasswordResetEnabled: false,
+          oidcEnabled: false,
+          localAuthEnabled: true,
+          wallEnabled: false,
+          markdownNotesEnabled: false,
+          mermaidNotesEnabled: false,
+        };
+      }
+      if (url === '/api/me') {
+        return user;
+      }
+      if (url.includes('key=boardTodoSort')) {
+        return { value: boardTodoSortValue };
+      }
+      if (url.startsWith('/api/user/preferences?key=')) {
+        return { value: '' };
+      }
+      throw new Error(`unexpected apiFetch url: ${url}`);
+    });
+  }
+
+  function installAnonymousAuth(): void {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/auth/status') {
+        return {
+          user: null,
+          bootstrapAvailable: false,
+          mode: 'anonymous',
+          pushConfigured: false,
+          selfServicePasswordResetEnabled: false,
+          oidcEnabled: false,
+          localAuthEnabled: true,
+          wallEnabled: false,
+          markdownNotesEnabled: false,
+          mermaidNotesEnabled: false,
+        };
+      }
+      throw new Error(`unexpected apiFetch url: ${url}`);
+    });
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+    window.history.replaceState({}, '', '/');
+    localStorage.clear();
+    apiFetchMock.mockReset();
+    renderProjectsMock.mockReset();
+    renderProjectsMock.mockResolvedValue(undefined);
+    renderBoardMock.mockReset();
+    renderBoardMock.mockResolvedValue(undefined);
+    loadUserThemeMock.mockClear();
+    applyWallpaperForAuthContextMock.mockClear();
+    loadUserWallpaperMock.mockClear();
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('applies saved newest to a board URL with no sort before render', async () => {
+    window.history.replaceState({}, '', '/alpha');
+    installSignedInAuth(userStatus(), 'newest');
+    const mod = await loadRouterModule();
+
+    await mod.router();
+
+    expect(new URL(window.location.href).searchParams.get('sort')).toBe('newest');
+    expect(renderBoardMock).toHaveBeenCalledTimes(1);
+    expect(renderBoardMock.mock.calls[0][5]).toBe('newest');
+  });
+
+  it('applies saved oldest to a board URL with no sort before render', async () => {
+    window.history.replaceState({}, '', '/alpha');
+    installSignedInAuth(userStatus(), 'oldest');
+    const mod = await loadRouterModule();
+
+    await mod.router();
+
+    expect(new URL(window.location.href).searchParams.get('sort')).toBe('oldest');
+    expect(renderBoardMock.mock.calls[0][5]).toBe('oldest');
+  });
+
+  it('leaves a board URL without sort when the saved preference is default', async () => {
+    window.history.replaceState({}, '', '/alpha');
+    installSignedInAuth(userStatus(), 'default');
+    const mod = await loadRouterModule();
+
+    await mod.router();
+
+    expect(new URL(window.location.href).searchParams.get('sort')).toBeNull();
+    expect(renderBoardMock.mock.calls[0][5]).toBeNull();
+  });
+
+  it('lets an explicit sort=oldest override a saved newest without overwriting the preference', async () => {
+    window.history.replaceState({}, '', '/alpha?sort=oldest');
+    installSignedInAuth(userStatus(), 'newest');
+    const mod = await loadRouterModule();
+
+    await mod.router();
+
+    const prefs = await import('./core/board-sort-preferences.js');
+    expect(new URL(window.location.href).searchParams.get('sort')).toBe('oldest');
+    expect(renderBoardMock.mock.calls[0][5]).toBe('oldest');
+    expect(prefs.getBoardTodoSortPreference()).toBe('newest');
+    expect(apiFetchMock.mock.calls.some((call) => call[0] === '/api/user/preferences' && call[1]?.method === 'PUT')).toBe(false);
+  });
+
+  it('does not let an invalid sort query override a saved newest preference', async () => {
+    window.history.replaceState({}, '', '/alpha?sort=bogus');
+    installSignedInAuth(userStatus(), 'newest');
+    const mod = await loadRouterModule();
+
+    await mod.router();
+
+    const prefs = await import('./core/board-sort-preferences.js');
+    expect(new URL(window.location.href).searchParams.get('sort')).toBe('newest');
+    expect(renderBoardMock.mock.calls[0][5]).toBe('newest');
+    expect(prefs.getBoardTodoSortPreference()).toBe('newest');
+    expect(apiFetchMock.mock.calls.some((call) => call[0] === '/api/user/preferences' && call[1]?.method === 'PUT')).toBe(false);
+  });
+
+  it('leaves an invalid sort query alone when the saved preference is default', async () => {
+    window.history.replaceState({}, '', '/alpha?sort=bogus');
+    installSignedInAuth(userStatus(), 'default');
+    const mod = await loadRouterModule();
+
+    await mod.router();
+
+    const prefs = await import('./core/board-sort-preferences.js');
+    expect(new URL(window.location.href).searchParams.get('sort')).toBe('bogus');
+    expect(renderBoardMock.mock.calls[0][5]).toBe('bogus');
+    expect(prefs.getBoardTodoSortPreference()).toBe('default');
+    expect(apiFetchMock.mock.calls.some((call) => call[0] === '/api/user/preferences' && call[1]?.method === 'PUT')).toBe(false);
+  });
+
+  it('keeps URL-only sort behavior when there is no authenticated user', async () => {
+    const prefs = await import('./core/board-sort-preferences.js');
+    localStorage.setItem(prefs.BOARD_TODO_SORT_STORAGE_KEY, 'newest');
+    window.history.replaceState({}, '', '/alpha');
+    installAnonymousAuth();
+    const mod = await loadRouterModule();
+
+    await mod.router();
+
+    expect(new URL(window.location.href).searchParams.get('sort')).toBeNull();
+    expect(renderBoardMock.mock.calls[0][5]).toBeNull();
+    expect(apiFetchMock.mock.calls.some((call) => typeof call[0] === 'string' && call[0].includes('key=boardTodoSort'))).toBe(false);
+  });
+
+  it('does not carry board todo sort from user A to user B on login', async () => {
+    const prefs = await import('./core/board-sort-preferences.js');
+    localStorage.setItem(prefs.BOARD_TODO_SORT_STORAGE_KEY, 'newest');
+    installSignedInAuth(userStatus(), 'newest');
+    const mod = await loadRouterModule();
+    await mod.router();
+    expect(prefs.getBoardTodoSortPreference()).toBe('newest');
+
+    const mutations = await import('./state/mutations.js');
+    mutations.setAuthStatusChecked(false);
+    installSignedInAuth(userBob(), '');
+    window.history.replaceState({}, '', '/alpha');
+    await mod.router();
+
+    expect(prefs.getBoardTodoSortPreference()).toBe('default');
+    expect(new URL(window.location.href).searchParams.get('sort')).toBeNull();
+    expect(renderBoardMock.mock.calls.at(-1)?.[5]).toBeNull();
+  });
+});

--- a/internal/httpapi/web/modules/router.ts
+++ b/internal/httpapi/web/modules/router.ts
@@ -23,6 +23,13 @@ import {
   loadWrapLanesPreferenceFromServer,
   WRAP_LANES_PREFERENCE_KEY,
 } from './core/wrap-lanes-preferences.js';
+import {
+  BOARD_TODO_SORT_PREFERENCE_KEY,
+  boardTodoSortUrlParam,
+  getBoardTodoSortPreference,
+  isBoardTodoSortUrlParam,
+  loadBoardTodoSortPreferenceFromServer,
+} from './core/board-sort-preferences.js';
 
 // Attach foreground listeners once at module load (idempotent guard lives in initForegroundLifecycle).
 initForegroundLifecycle();
@@ -243,6 +250,10 @@ async function routeOnceBody(): Promise<void> {
         apiFetch<{ value: string }>(`/api/user/preferences?key=${WRAP_LANES_PREFERENCE_KEY}`),
       );
 
+      await loadBoardTodoSortPreferenceFromServer(() =>
+        apiFetch<{ value: string }>(`/api/user/preferences?key=${BOARD_TODO_SORT_PREFERENCE_KEY}`),
+      );
+
       // Load email notification preferences
       await loadUserEmailNotifyPref();
     }
@@ -272,7 +283,7 @@ async function routeOnceBody(): Promise<void> {
     }
   }
 
-  const r = parseRoute();
+  let r = parseRoute();
 	const authMethodReturn = new URL(window.location.href).searchParams.get("auth_method");
 	if (authMethodReturn && getUser()) {
 		const cleanURL = new URL(window.location.href);
@@ -280,6 +291,15 @@ async function routeOnceBody(): Promise<void> {
 		window.history.replaceState({}, "", cleanURL.pathname + cleanURL.search + cleanURL.hash);
 		window.setTimeout(() => window.dispatchEvent(new CustomEvent("scrumboy:auth-method-return", { detail: authMethodReturn })), 0);
 	}
+  if (r.name === "boardBySlug" && getUser() && !isBoardTodoSortUrlParam(r.sort)) {
+    const applied = boardTodoSortUrlParam(getBoardTodoSortPreference());
+    if (applied) {
+      const url = new URL(window.location.href);
+      url.searchParams.set("sort", applied);
+      history.replaceState({}, "", url.pathname + url.search + url.hash);
+      r = parseRoute();
+    }
+  }
   console.log("Router: parsed route:", r);
   setRoute(r.name);
   setTag(r.tag || "");

--- a/internal/httpapi/web/modules/views/board-filter-panel.test.ts
+++ b/internal/httpapi/web/modules/views/board-filter-panel.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Board, PriorityTier } from '../types.js';
 import { NO_PRIORITY_FILTER_VALUE } from '../types.js';
+import { BOARD_TODO_SORT_STORAGE_KEY, getBoardTodoSortPreference } from '../core/board-sort-preferences.js';
 import { buildFilterPanelHtml, isBoardFilterActive } from './board-rendering.js';
 import type { BoardMember } from '../state/state.js';
 import enCatalog from '../i18n/locales/en.json';
@@ -12,12 +13,14 @@ const selectorState: {
   tag: string;
   search: string;
   tagColors: Record<string, string>;
+  user: { id: number; name: string; email: string } | null;
 } = {
   board: null,
   slug: null,
   tag: '',
   search: '',
   tagColors: {},
+  user: { id: 1, name: 'Me', email: 'me@example.com' },
 };
 
 const toastMock = vi.fn();
@@ -32,6 +35,7 @@ vi.mock('../state/selectors.js', () => ({
   getSprintIdFromUrl: () => new URL(window.location.href).searchParams.get('sprintId'),
   getTag: () => selectorState.tag,
   getTagColors: () => selectorState.tagColors,
+  getUser: () => selectorState.user,
 }));
 
 vi.mock('../utils.js', () => ({
@@ -55,6 +59,7 @@ vi.mock('../utils.js', () => ({
 
 function makeMembers(): BoardMember[] {
   return [
+    { userId: 1, name: 'Me', email: 'me@example.com', role: 'contributor' },
     { userId: 5, name: 'Alice Example', email: 'alice@example.com', role: 'maintainer' },
     { userId: 9, name: '', email: 'noname@example.com', role: 'contributor' },
   ];
@@ -98,6 +103,9 @@ async function setupState(url: string, opts?: { tag?: string; search?: string; a
 
 describe('board filter panel (assignee + sort)', () => {
   beforeEach(async () => {
+    localStorage.clear();
+    selectorState.user = { id: 1, name: 'Me', email: 'me@example.com' };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 204 })));
     const i18n = await import('../i18n/index.js');
     await i18n.initI18n({
       locale: 'en',
@@ -109,12 +117,15 @@ describe('board filter panel (assignee + sort)', () => {
     const i18n = await import('../i18n/index.js');
     i18n.resetI18nForTests();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     document.body.innerHTML = '';
     window.history.replaceState({}, '', '/');
+    localStorage.clear();
     selectorState.board = null;
     selectorState.slug = null;
     selectorState.tag = '';
     selectorState.search = '';
+    selectorState.user = { id: 1, name: 'Me', email: 'me@example.com' };
   });
 
   describe('buildFilterPanelHtml', () => {
@@ -126,6 +137,7 @@ describe('board filter panel (assignee + sort)', () => {
       expect(html).toContain('data-assignee-option=""');
       expect(html).toContain('data-assignee-option="unassigned"');
       expect(html).toContain('data-assignee-option="me"');
+      expect(html).not.toContain('data-assignee-option="1"');
       expect(html).toContain('data-assignee-option="5"');
       expect(html).toContain('>Alice Example<');
       // Falls back to email when name is blank.
@@ -138,6 +150,23 @@ describe('board filter panel (assignee + sort)', () => {
     it('omits the "Assigned to me" option when there is no logged-in user (anonymous/temp boards)', () => {
       const html = buildFilterPanelHtml(null, null, makeMembers(), null);
       expect(html).not.toContain('data-assignee-option="me"');
+      expect(html).toContain('data-assignee-option="1"');
+      expect(html).toContain('data-assignee-option="5"');
+      expect(html).toContain('data-assignee-option="9"');
+    });
+
+    it('omits the logged-in user\'s named member option while keeping Assigned to me and other members', () => {
+      const html = buildFilterPanelHtml(null, null, makeMembers(), { id: 1, name: 'Me', email: 'me@example.com' });
+      expect(html).toContain('data-assignee-option="me"');
+      expect(html).not.toContain('data-assignee-option="1"');
+      expect(html).toContain('data-assignee-option="5"');
+      expect(html).toContain('data-assignee-option="9"');
+    });
+
+    it('marks Assigned to me as active for a legacy numeric current-user assignee value', () => {
+      const html = buildFilterPanelHtml('1', null, makeMembers(), { id: 1, name: 'Me', email: 'me@example.com' });
+      expect(html).toContain('class="search-filter-option is-active" data-assignee-option="me"');
+      expect(html).not.toContain('data-assignee-option="1"');
     });
 
     it('marks the option matching the current assignee/sort value as active', () => {
@@ -335,6 +364,57 @@ describe('board filter panel (assignee + sort)', () => {
       expect(new URL(window.location.href).searchParams.get('sort')).toBeNull();
       expect(reloadBoard).toHaveBeenLastCalledWith('alpha', '', null, null, null, null, null);
       expect(toastMock).not.toHaveBeenCalled();
+    });
+
+    it('persists newest, oldest, and default board sort preferences when signed in', async () => {
+      const { boardFilters } = await setupState('/alpha');
+      const reloadBoard = vi.fn().mockResolvedValue(undefined);
+      boardFilters.bindBoardFilterUi({ reloadBoard, showError: vi.fn() });
+
+      (document.querySelector('[data-sort-option="newest"]') as HTMLButtonElement).click();
+      expect(new URL(window.location.href).searchParams.get('sort')).toBe('newest');
+      expect(getBoardTodoSortPreference()).toBe('newest');
+      expect(localStorage.getItem(BOARD_TODO_SORT_STORAGE_KEY)).toBe('newest');
+      expect(fetch).toHaveBeenCalledWith('/api/user/preferences', expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ key: 'boardTodoSort', value: 'newest' }),
+      }));
+
+      (document.querySelector('[data-sort-option="oldest"]') as HTMLButtonElement).click();
+      expect(new URL(window.location.href).searchParams.get('sort')).toBe('oldest');
+      expect(getBoardTodoSortPreference()).toBe('oldest');
+      expect(fetch).toHaveBeenCalledWith('/api/user/preferences', expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ key: 'boardTodoSort', value: 'oldest' }),
+      }));
+
+      toastMock.mockClear();
+      (document.querySelector('[data-sort-option=""]') as HTMLButtonElement).click();
+      expect(new URL(window.location.href).searchParams.get('sort')).toBeNull();
+      expect(getBoardTodoSortPreference()).toBe('default');
+      expect(fetch).toHaveBeenCalledWith('/api/user/preferences', expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ key: 'boardTodoSort', value: 'default' }),
+      }));
+      expect(reloadBoard).toHaveBeenLastCalledWith('alpha', '', null, null, null, null, null);
+      expect(toastMock).not.toHaveBeenCalled();
+    });
+
+    it('does not PUT a board sort preference when there is no signed-in user', async () => {
+      selectorState.user = null;
+      const { boardFilters } = await setupState('/alpha', { user: null });
+      const reloadBoard = vi.fn().mockResolvedValue(undefined);
+      boardFilters.bindBoardFilterUi({ reloadBoard, showError: vi.fn() });
+      const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+      fetchMock.mockClear();
+
+      (document.querySelector('[data-sort-option="newest"]') as HTMLButtonElement).click();
+
+      expect(new URL(window.location.href).searchParams.get('sort')).toBe('newest');
+      expect(reloadBoard).toHaveBeenCalledWith('alpha', '', null, null, null, 'newest', null);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(localStorage.getItem(BOARD_TODO_SORT_STORAGE_KEY)).toBeNull();
+      expect(getBoardTodoSortPreference()).toBe('default');
     });
 
     it('toggles the --active pulse class on the toggle button as filters are applied/cleared', async () => {

--- a/internal/httpapi/web/modules/views/board-filters.test.ts
+++ b/internal/httpapi/web/modules/views/board-filters.test.ts
@@ -26,6 +26,7 @@ vi.mock('../state/selectors.js', () => ({
   getSprintIdFromUrl: () => new URL(window.location.href).searchParams.get('sprintId'),
   getTag: () => selectorState.tag,
   getTagColors: () => selectorState.tagColors,
+  getUser: () => null,
 }));
 
 vi.mock('../utils.js', () => ({

--- a/internal/httpapi/web/modules/views/board-filters.ts
+++ b/internal/httpapi/web/modules/views/board-filters.ts
@@ -1,5 +1,6 @@
 import { on } from '../events.js';
 import { apiErrorMessage, t } from '../i18n/index.js';
+import { normalizeBoardTodoSort, setBoardTodoSortPreference } from '../core/board-sort-preferences.js';
 import {
   getAssigneeFromUrl,
   getBoard,
@@ -10,6 +11,7 @@ import {
   getSprintIdFromUrl,
   getTag,
   getTagColors,
+  getUser,
 } from '../state/selectors.js';
 import { Board } from '../types.js';
 import { boardSprintsEnabled } from '../sprints.js';
@@ -270,6 +272,9 @@ function handleFilterPanelDocumentClick(e: MouseEvent): void {
       panel.querySelectorAll("[data-assignee-option]").forEach((el) => el.classList.remove("is-active"));
     } else if (kind === "sort") {
       setSortParam(value);
+      if (getUser()) {
+        setBoardTodoSortPreference(normalizeBoardTodoSort(value));
+      }
       panel.querySelectorAll("[data-sort-option]").forEach((el) => el.classList.remove("is-active"));
     } else {
       setPriorityParam(value);

--- a/internal/httpapi/web/modules/views/board-rendering.ts
+++ b/internal/httpapi/web/modules/views/board-rendering.ts
@@ -422,11 +422,14 @@ function assigneeFilterOptionsHtml(assignee: string | null, boardMembers: BoardM
   const allAssigneesLabel = escapeHTML(t("board.filters.allAssignees"));
   const unassignedLabel = escapeHTML(t("board.filters.unassigned"));
   const assignedToMeLabel = escapeHTML(t("board.filters.assignedToMe"));
-  const optionClass = (value: string) => `search-filter-option${current === value ? " is-active" : ""}`;
+  const currentUserId = user && typeof user.id === "number" ? user.id : null;
+  const meIsActive = current === "me" || (currentUserId != null && current === String(currentUserId));
+  const optionClass = (value: string, active = current === value) => `search-filter-option${active ? " is-active" : ""}`;
   const meOption = user
-    ? `<button type="button" class="${optionClass("me")}" data-assignee-option="me" data-i18n-text="board.filters.assignedToMe">${assignedToMeLabel}</button>`
+    ? `<button type="button" class="${optionClass("me", meIsActive)}" data-assignee-option="me" data-i18n-text="board.filters.assignedToMe">${assignedToMeLabel}</button>`
     : "";
   const memberOptions = boardMembers
+    .filter((m) => currentUserId == null || m.userId !== currentUserId)
     .map((m) => {
       const value = String(m.userId);
       return `<button type="button" class="${optionClass(value)}" data-assignee-option="${escapeHTML(value)}">${escapeHTML(memberDisplayName(m))}</button>`;

--- a/internal/store/sprint_definition_contract_test.go
+++ b/internal/store/sprint_definition_contract_test.go
@@ -96,8 +96,8 @@ func TestSprintDefinitionStoreOwnsDefinitionValidationByState(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CreateSprint: %v", err)
 		}
-		if err := st.ActivateSprint(ctx, project.ID, active.ID); err != nil {
-			t.Fatalf("ActivateSprint: %v", err)
+		if _, err := st.db.ExecContext(ctx, `UPDATE sprints SET state = ?, started_at = ? WHERE id = ?`, SprintStateActive, start.UnixMilli(), active.ID); err != nil {
+			t.Fatalf("set active fixture state: %v", err)
 		}
 		newName := "renamed active"
 		if err := st.UpdateSprint(ctx, active.ID, UpdateSprintInput{Name: &newName}); err == nil || !strings.Contains(err.Error(), "only endAt") {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.32.1"
+const Version = "3.32.2"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
- Your own name is now filtered out of the Assignee section (Assigned to me was always there, thus redundant)
- Your sort preference for Newest First, Oldest First, etc. is retained.
