### PR TITLE
Security/go 1.25.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.32.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags), **3.29.0** (MCP JSON-RPC error/`board_get` identity), **3.30.0** (reversible per-project sprint capability), **3.31.0** (per-project priority tiers) - see those releases.
 
+## [3.32.4] - 2026-08-18
+
+### Security
+
+- **Go 1.25.13 toolchain** - Bump the `go.mod` toolchain from `go1.25.12` to
+  `go1.25.13` and pin the Docker build image to `golang:1.25.13-alpine` by
+  multi-platform manifest digest so the standard-library vulnerabilities
+  fixed in that patch are no longer reported by OSV Scanner. The `go 1.25.0`
+  language-version directive is unchanged.
+
 ## [3.32.3] - 2026-08-17
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # runs on the host arch. With CGO disabled the build cross-compiles to the
 # requested TARGETARCH natively -- no QEMU emulation of the compiler, so multi
 # -arch builds stay fast.
-FROM --platform=$BUILDPLATFORM golang:1.25.12-alpine@sha256:56961d79ea8129efddcc0b8643fd8a5416b4e6228cfd477e3fd61deb2672c587 AS build
+FROM --platform=$BUILDPLATFORM golang:1.25.13-alpine@sha256:1e0126852075c9c60731c8ba49088448b91f63e2aed97ca9d1a9791622a05946 AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.32.3-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.32.4-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module scrumboy
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 require (
 	github.com/SherClockHolmes/webpush-go v1.4.0

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.32.3"
+const Version = "3.32.4"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
**Go 1.25.13 toolchain** - Bump the `go.mod` toolchain from `go1.25.12` to
  `go1.25.13` and pin the Docker build image to `golang:1.25.13-alpine` by
  multi-platform manifest digest so the standard-library vulnerabilities
  fixed in that patch are no longer reported by OSV Scanner. The `go 1.25.0`
  language-version directive is unchanged.