### PR TITLE
feat: double-click a lane or board background to create a card

### DIFF
--- a/internal/httpapi/web/dist/views/board-dblclick.js
+++ b/internal/httpapi/web/dist/views/board-dblclick.js
@@ -1,0 +1,32 @@
+// Double-click-to-create target resolution for the board view.
+//
+// Double-clicking anywhere on a lane (header, padding, or empty list space)
+// creates a card in that lane; double-clicking empty board background (below,
+// beside, or between lanes) creates a card in the first column of the
+// workflow. Double-clicks on cards or interactive controls resolve to null so
+// existing behavior (single-click edit, buttons) is untouched.
+/** Empty board surface: creating from here targets the first workflow column. */
+const BACKGROUND_SELECTOR = ".board, .mobile-board-wrapper, .container, .page";
+/**
+ * Elements whose double-clicks must not trigger creation: cards (single-click
+ * already opens edit), lane controls like "Load more", and form controls.
+ */
+const INTERACTIVE_SELECTOR = "[data-todo-id], [data-load-more], button, a, input, textarea, select, label, [role='button'], [contenteditable='true']";
+/**
+ * Resolve a double-click target to the column key a new card should go to,
+ * or null when the double-click should do nothing.
+ */
+export function resolveDblClickCreateTarget(target, firstColumnKey) {
+    if (!(target instanceof Element))
+        return null;
+    if (target.closest(INTERACTIVE_SELECTOR))
+        return null;
+    const col = target.closest(".col");
+    if (col) {
+        // The agenda lane shows calendar events, not workflow todos.
+        if (col.classList.contains("col--agenda"))
+            return null;
+        return col.getAttribute("data-column") || null;
+    }
+    return target.matches(BACKGROUND_SELECTOR) ? firstColumnKey : null;
+}

--- a/internal/httpapi/web/dist/views/board.js
+++ b/internal/httpapi/web/dist/views/board.js
@@ -21,6 +21,7 @@ import { on, off } from '../events.js';
 import { recordLocalMutation, } from '../realtime/guard.js';
 import { buildBoardColumnsHtml, buildFiltersHtml, buildNoResultsHtml, buildTopbarHtml, buildPriorityTierMap, getBoardColumns, visibleBoardLaneCount, renderVoiceCommandTriggerHtml, renderTodoCard, } from './board-rendering.js';
 import { AGENDA_COLUMN_KEY, agendaEvents, agendaLaneColor, agendaLaneTitle, agendaMobileTabAriaLabel, agendaMobileTabInnerHtml, applyAgendaScrollAfterRender, buildAgendaColumnHtml, captureAgendaListScroll, flushAgendaInitialScroll, isAgendaEnabled } from './board-agenda.js';
+import { resolveDblClickCreateTarget } from './board-dblclick.js';
 import { clearTodoMultiSelection, ensureBulkEditUi, getSelectedTodoIds, toggleTodoSelection, } from './board-selection.js';
 import { bootstrapLoadedBoardView } from './board-load-bootstrap.js';
 import { bindBoardFilterUi, clearSprintChipData, clearSprintChipDataIfSlugChanged, computeBoardChipsRender, ensureSprintSubscription, hasSprintChipDataForSlug, resetBoardFilterUiState, setSprintChipDataForSlug, updateChipsOnly, } from './board-filters.js';
@@ -392,6 +393,26 @@ function attachBoardDelegationHandlers() {
             contextMenu.style.left = `${mouseEvent.pageX}px`;
             contextMenu.style.top = `${mouseEvent.pageY}px`;
         }
+    });
+    // Double-click on a lane creates a card there; on empty board background,
+    // in the first workflow column. Bound on .page so the background below and
+    // beside the lanes is included. Desktop-only: no manual double-tap
+    // detection (mobile uses lane tabs and the New Todo button).
+    const pageEl = boardEl.closest(".page") ?? boardEl;
+    pageEl.addEventListener("dblclick", (e) => {
+        if (dragInProgress || dragJustEnded)
+            return;
+        const board = getBoard();
+        if (!board)
+            return;
+        if (!(isTemporaryBoard(board) || currentUserProjectRole === "maintainer"))
+            return;
+        const firstColumnKey = getBoardColumns(board)[0]?.key || "backlog";
+        const status = resolveDblClickCreateTarget(e.target, firstColumnKey);
+        if (!status)
+            return;
+        e.preventDefault();
+        openTodoDialog({ mode: "create", status, role: currentUserProjectRole });
     });
     ensureBulkEditUi({
         getRole: () => currentUserProjectRole,

--- a/internal/httpapi/web/modules/views/board-dblclick.test.ts
+++ b/internal/httpapi/web/modules/views/board-dblclick.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { resolveDblClickCreateTarget } from './board-dblclick.js';
+
+const FIRST_KEY = 'backlog';
+
+function q(selector: string): Element {
+  const el = document.querySelector(selector);
+  if (!el) throw new Error(`missing test element: ${selector}`);
+  return el;
+}
+
+describe('resolveDblClickCreateTarget', () => {
+  beforeEach(() => {
+    // Mirrors the board view markup: .page > .container > .mobile-board-wrapper > .board > section.col
+    document.body.innerHTML = `
+      <div class="page">
+        <div class="container">
+          <div class="filters"><div class="chips" id="tagChips"></div></div>
+          <div class="mobile-board-wrapper">
+            <div class="mobile-tabs" id="mobileTabs"></div>
+            <div class="board">
+              <section class="col col--agenda" data-column="agenda">
+                <div class="col__head"><span class="col__title">Agenda</span></div>
+                <div class="col__list" data-status="agenda"></div>
+              </section>
+              <section class="col" data-column="backlog">
+                <div class="col__head col__head--backlog"><span class="col__title">Not Started</span><span class="col__count">1</span></div>
+                <div class="col__list" data-status="backlog">
+                  <div class="card" data-todo-id="7" id="todo_7"><span class="card__title">Existing todo</span></div>
+                </div>
+                <div class="col__load-more" data-load-more="backlog"><button type="button">Load more</button></div>
+              </section>
+              <section class="col" data-column="inprogress">
+                <div class="col__head"><span class="col__title">In Progress</span></div>
+                <div class="col__list" data-status="inprogress"></div>
+              </section>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  });
+
+  describe('lane targets', () => {
+    it('resolves the lane key from its header title', () => {
+      expect(resolveDblClickCreateTarget(q('.col__head--backlog .col__title'), FIRST_KEY)).toBe('backlog');
+    });
+
+    it('resolves the lane key from empty list space, including in a lane with cards', () => {
+      expect(resolveDblClickCreateTarget(q('[data-status="backlog"]'), FIRST_KEY)).toBe('backlog');
+    });
+
+    it('resolves the lane key from an empty lane', () => {
+      expect(resolveDblClickCreateTarget(q('[data-status="inprogress"]'), FIRST_KEY)).toBe('inprogress');
+    });
+
+    it('resolves the lane key from the section element itself', () => {
+      expect(resolveDblClickCreateTarget(q('section[data-column="inprogress"]'), FIRST_KEY)).toBe('inprogress');
+    });
+  });
+
+  describe('background targets resolve to the first workflow column', () => {
+    it.each(['.board', '.mobile-board-wrapper', '.container', '.page'])('%s', (selector) => {
+      expect(resolveDblClickCreateTarget(q(selector), FIRST_KEY)).toBe(FIRST_KEY);
+    });
+
+    it('uses whatever first column key the caller passes (customized workflows)', () => {
+      expect(resolveDblClickCreateTarget(q('.board'), 'icebox')).toBe('icebox');
+    });
+  });
+
+  describe('excluded targets', () => {
+    it('ignores cards (single-click edit owns them)', () => {
+      expect(resolveDblClickCreateTarget(q('[data-todo-id="7"]'), FIRST_KEY)).toBeNull();
+    });
+
+    it('ignores elements inside cards', () => {
+      expect(resolveDblClickCreateTarget(q('.card__title'), FIRST_KEY)).toBeNull();
+    });
+
+    it('ignores the load-more control and its button', () => {
+      expect(resolveDblClickCreateTarget(q('[data-load-more="backlog"]'), FIRST_KEY)).toBeNull();
+      expect(resolveDblClickCreateTarget(q('[data-load-more="backlog"] button'), FIRST_KEY)).toBeNull();
+    });
+
+    it('ignores the agenda lane (calendar events, not todos)', () => {
+      expect(resolveDblClickCreateTarget(q('.col--agenda .col__title'), FIRST_KEY)).toBeNull();
+      expect(resolveDblClickCreateTarget(q('[data-status="agenda"]'), FIRST_KEY)).toBeNull();
+    });
+
+    it('ignores surfaces that are not board background (filters, mobile tabs)', () => {
+      expect(resolveDblClickCreateTarget(q('.filters'), FIRST_KEY)).toBeNull();
+      expect(resolveDblClickCreateTarget(q('.mobile-tabs'), FIRST_KEY)).toBeNull();
+    });
+
+    it('ignores non-element targets', () => {
+      expect(resolveDblClickCreateTarget(null, FIRST_KEY)).toBeNull();
+      expect(resolveDblClickCreateTarget(document.createTextNode('x'), FIRST_KEY)).toBeNull();
+    });
+
+    it('ignores a column without a data-column key', () => {
+      const col = q('section[data-column="inprogress"]');
+      col.removeAttribute('data-column');
+      expect(resolveDblClickCreateTarget(col, FIRST_KEY)).toBeNull();
+    });
+  });
+});

--- a/internal/httpapi/web/modules/views/board-dblclick.ts
+++ b/internal/httpapi/web/modules/views/board-dblclick.ts
@@ -1,0 +1,36 @@
+// Double-click-to-create target resolution for the board view.
+//
+// Double-clicking anywhere on a lane (header, padding, or empty list space)
+// creates a card in that lane; double-clicking empty board background (below,
+// beside, or between lanes) creates a card in the first column of the
+// workflow. Double-clicks on cards or interactive controls resolve to null so
+// existing behavior (single-click edit, buttons) is untouched.
+
+/** Empty board surface: creating from here targets the first workflow column. */
+const BACKGROUND_SELECTOR = ".board, .mobile-board-wrapper, .container, .page";
+
+/**
+ * Elements whose double-clicks must not trigger creation: cards (single-click
+ * already opens edit), lane controls like "Load more", and form controls.
+ */
+const INTERACTIVE_SELECTOR =
+  "[data-todo-id], [data-load-more], button, a, input, textarea, select, label, [role='button'], [contenteditable='true']";
+
+/**
+ * Resolve a double-click target to the column key a new card should go to,
+ * or null when the double-click should do nothing.
+ */
+export function resolveDblClickCreateTarget(
+  target: EventTarget | null,
+  firstColumnKey: string,
+): string | null {
+  if (!(target instanceof Element)) return null;
+  if (target.closest(INTERACTIVE_SELECTOR)) return null;
+  const col = target.closest(".col");
+  if (col) {
+    // The agenda lane shows calendar events, not workflow todos.
+    if (col.classList.contains("col--agenda")) return null;
+    return col.getAttribute("data-column") || null;
+  }
+  return target.matches(BACKGROUND_SELECTOR) ? firstColumnKey : null;
+}

--- a/internal/httpapi/web/modules/views/board.ts
+++ b/internal/httpapi/web/modules/views/board.ts
@@ -70,6 +70,7 @@ import {
   type SprintChipData,
 } from './board-rendering.js';
 import { AGENDA_COLUMN_KEY, agendaEvents, agendaLaneColor, agendaLaneTitle, agendaMobileTabAriaLabel, agendaMobileTabInnerHtml, applyAgendaScrollAfterRender, buildAgendaColumnHtml, captureAgendaListScroll, flushAgendaInitialScroll, isAgendaEnabled } from './board-agenda.js';
+import { resolveDblClickCreateTarget } from './board-dblclick.js';
 import {
   clearTodoMultiSelection,
   ensureBulkEditUi,
@@ -492,6 +493,23 @@ function attachBoardDelegationHandlers(): void {
       (contextMenu as HTMLElement).style.left = `${mouseEvent.pageX}px`;
       (contextMenu as HTMLElement).style.top = `${mouseEvent.pageY}px`;
     }
+  });
+
+  // Double-click on a lane creates a card there; on empty board background,
+  // in the first workflow column. Bound on .page so the background below and
+  // beside the lanes is included. Desktop-only: no manual double-tap
+  // detection (mobile uses lane tabs and the New Todo button).
+  const pageEl = boardEl.closest(".page") ?? boardEl;
+  pageEl.addEventListener("dblclick", (e: Event) => {
+    if (dragInProgress || dragJustEnded) return;
+    const board = getBoard();
+    if (!board) return;
+    if (!(isTemporaryBoard(board) || currentUserProjectRole === "maintainer")) return;
+    const firstColumnKey = getBoardColumns(board)[0]?.key || "backlog";
+    const status = resolveDblClickCreateTarget(e.target, firstColumnKey);
+    if (!status) return;
+    e.preventDefault();
+    openTodoDialog({ mode: "create", status, role: currentUserProjectRole });
   });
 
   ensureBulkEditUi({


### PR DESCRIPTION
Implements the UX proposal in #250 — double-click to create a card where you point.

Closes #250

## What

- **Double-click anywhere on a lane** (header, padding, or empty list space — with or without cards) opens the existing todo dialog in create mode with that lane preselected.
- **Double-click on empty board background** (below the lanes, beside the last lane, between wrapped rows) opens the create dialog with the **first workflow column** preselected, matching the existing `boardCols[0]?.key || "backlog"` fallback idiom so customized workflows work.
- **No behavior changes anywhere else:** double-clicks on cards, the load-more control, the agenda lane, and interactive elements are ignored, so single-click-to-edit is untouched. Creation is gated exactly like the New Todo button (temporary board or `maintainer` role); viewers get a no-op.

Desktop-only by design: no manual double-tap detection is added (mobile keeps lane tabs and the New Todo button). See the "out of scope" section of #250 for the reasoning; touch support can be a follow-up if the gesture proves out.

## How

- New `modules/views/board-dblclick.ts` exports a pure resolver, `resolveDblClickCreateTarget(target, firstColumnKey)`, that maps a double-click target to a column key or `null`.
- `board.ts` binds one delegated `dblclick` listener on `.page` (so background below/beside the lanes is covered) inside the existing `attachBoardDelegationHandlers` bound-flag block, and calls the existing `openTodoDialog({ mode: "create", status })`.
- No new UI surface, no new i18n strings, no API changes.

## Testing

- `modules/views/board-dblclick.test.ts`: 16 vitest cases covering the zone/exclusion matrix (lane header/list/section, all four background surfaces, custom first-column key, cards, load-more, agenda lane, filters/tabs, non-element targets).
- Full frontend suite under Node 22: 981 passed, 1 failed — the failure is `settings-calendar.test.ts > restores the persisted timezone when the timezone PATCH fails`, which fails identically on a clean `main` checkout (appears related to #248), and is untouched by this change.
- `npm run build` run and rebuilt `dist/` included; `go build ./cmd/scrumboy` and `go test ./...` pass.

## Documentation impact

No documentation impact — frontend-only interaction addition; no migrations, routes, env vars, persistence, auth, or documented dependency versions touched.
