### PR TITLE
Refactor/tag mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 > **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.33.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags), **3.29.0** (MCP JSON-RPC error/`board_get` identity), **3.30.0** (reversible per-project sprint capability), **3.31.0** (per-project priority tiers), **3.33.0** (Agenda ICS feeds need `SCRUMBOY_ENCRYPTION_KEY`) - see those releases.
 
+## [3.33.4] - 2026-08-22
+
+### Changed
+
+- **Tag mutation application services** - REST and MCP tag color and deletion
+  flows now go through application-layer services instead of handler-side
+  orchestration. HTTP/MCP error mapping, validation, and public behavior are
+  unchanged.
+
 ## [3.33.3] - 2026-08-20
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.33.3-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.33.4-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>

--- a/internal/application/tag/mcp_color.go
+++ b/internal/application/tag/mcp_color.go
@@ -7,24 +7,9 @@ import (
 	"scrumboy/internal/store"
 )
 
-var (
-	// ErrMaintainerRequired reports that a durable MCP project-ID color target
-	// does not satisfy the characterized role precondition.
-	ErrMaintainerRequired = errors.New("tag color maintainer required")
-	// ErrColorProjectionMissing reports that a successful project color
-	// mutation is absent from the required post-write tag projection.
-	ErrColorProjectionMissing = errors.New("updated tag color missing from projection")
-)
-
-// MCPProjectAccessStore resolves the project-slug access boundary used by MCP
-// project color operations.
-type MCPProjectAccessStore interface {
-	GetProjectContextBySlug(
-		ctx context.Context,
-		slug string,
-		mode store.Mode,
-	) (store.ProjectContext, error)
-}
+// ErrColorProjectionMissing reports that a successful project color mutation
+// is absent from the required post-write tag projection.
+var ErrColorProjectionMissing = errors.New("updated tag color missing from projection")
 
 // MCPColorServiceDependencies contains only the access, read, and color
 // persistence capabilities required by MCP tag color operations.

--- a/internal/application/tag/mcp_color.go
+++ b/internal/application/tag/mcp_color.go
@@ -1,0 +1,327 @@
+package tag
+
+import (
+	"context"
+	"errors"
+
+	"scrumboy/internal/store"
+)
+
+var (
+	// ErrMaintainerRequired reports that a durable MCP project-ID color target
+	// does not satisfy the characterized role precondition.
+	ErrMaintainerRequired = errors.New("tag color maintainer required")
+	// ErrColorProjectionMissing reports that a successful project color
+	// mutation is absent from the required post-write tag projection.
+	ErrColorProjectionMissing = errors.New("updated tag color missing from projection")
+)
+
+// MCPProjectAccessStore resolves the project-slug access boundary used by MCP
+// project color operations.
+type MCPProjectAccessStore interface {
+	GetProjectContextBySlug(
+		ctx context.Context,
+		slug string,
+		mode store.Mode,
+	) (store.ProjectContext, error)
+}
+
+// MCPColorServiceDependencies contains only the access, read, and color
+// persistence capabilities required by MCP tag color operations.
+type MCPColorServiceDependencies struct {
+	Access           MCPProjectAccessStore
+	MineRead         MineTagReadStore
+	ProjectRead      ProjectTagReadStore
+	MineColor        LegacyRowColorStore
+	DurableIDColor   DurableProjectIDColorStore
+	TemporaryIDColor TemporaryBoardIDColorStore
+	DurableNameColor DurableProjectNameColorStore
+}
+
+// MCPColorService prepares MCP-specific color operations while preserving the
+// mine and project read boundaries characterized at the adapter seam.
+type MCPColorService struct {
+	access           MCPProjectAccessStore
+	mineRead         MineTagReadStore
+	projectRead      ProjectTagReadStore
+	mineColor        LegacyRowColorStore
+	durableIDColor   DurableProjectIDColorStore
+	temporaryIDColor TemporaryBoardIDColorStore
+	durableNameColor DurableProjectNameColorStore
+}
+
+// NewMCPColorService constructs the additive MCP color application service.
+func NewMCPColorService(deps MCPColorServiceDependencies) *MCPColorService {
+	return &MCPColorService{
+		access:           deps.Access,
+		mineRead:         deps.MineRead,
+		projectRead:      deps.ProjectRead,
+		mineColor:        deps.MineColor,
+		durableIDColor:   deps.DurableIDColor,
+		temporaryIDColor: deps.TemporaryIDColor,
+		durableNameColor: deps.DurableNameColor,
+	}
+}
+
+// MCPMineIDColorTarget contains already-validated transport-neutral input for
+// one mine tag color operation.
+type MCPMineIDColorTarget struct {
+	TagID int64
+	Color ColorIntent
+}
+
+// PreparedMCPMineIDColor binds the exact context, actor, selected pre-read tag,
+// and color intent for one mine color mutation.
+type PreparedMCPMineIDColor struct {
+	ctx     context.Context
+	service *MCPColorService
+	actorID int64
+	tag     store.TagWithColor
+	color   ColorIntent
+}
+
+// PrepareMineID extracts the actor, reads the mine library exactly once, and
+// selects the requested tag by exact row ID.
+func (s *MCPColorService) PrepareMineID(
+	ctx context.Context,
+	target MCPMineIDColorTarget,
+) (*PreparedMCPMineIDColor, error) {
+	actorID, ok := store.UserIDFromContext(ctx)
+	if !ok {
+		return nil, ErrActorRequired
+	}
+
+	tags, err := s.mineRead.ListUserTags(ctx, actorID)
+	if err != nil {
+		return nil, err
+	}
+	tag, found := findMineTagByID(tags, target.TagID)
+	if !found {
+		return nil, store.ErrNotFound
+	}
+
+	return &PreparedMCPMineIDColor{
+		ctx:     ctx,
+		service: s,
+		actorID: actorID,
+		tag:     cloneTagWithColor(tag),
+		color:   target.Color,
+	}, nil
+}
+
+// Update performs the legacy row-oriented mine mutation once and returns the
+// characterized synthetic result based on the bound pre-read item.
+func (p *PreparedMCPMineIDColor) Update() (store.TagWithColor, error) {
+	color := p.color.StoreValue()
+	actorID := p.actorID
+	err := p.service.mineColor.UpdateTagColor(p.ctx, &actorID, p.tag.TagID, color)
+	if err != nil && !(p.color.IsClear() && errors.Is(err, store.ErrNotFound)) {
+		return store.TagWithColor{}, err
+	}
+
+	result := cloneTagWithColor(p.tag)
+	result.Color = cloneString(color)
+	return result, nil
+}
+
+// MCPProjectNameColorTarget contains already-validated transport-neutral input
+// for one project tag color operation addressed by name.
+type MCPProjectNameColorTarget struct {
+	ProjectSlug string
+	Mode        store.Mode
+	Name        string
+	Color       ColorIntent
+}
+
+// PreparedMCPProjectNameColor binds one slug-resolved project context, actor,
+// exact name, and color intent.
+type PreparedMCPProjectNameColor struct {
+	ctx            context.Context
+	service        *MCPColorService
+	projectContext store.ProjectContext
+	actorID        int64
+	name           string
+	color          ColorIntent
+}
+
+// PrepareProjectName resolves project access exactly once and then extracts
+// the actor. It deliberately adds no role gate or tag pre-read.
+func (s *MCPColorService) PrepareProjectName(
+	ctx context.Context,
+	target MCPProjectNameColorTarget,
+) (*PreparedMCPProjectNameColor, error) {
+	projectContext, err := s.access.GetProjectContextBySlug(ctx, target.ProjectSlug, target.Mode)
+	if err != nil {
+		return nil, err
+	}
+	actorID, ok := store.UserIDFromContext(ctx)
+	if !ok {
+		return nil, ErrActorRequired
+	}
+
+	return &PreparedMCPProjectNameColor{
+		ctx:            ctx,
+		service:        s,
+		projectContext: cloneProjectContext(projectContext),
+		actorID:        actorID,
+		name:           target.Name,
+		color:          target.Color,
+	}, nil
+}
+
+// Update mutates the grouped name once, then performs the required project tag
+// post-read and selects the result through the store grouping key.
+func (p *PreparedMCPProjectNameColor) Update() (store.TagCount, error) {
+	if err := p.service.durableNameColor.SetViewerTagColorByName(
+		p.ctx,
+		p.projectContext.Project.ID,
+		p.actorID,
+		p.name,
+		p.color.StoreValue(),
+	); err != nil {
+		return store.TagCount{}, err
+	}
+
+	tags, err := p.service.projectRead.ListTagCounts(p.ctx, &p.projectContext)
+	if err != nil {
+		return store.TagCount{}, err
+	}
+	groupKey := store.TagGroupKey(p.name)
+	for _, tag := range tags {
+		if tag.Name == groupKey {
+			return tag, nil
+		}
+	}
+	return store.TagCount{}, ErrColorProjectionMissing
+}
+
+// MCPProjectIDColorTarget contains already-validated transport-neutral input
+// for one project tag color operation addressed by row ID.
+type MCPProjectIDColorTarget struct {
+	ProjectSlug string
+	Mode        store.Mode
+	TagID       int64
+	Color       ColorIntent
+}
+
+// PreparedMCPProjectIDColor binds one slug-resolved project context, actor,
+// precondition-checked tag ID, and color intent.
+type PreparedMCPProjectIDColor struct {
+	ctx            context.Context
+	service        *MCPColorService
+	projectContext store.ProjectContext
+	actorID        int64
+	tagID          int64
+	color          ColorIntent
+}
+
+// PrepareProjectID preserves the characterized access, actor, pre-read,
+// existence, and durable-only role ordering.
+func (s *MCPColorService) PrepareProjectID(
+	ctx context.Context,
+	target MCPProjectIDColorTarget,
+) (*PreparedMCPProjectIDColor, error) {
+	projectContext, err := s.access.GetProjectContextBySlug(ctx, target.ProjectSlug, target.Mode)
+	if err != nil {
+		return nil, err
+	}
+	projectContext = cloneProjectContext(projectContext)
+
+	actorID, ok := store.UserIDFromContext(ctx)
+	if !ok {
+		return nil, ErrActorRequired
+	}
+
+	tags, err := s.projectRead.ListTagCounts(ctx, &projectContext)
+	if err != nil {
+		return nil, err
+	}
+	if _, found := findProjectTagByID(tags, target.TagID); !found {
+		return nil, store.ErrNotFound
+	}
+	if projectContext.Project.ExpiresAt == nil &&
+		!projectContext.Role.HasMinimumRole(store.RoleMaintainer) {
+		return nil, ErrMaintainerRequired
+	}
+
+	return &PreparedMCPProjectIDColor{
+		ctx:            ctx,
+		service:        s,
+		projectContext: projectContext,
+		actorID:        actorID,
+		tagID:          target.TagID,
+		color:          target.Color,
+	}, nil
+}
+
+// Update dispatches exactly one durable or temporary ID mutation, applies only
+// the characterized harmless-clear rule, and then returns the same ID from one
+// project tag post-read.
+func (p *PreparedMCPProjectIDColor) Update() (store.TagCount, error) {
+	color := p.color.StoreValue()
+	var err error
+	if p.projectContext.Project.ExpiresAt != nil {
+		actorID := p.actorID
+		err = p.service.temporaryIDColor.UpdateTagColorForTemporaryBoard(
+			p.ctx,
+			p.projectContext.Project.ID,
+			&actorID,
+			p.tagID,
+			color,
+		)
+	} else {
+		err = p.service.durableIDColor.UpdateTagColorForDurableProjectByID(
+			p.ctx,
+			p.projectContext.Project.ID,
+			p.actorID,
+			p.tagID,
+			color,
+		)
+	}
+	if err != nil && !(p.color.IsClear() && errors.Is(err, store.ErrNotFound)) {
+		return store.TagCount{}, err
+	}
+
+	tags, err := p.service.projectRead.ListTagCounts(p.ctx, &p.projectContext)
+	if err != nil {
+		return store.TagCount{}, err
+	}
+	if tag, found := findProjectTagByID(tags, p.tagID); found {
+		return tag, nil
+	}
+	return store.TagCount{}, ErrColorProjectionMissing
+}
+
+func findMineTagByID(tags []store.TagWithColor, tagID int64) (store.TagWithColor, bool) {
+	for _, tag := range tags {
+		if tag.TagID == tagID {
+			return tag, true
+		}
+	}
+	return store.TagWithColor{}, false
+}
+
+func findProjectTagByID(tags []store.TagCount, tagID int64) (store.TagCount, bool) {
+	for _, tag := range tags {
+		if tag.TagID == tagID {
+			return tag, true
+		}
+	}
+	return store.TagCount{}, false
+}
+
+func cloneTagWithColor(tag store.TagWithColor) store.TagWithColor {
+	tag.Color = cloneString(tag.Color)
+	return tag
+}
+
+func cloneProjectContext(projectContext store.ProjectContext) store.ProjectContext {
+	projectContext.Project.Image = cloneString(projectContext.Project.Image)
+	projectContext.Project.OwnerUserID = cloneInt64(projectContext.Project.OwnerUserID)
+	projectContext.Project.CreatorUserID = cloneInt64(projectContext.Project.CreatorUserID)
+	if projectContext.Project.ExpiresAt != nil {
+		expiresAt := *projectContext.Project.ExpiresAt
+		projectContext.Project.ExpiresAt = &expiresAt
+	}
+	return projectContext
+}

--- a/internal/application/tag/mcp_color_test.go
+++ b/internal/application/tag/mcp_color_test.go
@@ -1,0 +1,861 @@
+package tag
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"scrumboy/internal/store"
+)
+
+var _ MCPProjectAccessStore = (*store.Store)(nil)
+
+type mcpColorProjectReadStep struct {
+	trace              string
+	tags               []store.TagCount
+	err                error
+	returnContextError bool
+}
+
+type mcpColorCall struct {
+	operation      string
+	ctx            context.Context
+	slug           string
+	mode           store.Mode
+	projectContext store.ProjectContext
+	projectID      int64
+	viewerUserID   *int64
+	actorUserID    int64
+	tagID          int64
+	tagName        string
+	color          *string
+}
+
+type mcpColorFake struct {
+	trace []string
+	calls []mcpColorCall
+
+	projectContext   store.ProjectContext
+	accessErr        error
+	accessContextErr bool
+
+	mineTags           []store.TagWithColor
+	mineReadErr        error
+	mineReadContextErr bool
+
+	projectReadSteps []mcpColorProjectReadStep
+	projectReadIndex int
+
+	mineColorErr          error
+	mineColorContextErr   bool
+	mineNormalizedColor   *string
+	durableIDColorErr     error
+	durableIDContextErr   bool
+	temporaryIDColorErr   error
+	temporaryIDContextErr bool
+	durableNameColorErr   error
+	durableNameContextErr bool
+}
+
+func (f *mcpColorFake) GetProjectContextBySlug(
+	ctx context.Context,
+	slug string,
+	mode store.Mode,
+) (store.ProjectContext, error) {
+	f.trace = append(f.trace, "access")
+	f.calls = append(f.calls, mcpColorCall{operation: "access", ctx: ctx, slug: slug, mode: mode})
+	if f.accessContextErr {
+		return store.ProjectContext{}, ctx.Err()
+	}
+	if f.accessErr != nil {
+		return store.ProjectContext{}, f.accessErr
+	}
+	return f.projectContext, nil
+}
+
+func (f *mcpColorFake) ListUserTags(ctx context.Context, userID int64) ([]store.TagWithColor, error) {
+	f.trace = append(f.trace, "mine-read")
+	f.calls = append(f.calls, mcpColorCall{operation: "mine-read", ctx: ctx, actorUserID: userID})
+	if f.mineReadContextErr {
+		return nil, ctx.Err()
+	}
+	if f.mineReadErr != nil {
+		return nil, f.mineReadErr
+	}
+	return f.mineTags, nil
+}
+
+func (f *mcpColorFake) ListTagCounts(
+	ctx context.Context,
+	projectContext *store.ProjectContext,
+) ([]store.TagCount, error) {
+	if f.projectReadIndex >= len(f.projectReadSteps) {
+		f.trace = append(f.trace, "unexpected-project-read")
+		return nil, errors.New("unexpected project tag read")
+	}
+	step := f.projectReadSteps[f.projectReadIndex]
+	f.projectReadIndex++
+	f.trace = append(f.trace, step.trace)
+	f.calls = append(f.calls, mcpColorCall{
+		operation: step.trace, ctx: ctx, projectContext: cloneProjectContext(*projectContext),
+	})
+	if step.returnContextError {
+		return nil, ctx.Err()
+	}
+	if step.err != nil {
+		return nil, step.err
+	}
+	return step.tags, nil
+}
+
+func (f *mcpColorFake) UpdateTagColor(
+	ctx context.Context,
+	viewerUserID *int64,
+	tagID int64,
+	color *string,
+) error {
+	f.trace = append(f.trace, "mine-color")
+	f.calls = append(f.calls, mcpColorCall{
+		operation: "mine-color", ctx: ctx, viewerUserID: cloneInt64(viewerUserID), tagID: tagID,
+		color: cloneString(color),
+	})
+	if f.mineColorContextErr {
+		return ctx.Err()
+	}
+	if f.mineNormalizedColor != nil && color != nil {
+		*color = *f.mineNormalizedColor
+	}
+	return f.mineColorErr
+}
+
+func (f *mcpColorFake) UpdateTagColorForDurableProjectByID(
+	ctx context.Context,
+	projectID, viewerUserID, tagID int64,
+	color *string,
+) error {
+	f.trace = append(f.trace, "durable-id-color")
+	f.calls = append(f.calls, mcpColorCall{
+		operation: "durable-id-color", ctx: ctx, projectID: projectID,
+		viewerUserID: cloneInt64(&viewerUserID), tagID: tagID, color: cloneString(color),
+	})
+	if f.durableIDContextErr {
+		return ctx.Err()
+	}
+	return f.durableIDColorErr
+}
+
+func (f *mcpColorFake) UpdateTagColorForTemporaryBoard(
+	ctx context.Context,
+	projectID int64,
+	viewerUserID *int64,
+	tagID int64,
+	color *string,
+) error {
+	f.trace = append(f.trace, "temporary-id-color")
+	f.calls = append(f.calls, mcpColorCall{
+		operation: "temporary-id-color", ctx: ctx, projectID: projectID,
+		viewerUserID: cloneInt64(viewerUserID), tagID: tagID, color: cloneString(color),
+	})
+	if f.temporaryIDContextErr {
+		return ctx.Err()
+	}
+	return f.temporaryIDColorErr
+}
+
+func (f *mcpColorFake) SetViewerTagColorByName(
+	ctx context.Context,
+	projectID, viewerUserID int64,
+	name string,
+	color *string,
+) error {
+	f.trace = append(f.trace, "durable-name-color")
+	f.calls = append(f.calls, mcpColorCall{
+		operation: "durable-name-color", ctx: ctx, projectID: projectID,
+		viewerUserID: cloneInt64(&viewerUserID), tagName: name, color: cloneString(color),
+	})
+	if f.durableNameContextErr {
+		return ctx.Err()
+	}
+	return f.durableNameColorErr
+}
+
+func newMCPColorTestService(fake *mcpColorFake) *MCPColorService {
+	return NewMCPColorService(MCPColorServiceDependencies{
+		Access:           fake,
+		MineRead:         fake,
+		ProjectRead:      fake,
+		MineColor:        fake,
+		DurableIDColor:   fake,
+		TemporaryIDColor: fake,
+		DurableNameColor: fake,
+	})
+}
+
+func TestMCPColorMineIDSequenceAndSyntheticResult(t *testing.T) {
+	t.Run("success uses store-normalized fresh color", func(t *testing.T) {
+		originalTagColor := "#111111"
+		normalized := "#abcdef"
+		fake := &mcpColorFake{
+			mineTags:            []store.TagWithColor{{TagID: 17, Name: "mine", Color: &originalTagColor, CanDelete: true}},
+			mineNormalizedColor: &normalized,
+		}
+		ctx := store.WithUserID(context.Background(), 11)
+		inputColor := "  #abcdef  "
+		prepared, err := newMCPColorTestService(fake).PrepareMineID(ctx, MCPMineIDColorTarget{
+			TagID: 17,
+			Color: NewColorIntent(&inputColor),
+		})
+		if err != nil {
+			t.Fatalf("PrepareMineID() error = %v", err)
+		}
+		inputColor = "changed after preparation"
+		originalTagColor = "changed after preparation"
+
+		result, err := prepared.Update()
+		if err != nil {
+			t.Fatalf("Update() error = %v", err)
+		}
+		assertMCPColorTrace(t, fake, "mine-read", "mine-color")
+		if result.TagID != 17 || result.Name != "mine" || !result.CanDelete {
+			t.Fatalf("result = %#v", result)
+		}
+		assertMCPColorStringPointer(t, result.Color, "#abcdef")
+		call := findMCPColorCall(t, fake, "mine-color")
+		if call.ctx != ctx || call.tagID != 17 || call.viewerUserID == nil || *call.viewerUserID != 11 {
+			t.Fatalf("mine color call = %#v", call)
+		}
+		assertMCPColorStringPointer(t, call.color, "  #abcdef  ")
+	})
+
+	for _, tc := range []struct {
+		name        string
+		mutationErr error
+		wantErr     error
+	}{
+		{name: "nil clear succeeds"},
+		{name: "missing preference clear succeeds", mutationErr: store.ErrNotFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &mcpColorFake{
+				mineTags:     []store.TagWithColor{{TagID: 19, Name: "clear", Color: stringPointer("#123456")}},
+				mineColorErr: tc.mutationErr,
+			}
+			prepared, err := newMCPColorTestService(fake).PrepareMineID(
+				store.WithUserID(context.Background(), 13),
+				MCPMineIDColorTarget{TagID: 19, Color: NewColorIntent(nil)},
+			)
+			if err != nil {
+				t.Fatalf("PrepareMineID() error = %v", err)
+			}
+			result, err := prepared.Update()
+			if err != tc.wantErr {
+				t.Fatalf("Update() error = %v, want %v", err, tc.wantErr)
+			}
+			if result.Color != nil {
+				t.Fatalf("result color = %s, want nil", describeStringPointer(result.Color))
+			}
+			assertMCPColorTrace(t, fake, "mine-read", "mine-color")
+		})
+	}
+}
+
+func TestMCPColorMineIDFailures(t *testing.T) {
+	t.Run("missing actor stops before read", func(t *testing.T) {
+		fake := &mcpColorFake{}
+		prepared, err := newMCPColorTestService(fake).PrepareMineID(context.Background(), MCPMineIDColorTarget{TagID: 1})
+		if prepared != nil || !errors.Is(err, ErrActorRequired) {
+			t.Fatalf("PrepareMineID() = (%v, %v), want (nil, ErrActorRequired)", prepared, err)
+		}
+		assertMCPColorTrace(t, fake)
+	})
+
+	t.Run("pre-read error is unchanged", func(t *testing.T) {
+		readErr := errors.New("mine read failed")
+		fake := &mcpColorFake{mineReadErr: readErr}
+		prepared, err := newMCPColorTestService(fake).PrepareMineID(
+			store.WithUserID(context.Background(), 23), MCPMineIDColorTarget{TagID: 29},
+		)
+		if prepared != nil || err != readErr {
+			t.Fatalf("PrepareMineID() = (%v, %v), want (nil, identical error)", prepared, err)
+		}
+		assertMCPColorTrace(t, fake, "mine-read")
+	})
+
+	t.Run("missing tag is store not found", func(t *testing.T) {
+		fake := &mcpColorFake{mineTags: []store.TagWithColor{{TagID: 31}}}
+		prepared, err := newMCPColorTestService(fake).PrepareMineID(
+			store.WithUserID(context.Background(), 37), MCPMineIDColorTarget{TagID: 41},
+		)
+		if prepared != nil || !errors.Is(err, store.ErrNotFound) {
+			t.Fatalf("PrepareMineID() = (%v, %v), want (nil, store.ErrNotFound)", prepared, err)
+		}
+		assertMCPColorTrace(t, fake, "mine-read")
+	})
+
+	for _, tc := range []struct {
+		name  string
+		color ColorIntent
+		err   error
+	}{
+		{name: "non-clear not found remains error", color: NewColorIntent(stringPointer("#123456")), err: store.ErrNotFound},
+		{name: "ordinary mutation error is unchanged", color: NewColorIntent(nil), err: errors.New("mine write failed")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &mcpColorFake{
+				mineTags:     []store.TagWithColor{{TagID: 43, Name: "mine"}},
+				mineColorErr: tc.err,
+			}
+			prepared, err := newMCPColorTestService(fake).PrepareMineID(
+				store.WithUserID(context.Background(), 47), MCPMineIDColorTarget{TagID: 43, Color: tc.color},
+			)
+			if err != nil {
+				t.Fatalf("PrepareMineID() error = %v", err)
+			}
+			result, err := prepared.Update()
+			if err != tc.err || result != (store.TagWithColor{}) {
+				t.Fatalf("Update() = (%#v, %v), want zero result and identical %v", result, err, tc.err)
+			}
+			assertMCPColorTrace(t, fake, "mine-read", "mine-color")
+		})
+	}
+}
+
+func TestMCPColorProjectNameSequenceAndProjection(t *testing.T) {
+	ownerID := int64(53)
+	fake := &mcpColorFake{
+		projectContext: store.ProjectContext{
+			Project: store.Project{ID: 59, OwnerUserID: &ownerID},
+			Role:    store.RoleViewer,
+		},
+		projectReadSteps: []mcpColorProjectReadStep{{
+			trace: "project-read-post",
+			tags:  []store.TagCount{{TagID: 0, Name: "make-space", Count: 3, Color: stringPointer("#abcdef")}},
+		}},
+	}
+	ctx := store.WithUserID(context.Background(), 61)
+	prepared, err := newMCPColorTestService(fake).PrepareProjectName(ctx, MCPProjectNameColorTarget{
+		ProjectSlug: "project-slug",
+		Mode:        store.ModeFull,
+		Name:        "Make Space",
+		Color:       NewColorIntent(stringPointer("#abcdef")),
+	})
+	if err != nil {
+		t.Fatalf("PrepareProjectName() error = %v", err)
+	}
+	ownerID = 999
+	fake.projectContext.Project.ID = 999
+
+	result, err := prepared.Update()
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	assertMCPColorTrace(t, fake, "access", "durable-name-color", "project-read-post")
+	if result.Name != "make-space" || result.Count != 3 {
+		t.Fatalf("result = %#v", result)
+	}
+	access := findMCPColorCall(t, fake, "access")
+	if access.ctx != ctx || access.slug != "project-slug" || access.mode != store.ModeFull {
+		t.Fatalf("access call = %#v", access)
+	}
+	mutation := findMCPColorCall(t, fake, "durable-name-color")
+	if mutation.ctx != ctx || mutation.projectID != 59 || mutation.viewerUserID == nil ||
+		*mutation.viewerUserID != 61 || mutation.tagName != "Make Space" {
+		t.Fatalf("name mutation = %#v", mutation)
+	}
+	postRead := findMCPColorCall(t, fake, "project-read-post")
+	if postRead.ctx != ctx || postRead.projectContext.Project.ID != 59 ||
+		postRead.projectContext.Project.OwnerUserID == nil || *postRead.projectContext.Project.OwnerUserID != 53 {
+		t.Fatalf("post-read = %#v", postRead)
+	}
+}
+
+func TestMCPColorProjectNameFailures(t *testing.T) {
+	t.Run("access error is unchanged", func(t *testing.T) {
+		accessErr := errors.New("access failed")
+		fake := &mcpColorFake{accessErr: accessErr}
+		prepared, err := newMCPColorTestService(fake).PrepareProjectName(
+			store.WithUserID(context.Background(), 67), MCPProjectNameColorTarget{ProjectSlug: "missing"},
+		)
+		if prepared != nil || err != accessErr {
+			t.Fatalf("PrepareProjectName() = (%v, %v), want (nil, identical error)", prepared, err)
+		}
+		assertMCPColorTrace(t, fake, "access")
+	})
+
+	t.Run("missing actor follows access", func(t *testing.T) {
+		fake := &mcpColorFake{projectContext: store.ProjectContext{Project: store.Project{ID: 71}}}
+		prepared, err := newMCPColorTestService(fake).PrepareProjectName(
+			context.Background(), MCPProjectNameColorTarget{ProjectSlug: "project"},
+		)
+		if prepared != nil || !errors.Is(err, ErrActorRequired) {
+			t.Fatalf("PrepareProjectName() = (%v, %v), want (nil, ErrActorRequired)", prepared, err)
+		}
+		assertMCPColorTrace(t, fake, "access")
+	})
+
+	for _, tc := range []struct {
+		name        string
+		mutationErr error
+		readStep    *mcpColorProjectReadStep
+		wantErr     error
+		wantTrace   []string
+	}{
+		{
+			name: "mutation error prevents post-read", mutationErr: errors.New("name write failed"),
+			wantTrace: []string{"access", "durable-name-color"},
+		},
+		{
+			name: "post-read error follows one mutation", readStep: &mcpColorProjectReadStep{
+				trace: "project-read-post", err: errors.New("name post-read failed"),
+			}, wantTrace: []string{"access", "durable-name-color", "project-read-post"},
+		},
+		{
+			name: "missing grouped projection is application error", readStep: &mcpColorProjectReadStep{
+				trace: "project-read-post", tags: []store.TagCount{{Name: "other"}},
+			}, wantErr: ErrColorProjectionMissing,
+			wantTrace: []string{"access", "durable-name-color", "project-read-post"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &mcpColorFake{
+				projectContext:      store.ProjectContext{Project: store.Project{ID: 73}, Role: store.RoleViewer},
+				durableNameColorErr: tc.mutationErr,
+			}
+			if tc.readStep != nil {
+				fake.projectReadSteps = []mcpColorProjectReadStep{*tc.readStep}
+			}
+			prepared, err := newMCPColorTestService(fake).PrepareProjectName(
+				store.WithUserID(context.Background(), 79),
+				MCPProjectNameColorTarget{ProjectSlug: "project", Name: "group", Color: NewColorIntent(nil)},
+			)
+			if err != nil {
+				t.Fatalf("PrepareProjectName() error = %v", err)
+			}
+			result, err := prepared.Update()
+			wantErr := tc.wantErr
+			if wantErr == nil {
+				if tc.mutationErr != nil {
+					wantErr = tc.mutationErr
+				} else {
+					wantErr = tc.readStep.err
+				}
+			}
+			if err != wantErr || result != (store.TagCount{}) {
+				t.Fatalf("Update() = (%#v, %v), want zero result and identical %v", result, err, wantErr)
+			}
+			assertMCPColorTrace(t, fake, tc.wantTrace...)
+			if countMCPColorCalls(fake, "durable-name-color") != 1 {
+				t.Fatalf("name mutation calls = %d, want 1", countMCPColorCalls(fake, "durable-name-color"))
+			}
+		})
+	}
+
+	t.Run("temporary name still reaches durable-only store capability", func(t *testing.T) {
+		expiresAt := time.Now()
+		fake := &mcpColorFake{
+			projectContext:      store.ProjectContext{Project: store.Project{ID: 83, ExpiresAt: &expiresAt}},
+			durableNameColorErr: store.ErrValidation,
+		}
+		prepared, err := newMCPColorTestService(fake).PrepareProjectName(
+			store.WithUserID(context.Background(), 89),
+			MCPProjectNameColorTarget{ProjectSlug: "temporary", Name: "name"},
+		)
+		if err != nil {
+			t.Fatalf("PrepareProjectName() error = %v", err)
+		}
+		if _, err := prepared.Update(); err != store.ErrValidation {
+			t.Fatalf("Update() error = %v, want store.ErrValidation", err)
+		}
+		assertMCPColorTrace(t, fake, "access", "durable-name-color")
+	})
+}
+
+func TestMCPColorProjectIDDurableAndTemporarySequences(t *testing.T) {
+	tests := []struct {
+		name         string
+		project      store.Project
+		role         store.ProjectRole
+		wantMutation string
+	}{
+		{name: "durable maintainer", project: store.Project{ID: 97}, role: store.RoleMaintainer, wantMutation: "durable-id-color"},
+		{name: "temporary viewer skips durable role gate", project: temporaryProject(101), role: store.RoleViewer, wantMutation: "temporary-id-color"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &mcpColorFake{
+				projectContext: store.ProjectContext{Project: tt.project, Role: tt.role},
+				projectReadSteps: []mcpColorProjectReadStep{
+					{trace: "project-read-pre", tags: []store.TagCount{{TagID: 103, Name: "target"}}},
+					{trace: "project-read-post", tags: []store.TagCount{{TagID: 103, Name: "target", Color: stringPointer("#abcdef")}}},
+				},
+			}
+			ctx := store.WithUserID(context.Background(), 107)
+			prepared, err := newMCPColorTestService(fake).PrepareProjectID(ctx, MCPProjectIDColorTarget{
+				ProjectSlug: "project", Mode: store.ModeFull, TagID: 103,
+				Color: NewColorIntent(stringPointer("#abcdef")),
+			})
+			if err != nil {
+				t.Fatalf("PrepareProjectID() error = %v", err)
+			}
+
+			result, err := prepared.Update()
+			if err != nil {
+				t.Fatalf("Update() error = %v", err)
+			}
+			assertMCPColorTrace(t, fake, "access", "project-read-pre", tt.wantMutation, "project-read-post")
+			if result.TagID != 103 || result.Name != "target" {
+				t.Fatalf("result = %#v", result)
+			}
+			mutation := findMCPColorCall(t, fake, tt.wantMutation)
+			if mutation.ctx != ctx || mutation.projectID != tt.project.ID || mutation.tagID != 103 ||
+				mutation.viewerUserID == nil || *mutation.viewerUserID != 107 {
+				t.Fatalf("mutation = %#v", mutation)
+			}
+			if countMCPColorCalls(fake, "durable-id-color")+countMCPColorCalls(fake, "temporary-id-color") != 1 {
+				t.Fatalf("ID mutation calls = %d, want 1", countMCPColorCalls(fake, "durable-id-color")+countMCPColorCalls(fake, "temporary-id-color"))
+			}
+		})
+	}
+}
+
+func TestMCPColorPreparedProjectIDOwnsTemporaryClassification(t *testing.T) {
+	expiresAt := time.Now().Add(time.Hour)
+	fake := &mcpColorFake{
+		projectContext: store.ProjectContext{
+			Project: store.Project{ID: 109, ExpiresAt: &expiresAt},
+			Role:    store.RoleViewer,
+		},
+		projectReadSteps: []mcpColorProjectReadStep{
+			{trace: "project-read-pre", tags: []store.TagCount{{TagID: 113}}},
+			{trace: "project-read-post", tags: []store.TagCount{{TagID: 113}}},
+		},
+	}
+	prepared, err := newMCPColorTestService(fake).PrepareProjectID(
+		store.WithUserID(context.Background(), 127),
+		MCPProjectIDColorTarget{ProjectSlug: "temporary", TagID: 113},
+	)
+	if err != nil {
+		t.Fatalf("PrepareProjectID() error = %v", err)
+	}
+
+	// Changing the access fake's source after preparation must not turn the
+	// already-prepared temporary operation into a durable one.
+	fake.projectContext.Project.ExpiresAt = nil
+
+	if _, err := prepared.Update(); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	assertMCPColorTrace(t, fake, "access", "project-read-pre", "temporary-id-color", "project-read-post")
+	if countMCPColorCalls(fake, "temporary-id-color") != 1 || countMCPColorCalls(fake, "durable-id-color") != 0 {
+		t.Fatalf(
+			"temporary calls = %d, durable calls = %d, want 1 and 0",
+			countMCPColorCalls(fake, "temporary-id-color"),
+			countMCPColorCalls(fake, "durable-id-color"),
+		)
+	}
+}
+
+func TestMCPColorProjectIDPreparationOrdering(t *testing.T) {
+	t.Run("access error stops before actor and read", func(t *testing.T) {
+		accessErr := errors.New("access failed")
+		fake := &mcpColorFake{accessErr: accessErr}
+		prepared, err := newMCPColorTestService(fake).PrepareProjectID(
+			store.WithUserID(context.Background(), 109), MCPProjectIDColorTarget{ProjectSlug: "missing", TagID: 1},
+		)
+		if prepared != nil || err != accessErr {
+			t.Fatalf("PrepareProjectID() = (%v, %v), want (nil, identical error)", prepared, err)
+		}
+		assertMCPColorTrace(t, fake, "access")
+	})
+
+	t.Run("missing actor follows access and precedes read", func(t *testing.T) {
+		fake := &mcpColorFake{projectContext: store.ProjectContext{Project: store.Project{ID: 113}}}
+		prepared, err := newMCPColorTestService(fake).PrepareProjectID(
+			context.Background(), MCPProjectIDColorTarget{ProjectSlug: "project", TagID: 1},
+		)
+		if prepared != nil || !errors.Is(err, ErrActorRequired) {
+			t.Fatalf("PrepareProjectID() = (%v, %v), want (nil, ErrActorRequired)", prepared, err)
+		}
+		assertMCPColorTrace(t, fake, "access")
+	})
+
+	t.Run("pre-read error is unchanged", func(t *testing.T) {
+		readErr := errors.New("pre-read failed")
+		fake := &mcpColorFake{
+			projectContext:   store.ProjectContext{Project: store.Project{ID: 127}, Role: store.RoleMaintainer},
+			projectReadSteps: []mcpColorProjectReadStep{{trace: "project-read-pre", err: readErr}},
+		}
+		prepared, err := newMCPColorTestService(fake).PrepareProjectID(
+			store.WithUserID(context.Background(), 131), MCPProjectIDColorTarget{ProjectSlug: "project", TagID: 137},
+		)
+		if prepared != nil || err != readErr {
+			t.Fatalf("PrepareProjectID() = (%v, %v), want (nil, identical error)", prepared, err)
+		}
+		assertMCPColorTrace(t, fake, "access", "project-read-pre")
+	})
+
+	t.Run("wrong tag wins before insufficient durable role", func(t *testing.T) {
+		fake := &mcpColorFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 139}, Role: store.RoleViewer},
+			projectReadSteps: []mcpColorProjectReadStep{{
+				trace: "project-read-pre", tags: []store.TagCount{{TagID: 149}},
+			}},
+		}
+		prepared, err := newMCPColorTestService(fake).PrepareProjectID(
+			store.WithUserID(context.Background(), 151), MCPProjectIDColorTarget{ProjectSlug: "project", TagID: 157},
+		)
+		if prepared != nil || !errors.Is(err, store.ErrNotFound) {
+			t.Fatalf("PrepareProjectID() = (%v, %v), want (nil, store.ErrNotFound)", prepared, err)
+		}
+		assertMCPColorTrace(t, fake, "access", "project-read-pre")
+	})
+
+	t.Run("durable role gate follows successful pre-read", func(t *testing.T) {
+		fake := &mcpColorFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 163}, Role: store.RoleContributor},
+			projectReadSteps: []mcpColorProjectReadStep{{
+				trace: "project-read-pre", tags: []store.TagCount{{TagID: 167}},
+			}},
+		}
+		prepared, err := newMCPColorTestService(fake).PrepareProjectID(
+			store.WithUserID(context.Background(), 173), MCPProjectIDColorTarget{ProjectSlug: "project", TagID: 167},
+		)
+		if prepared != nil || !errors.Is(err, ErrMaintainerRequired) {
+			t.Fatalf("PrepareProjectID() = (%v, %v), want (nil, ErrMaintainerRequired)", prepared, err)
+		}
+		assertMCPColorTrace(t, fake, "access", "project-read-pre")
+	})
+}
+
+func TestMCPColorProjectIDMutationAndPostReadFailures(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		temporary    bool
+		color        ColorIntent
+		mutationErr  error
+		postRead     *mcpColorProjectReadStep
+		wantErr      error
+		wantPostRead bool
+	}{
+		{name: "durable mutation error", mutationErr: errors.New("durable write failed"), color: NewColorIntent(stringPointer("#123456"))},
+		{name: "temporary mutation error", temporary: true, mutationErr: errors.New("temporary write failed"), color: NewColorIntent(stringPointer("#123456"))},
+		{name: "durable non-clear not found", mutationErr: store.ErrNotFound, color: NewColorIntent(stringPointer("#123456"))},
+		{name: "temporary non-clear not found", temporary: true, mutationErr: store.ErrNotFound, color: NewColorIntent(stringPointer("#123456"))},
+		{
+			name: "durable harmless clear not found", mutationErr: store.ErrNotFound, color: NewColorIntent(nil), wantPostRead: true,
+			postRead: &mcpColorProjectReadStep{trace: "project-read-post", tags: []store.TagCount{{TagID: 179}}},
+		},
+		{
+			name: "temporary harmless clear not found", temporary: true, mutationErr: store.ErrNotFound, color: NewColorIntent(nil), wantPostRead: true,
+			postRead: &mcpColorProjectReadStep{trace: "project-read-post", tags: []store.TagCount{{TagID: 179}}},
+		},
+		{
+			name: "durable post-read error", color: NewColorIntent(nil), wantPostRead: true,
+			postRead: &mcpColorProjectReadStep{trace: "project-read-post", err: errors.New("post-read failed")},
+		},
+		{
+			name: "temporary post-read error", temporary: true, color: NewColorIntent(nil), wantPostRead: true,
+			postRead: &mcpColorProjectReadStep{trace: "project-read-post", err: errors.New("post-read failed")},
+		},
+		{
+			name: "post-read target missing", color: NewColorIntent(nil), wantPostRead: true, wantErr: ErrColorProjectionMissing,
+			postRead: &mcpColorProjectReadStep{trace: "project-read-post", tags: []store.TagCount{{TagID: 181}}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			project := store.Project{ID: 191}
+			role := store.RoleMaintainer
+			mutationName := "durable-id-color"
+			if tc.temporary {
+				project = temporaryProject(191)
+				role = store.RoleViewer
+				mutationName = "temporary-id-color"
+			}
+			fake := &mcpColorFake{
+				projectContext: store.ProjectContext{Project: project, Role: role},
+				projectReadSteps: []mcpColorProjectReadStep{{
+					trace: "project-read-pre", tags: []store.TagCount{{TagID: 179}},
+				}},
+			}
+			if tc.postRead != nil {
+				fake.projectReadSteps = append(fake.projectReadSteps, *tc.postRead)
+			}
+			if tc.temporary {
+				fake.temporaryIDColorErr = tc.mutationErr
+			} else {
+				fake.durableIDColorErr = tc.mutationErr
+			}
+
+			prepared, err := newMCPColorTestService(fake).PrepareProjectID(
+				store.WithUserID(context.Background(), 193),
+				MCPProjectIDColorTarget{ProjectSlug: "project", TagID: 179, Color: tc.color},
+			)
+			if err != nil {
+				t.Fatalf("PrepareProjectID() error = %v", err)
+			}
+			result, err := prepared.Update()
+			wantErr := tc.wantErr
+			if wantErr == nil {
+				switch {
+				case tc.mutationErr != nil && !tc.color.IsClear():
+					wantErr = tc.mutationErr
+				case tc.mutationErr != nil && !errors.Is(tc.mutationErr, store.ErrNotFound):
+					wantErr = tc.mutationErr
+				case tc.postRead != nil && tc.postRead.err != nil:
+					wantErr = tc.postRead.err
+				}
+			}
+			if err != wantErr {
+				t.Fatalf("Update() error = %v, want identical %v", err, wantErr)
+			}
+			if wantErr != nil && result != (store.TagCount{}) {
+				t.Fatalf("Update() result = %#v, want zero after error", result)
+			}
+			wantTrace := []string{"access", "project-read-pre", mutationName}
+			if tc.wantPostRead {
+				wantTrace = append(wantTrace, "project-read-post")
+			}
+			assertMCPColorTrace(t, fake, wantTrace...)
+			if countMCPColorCalls(fake, mutationName) != 1 {
+				t.Fatalf("mutation calls = %d, want 1", countMCPColorCalls(fake, mutationName))
+			}
+		})
+	}
+}
+
+func TestMCPColorCancellationUsesExactBoundContext(t *testing.T) {
+	t.Run("access", func(t *testing.T) {
+		fake := &mcpColorFake{accessContextErr: true}
+		ctx, cancel := context.WithCancel(store.WithUserID(context.Background(), 197))
+		cancel()
+		prepared, err := newMCPColorTestService(fake).PrepareProjectID(ctx, MCPProjectIDColorTarget{ProjectSlug: "project"})
+		if prepared != nil || err != context.Canceled {
+			t.Fatalf("PrepareProjectID() = (%v, %v), want (nil, context.Canceled)", prepared, err)
+		}
+		assertMCPColorTrace(t, fake, "access")
+		if findMCPColorCall(t, fake, "access").ctx != ctx {
+			t.Fatal("access did not receive exact bound context")
+		}
+	})
+
+	t.Run("mine pre-read", func(t *testing.T) {
+		fake := &mcpColorFake{mineReadContextErr: true}
+		ctx, cancel := context.WithCancel(store.WithUserID(context.Background(), 199))
+		cancel()
+		prepared, err := newMCPColorTestService(fake).PrepareMineID(ctx, MCPMineIDColorTarget{TagID: 1})
+		if prepared != nil || err != context.Canceled {
+			t.Fatalf("PrepareMineID() = (%v, %v), want (nil, context.Canceled)", prepared, err)
+		}
+		assertMCPColorTrace(t, fake, "mine-read")
+		if findMCPColorCall(t, fake, "mine-read").ctx != ctx {
+			t.Fatal("mine read did not receive exact bound context")
+		}
+	})
+
+	t.Run("project pre-read", func(t *testing.T) {
+		fake := &mcpColorFake{
+			projectContext:   store.ProjectContext{Project: store.Project{ID: 211}, Role: store.RoleMaintainer},
+			projectReadSteps: []mcpColorProjectReadStep{{trace: "project-read-pre", returnContextError: true}},
+		}
+		ctx, cancel := context.WithCancel(store.WithUserID(context.Background(), 223))
+		cancel()
+		prepared, err := newMCPColorTestService(fake).PrepareProjectID(ctx, MCPProjectIDColorTarget{ProjectSlug: "project", TagID: 227})
+		if prepared != nil || err != context.Canceled {
+			t.Fatalf("PrepareProjectID() = (%v, %v), want (nil, context.Canceled)", prepared, err)
+		}
+		assertMCPColorTrace(t, fake, "access", "project-read-pre")
+		if findMCPColorCall(t, fake, "project-read-pre").ctx != ctx {
+			t.Fatal("project pre-read did not receive exact bound context")
+		}
+	})
+
+	t.Run("mutation after preparation", func(t *testing.T) {
+		fake := &mcpColorFake{
+			projectContext:      store.ProjectContext{Project: store.Project{ID: 229}, Role: store.RoleMaintainer},
+			projectReadSteps:    []mcpColorProjectReadStep{{trace: "project-read-pre", tags: []store.TagCount{{TagID: 233}}}},
+			durableIDContextErr: true,
+		}
+		ctx, cancel := context.WithCancel(store.WithUserID(context.Background(), 239))
+		prepared, err := newMCPColorTestService(fake).PrepareProjectID(ctx, MCPProjectIDColorTarget{ProjectSlug: "project", TagID: 233})
+		if err != nil {
+			t.Fatalf("PrepareProjectID() error = %v", err)
+		}
+		cancel()
+		if _, err := prepared.Update(); err != context.Canceled {
+			t.Fatalf("Update() error = %v, want context.Canceled", err)
+		}
+		assertMCPColorTrace(t, fake, "access", "project-read-pre", "durable-id-color")
+		if findMCPColorCall(t, fake, "durable-id-color").ctx != ctx {
+			t.Fatal("mutation did not receive exact bound context")
+		}
+	})
+
+	t.Run("post-read after committed mutation", func(t *testing.T) {
+		fake := &mcpColorFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 241}, Role: store.RoleMaintainer},
+			projectReadSteps: []mcpColorProjectReadStep{
+				{trace: "project-read-pre", tags: []store.TagCount{{TagID: 251}}},
+				{trace: "project-read-post", returnContextError: true},
+			},
+		}
+		ctx, cancel := context.WithCancel(store.WithUserID(context.Background(), 257))
+		prepared, err := newMCPColorTestService(fake).PrepareProjectID(ctx, MCPProjectIDColorTarget{ProjectSlug: "project", TagID: 251})
+		if err != nil {
+			t.Fatalf("PrepareProjectID() error = %v", err)
+		}
+		cancel()
+		if _, err := prepared.Update(); err != context.Canceled {
+			t.Fatalf("Update() error = %v, want context.Canceled", err)
+		}
+		assertMCPColorTrace(t, fake, "access", "project-read-pre", "durable-id-color", "project-read-post")
+		if countMCPColorCalls(fake, "durable-id-color") != 1 {
+			t.Fatalf("mutation calls = %d, want 1", countMCPColorCalls(fake, "durable-id-color"))
+		}
+		if findMCPColorCall(t, fake, "project-read-post").ctx != ctx {
+			t.Fatal("post-read did not receive exact bound context")
+		}
+	})
+}
+
+func temporaryProject(id int64) store.Project {
+	expiresAt := time.Now().Add(time.Hour)
+	return store.Project{ID: id, ExpiresAt: &expiresAt}
+}
+
+func assertMCPColorTrace(t *testing.T, fake *mcpColorFake, want ...string) {
+	t.Helper()
+	if !reflect.DeepEqual(fake.trace, want) {
+		t.Fatalf("trace = %v, want %v", fake.trace, want)
+	}
+}
+
+func findMCPColorCall(t *testing.T, fake *mcpColorFake, operation string) mcpColorCall {
+	t.Helper()
+	for _, call := range fake.calls {
+		if call.operation == operation {
+			return call
+		}
+	}
+	t.Fatalf("missing %q call in %#v", operation, fake.calls)
+	return mcpColorCall{}
+}
+
+func countMCPColorCalls(fake *mcpColorFake, operation string) int {
+	count := 0
+	for _, call := range fake.calls {
+		if call.operation == operation {
+			count++
+		}
+	}
+	return count
+}
+
+func assertMCPColorStringPointer(t *testing.T, got *string, want string) {
+	t.Helper()
+	if got == nil || *got != want {
+		t.Fatalf("color = %s, want %q", describeStringPointer(got), want)
+	}
+}

--- a/internal/application/tag/mcp_deletion.go
+++ b/internal/application/tag/mcp_deletion.go
@@ -1,0 +1,140 @@
+package tag
+
+import (
+	"context"
+
+	"scrumboy/internal/store"
+)
+
+// MCPDeletionServiceDependencies contains only the access, read, and row
+// deletion capabilities required by MCP tag deletion operations.
+type MCPDeletionServiceDependencies struct {
+	Access        MCPProjectAccessStore
+	MineRead      MineTagReadStore
+	ProjectScoped ProjectScopedTagReadStore
+	Rows          LegacyRowDeletionStore
+}
+
+// MCPDeletionService prepares MCP-specific tag deletion operations. It has no
+// publisher, affected-project result, or post-delete read capability.
+type MCPDeletionService struct {
+	access        MCPProjectAccessStore
+	mineRead      MineTagReadStore
+	projectScoped ProjectScopedTagReadStore
+	rows          LegacyRowDeletionStore
+}
+
+// NewMCPDeletionService constructs the additive MCP deletion service.
+func NewMCPDeletionService(deps MCPDeletionServiceDependencies) *MCPDeletionService {
+	return &MCPDeletionService{
+		access:        deps.Access,
+		mineRead:      deps.MineRead,
+		projectScoped: deps.ProjectScoped,
+		rows:          deps.Rows,
+	}
+}
+
+// MCPMineIDDeletionTarget contains already-validated transport-neutral input
+// for one mine tag deletion.
+type MCPMineIDDeletionTarget struct {
+	TagID int64
+}
+
+// PreparedMCPMineIDDeletion binds the actor and exact mine tag ID selected by
+// the characterized pre-read.
+type PreparedMCPMineIDDeletion struct {
+	ctx     context.Context
+	service *MCPDeletionService
+	actorID int64
+	tagID   int64
+}
+
+// PrepareMineID extracts the actor, reads the mine library exactly once, and
+// selects the requested row by exact ID.
+func (s *MCPDeletionService) PrepareMineID(
+	ctx context.Context,
+	target MCPMineIDDeletionTarget,
+) (*PreparedMCPMineIDDeletion, error) {
+	actorID, ok := store.UserIDFromContext(ctx)
+	if !ok {
+		return nil, ErrActorRequired
+	}
+
+	tags, err := s.mineRead.ListUserTags(ctx, actorID)
+	if err != nil {
+		return nil, err
+	}
+	if _, found := findMineTagByID(tags, target.TagID); !found {
+		return nil, store.ErrNotFound
+	}
+
+	return &PreparedMCPMineIDDeletion{
+		ctx:     ctx,
+		service: s,
+		actorID: actorID,
+		tagID:   target.TagID,
+	}, nil
+}
+
+// Delete performs the legacy row-oriented mine deletion exactly once.
+func (p *PreparedMCPMineIDDeletion) Delete() error {
+	return p.service.rows.DeleteTag(p.ctx, p.actorID, p.tagID, false)
+}
+
+// MCPProjectIDDeletionTarget contains already-validated transport-neutral
+// input for one project-scoped tag deletion.
+type MCPProjectIDDeletionTarget struct {
+	ProjectSlug string
+	Mode        store.Mode
+	TagID       int64
+}
+
+// PreparedMCPProjectIDDeletion binds the actor, exact tag ID, and anonymous
+// board classification derived after the characterized access checks.
+type PreparedMCPProjectIDDeletion struct {
+	ctx              context.Context
+	service          *MCPDeletionService
+	actorID          int64
+	tagID            int64
+	isAnonymousBoard bool
+}
+
+// PrepareProjectID preserves the access, actor, Maintainer, and project-scoped
+// target ordering of the existing MCP adapter.
+func (s *MCPDeletionService) PrepareProjectID(
+	ctx context.Context,
+	target MCPProjectIDDeletionTarget,
+) (*PreparedMCPProjectIDDeletion, error) {
+	projectContext, err := s.access.GetProjectContextBySlug(ctx, target.ProjectSlug, target.Mode)
+	if err != nil {
+		return nil, err
+	}
+
+	actorID, ok := store.UserIDFromContext(ctx)
+	if !ok {
+		return nil, ErrActorRequired
+	}
+	if !projectContext.Role.HasMinimumRole(store.RoleMaintainer) {
+		return nil, ErrMaintainerRequired
+	}
+	if _, err := s.projectScoped.GetProjectScopedTagByID(
+		ctx,
+		projectContext.Project.ID,
+		target.TagID,
+	); err != nil {
+		return nil, err
+	}
+
+	return &PreparedMCPProjectIDDeletion{
+		ctx:              ctx,
+		service:          s,
+		actorID:          actorID,
+		tagID:            target.TagID,
+		isAnonymousBoard: projectContext.Project.ExpiresAt != nil && projectContext.Project.CreatorUserID == nil,
+	}, nil
+}
+
+// Delete performs the prepared project-scoped row deletion exactly once.
+func (p *PreparedMCPProjectIDDeletion) Delete() error {
+	return p.service.rows.DeleteTag(p.ctx, p.actorID, p.tagID, p.isAnonymousBoard)
+}

--- a/internal/application/tag/mcp_deletion_test.go
+++ b/internal/application/tag/mcp_deletion_test.go
@@ -1,0 +1,361 @@
+package tag
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"scrumboy/internal/store"
+)
+
+type mcpDeletionCall struct {
+	ctx              context.Context
+	projectSlug      string
+	mode             store.Mode
+	projectID        int64
+	actorID          int64
+	tagID            int64
+	isAnonymousBoard bool
+}
+
+type mcpDeletionFake struct {
+	trace          []string
+	calls          []mcpDeletionCall
+	projectContext store.ProjectContext
+	mineTags       []store.TagWithColor
+	accessErr      error
+	mineReadErr    error
+	projectReadErr error
+	deleteErr      error
+	contextErrors  bool
+}
+
+func (f *mcpDeletionFake) GetProjectContextBySlug(
+	ctx context.Context,
+	slug string,
+	mode store.Mode,
+) (store.ProjectContext, error) {
+	f.record("project-access", mcpDeletionCall{ctx: ctx, projectSlug: slug, mode: mode})
+	if f.contextErrors {
+		return store.ProjectContext{}, ctx.Err()
+	}
+	if f.accessErr != nil {
+		return store.ProjectContext{}, f.accessErr
+	}
+	return f.projectContext, nil
+}
+
+func (f *mcpDeletionFake) ListUserTags(
+	ctx context.Context,
+	userID int64,
+) ([]store.TagWithColor, error) {
+	f.record("mine-read", mcpDeletionCall{ctx: ctx, actorID: userID})
+	if f.contextErrors {
+		return nil, ctx.Err()
+	}
+	if f.mineReadErr != nil {
+		return nil, f.mineReadErr
+	}
+	return f.mineTags, nil
+}
+
+func (f *mcpDeletionFake) GetProjectScopedTagByID(
+	ctx context.Context,
+	projectID, tagID int64,
+) (store.TagWithColor, error) {
+	f.record("project-tag-read", mcpDeletionCall{ctx: ctx, projectID: projectID, tagID: tagID})
+	if f.contextErrors {
+		return store.TagWithColor{}, ctx.Err()
+	}
+	if f.projectReadErr != nil {
+		return store.TagWithColor{}, f.projectReadErr
+	}
+	return store.TagWithColor{TagID: tagID, Name: "project-row"}, nil
+}
+
+func (f *mcpDeletionFake) DeleteTag(
+	ctx context.Context,
+	userID, tagID int64,
+	isAnonymousBoard bool,
+) error {
+	f.record("row-delete", mcpDeletionCall{
+		ctx: ctx, actorID: userID, tagID: tagID, isAnonymousBoard: isAnonymousBoard,
+	})
+	if f.contextErrors {
+		return ctx.Err()
+	}
+	return f.deleteErr
+}
+
+func (f *mcpDeletionFake) record(operation string, call mcpDeletionCall) {
+	f.trace = append(f.trace, operation)
+	f.calls = append(f.calls, call)
+}
+
+func newMCPDeletionTestService(fake *mcpDeletionFake) *MCPDeletionService {
+	return NewMCPDeletionService(MCPDeletionServiceDependencies{
+		Access:        fake,
+		MineRead:      fake,
+		ProjectScoped: fake,
+		Rows:          fake,
+	})
+}
+
+func TestMCPDeletionMineIDSequenceAndErrors(t *testing.T) {
+	t.Run("success uses one pre-read and one row deletion", func(t *testing.T) {
+		fake := &mcpDeletionFake{mineTags: []store.TagWithColor{
+			{TagID: 7, Name: "other"},
+			{TagID: 11, Name: "target"},
+		}}
+		ctx := store.WithUserID(context.Background(), 5)
+		prepared, err := newMCPDeletionTestService(fake).PrepareMineID(ctx, MCPMineIDDeletionTarget{TagID: 11})
+		if err != nil {
+			t.Fatalf("PrepareMineID() error = %v", err)
+		}
+		if err := prepared.Delete(); err != nil {
+			t.Fatalf("Delete() error = %v", err)
+		}
+
+		assertMCPDeletionTrace(t, fake, "mine-read", "row-delete")
+		if len(fake.calls) != 2 || fake.calls[0].ctx != ctx || fake.calls[0].actorID != 5 {
+			t.Fatalf("mine read calls = %#v", fake.calls)
+		}
+		assertMCPDeletionRowCall(t, fake.calls[1], ctx, 5, 11, false)
+	})
+
+	t.Run("missing actor wins before mine read", func(t *testing.T) {
+		fake := &mcpDeletionFake{}
+		prepared, err := newMCPDeletionTestService(fake).PrepareMineID(context.Background(), MCPMineIDDeletionTarget{TagID: 13})
+		if prepared != nil || !errors.Is(err, ErrActorRequired) {
+			t.Fatalf("PrepareMineID() = (%v, %v), want (nil, ErrActorRequired)", prepared, err)
+		}
+		assertMCPDeletionTrace(t, fake)
+	})
+
+	t.Run("absent exact ID returns not found without deletion", func(t *testing.T) {
+		fake := &mcpDeletionFake{mineTags: []store.TagWithColor{{TagID: 17}}}
+		prepared, err := newMCPDeletionTestService(fake).PrepareMineID(
+			store.WithUserID(context.Background(), 19),
+			MCPMineIDDeletionTarget{TagID: 23},
+		)
+		if prepared != nil || !errors.Is(err, store.ErrNotFound) {
+			t.Fatalf("PrepareMineID() = (%v, %v), want (nil, store.ErrNotFound)", prepared, err)
+		}
+		assertMCPDeletionTrace(t, fake, "mine-read")
+	})
+
+	t.Run("read error preserves identity", func(t *testing.T) {
+		readErr := errors.New("mine read failed")
+		fake := &mcpDeletionFake{mineReadErr: readErr}
+		prepared, err := newMCPDeletionTestService(fake).PrepareMineID(
+			store.WithUserID(context.Background(), 29),
+			MCPMineIDDeletionTarget{TagID: 31},
+		)
+		if prepared != nil || err != readErr {
+			t.Fatalf("PrepareMineID() = (%v, %v), want (nil, identical %v)", prepared, err, readErr)
+		}
+		assertMCPDeletionTrace(t, fake, "mine-read")
+	})
+
+	t.Run("delete error preserves identity without post-read or retry", func(t *testing.T) {
+		deleteErr := errors.New("mine delete failed")
+		fake := &mcpDeletionFake{
+			mineTags:  []store.TagWithColor{{TagID: 37}},
+			deleteErr: deleteErr,
+		}
+		prepared, err := newMCPDeletionTestService(fake).PrepareMineID(
+			store.WithUserID(context.Background(), 41),
+			MCPMineIDDeletionTarget{TagID: 37},
+		)
+		if err != nil {
+			t.Fatalf("PrepareMineID() error = %v", err)
+		}
+		if err := prepared.Delete(); err != deleteErr {
+			t.Fatalf("Delete() error = %v, want identical %v", err, deleteErr)
+		}
+		assertMCPDeletionTrace(t, fake, "mine-read", "row-delete")
+	})
+}
+
+func TestMCPDeletionProjectIDSequenceAndClassification(t *testing.T) {
+	expiresAt := time.Unix(1_800_000_000, 0)
+	creatorID := int64(43)
+	tests := []struct {
+		name          string
+		project       store.Project
+		wantAnonymous bool
+	}{
+		{name: "durable", project: store.Project{ID: 47}},
+		{name: "creator temporary", project: store.Project{ID: 47, ExpiresAt: &expiresAt, CreatorUserID: &creatorID}},
+		{name: "anonymous temporary", project: store.Project{ID: 47, ExpiresAt: &expiresAt}, wantAnonymous: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &mcpDeletionFake{projectContext: store.ProjectContext{
+				Project: tt.project,
+				Role:    store.RoleMaintainer,
+			}}
+			ctx := store.WithUserID(context.Background(), 53)
+			prepared, err := newMCPDeletionTestService(fake).PrepareProjectID(ctx, MCPProjectIDDeletionTarget{
+				ProjectSlug: "exact-slug",
+				Mode:        store.ModeFull,
+				TagID:       59,
+			})
+			if err != nil {
+				t.Fatalf("PrepareProjectID() error = %v", err)
+			}
+
+			// A prepared deletion owns the classification used by Delete.
+			fake.projectContext.Project.ExpiresAt = nil
+			fake.projectContext.Project.CreatorUserID = int64Pointer(999)
+			if err := prepared.Delete(); err != nil {
+				t.Fatalf("Delete() error = %v", err)
+			}
+
+			assertMCPDeletionTrace(t, fake, "project-access", "project-tag-read", "row-delete")
+			access := fake.calls[0]
+			if access.ctx != ctx || access.projectSlug != "exact-slug" || access.mode != store.ModeFull {
+				t.Fatalf("access call = %#v", access)
+			}
+			projectRead := fake.calls[1]
+			if projectRead.ctx != ctx || projectRead.projectID != 47 || projectRead.tagID != 59 {
+				t.Fatalf("project read call = %#v", projectRead)
+			}
+			assertMCPDeletionRowCall(t, fake.calls[2], ctx, 53, 59, tt.wantAnonymous)
+		})
+	}
+}
+
+func TestMCPDeletionProjectIDPreparationPrecedence(t *testing.T) {
+	accessErr := errors.New("project access failed")
+	projectReadErr := errors.New("project tag missing")
+	tests := []struct {
+		name           string
+		withActor      bool
+		role           store.ProjectRole
+		accessErr      error
+		projectReadErr error
+		wantErr        error
+		wantTrace      []string
+	}{
+		{
+			name: "access failure wins", withActor: true, role: store.RoleMaintainer,
+			accessErr: accessErr, wantErr: accessErr, wantTrace: []string{"project-access"},
+		},
+		{
+			name: "missing actor follows access", role: store.RoleMaintainer,
+			wantErr: ErrActorRequired, wantTrace: []string{"project-access"},
+		},
+		{
+			name: "viewer fails before target read", withActor: true, role: store.RoleViewer,
+			wantErr: ErrMaintainerRequired, wantTrace: []string{"project-access"},
+		},
+		{
+			name: "creator temporary empty role fails before target read", withActor: true,
+			wantErr: ErrMaintainerRequired, wantTrace: []string{"project-access"},
+		},
+		{
+			name: "project-scoped read failure follows role", withActor: true, role: store.RoleMaintainer,
+			projectReadErr: projectReadErr, wantErr: projectReadErr,
+			wantTrace: []string{"project-access", "project-tag-read"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expiresAt := time.Unix(1_800_000_000, 0)
+			creatorID := int64(61)
+			fake := &mcpDeletionFake{
+				projectContext: store.ProjectContext{
+					Project: store.Project{ID: 67, ExpiresAt: &expiresAt, CreatorUserID: &creatorID},
+					Role:    tt.role,
+				},
+				accessErr:      tt.accessErr,
+				projectReadErr: tt.projectReadErr,
+			}
+			ctx := context.Background()
+			if tt.withActor {
+				ctx = store.WithUserID(ctx, 71)
+			}
+			prepared, err := newMCPDeletionTestService(fake).PrepareProjectID(ctx, MCPProjectIDDeletionTarget{
+				ProjectSlug: "ordered",
+				Mode:        store.ModeFull,
+				TagID:       73,
+			})
+			if prepared != nil || !errors.Is(err, tt.wantErr) {
+				t.Fatalf("PrepareProjectID() = (%v, %v), want (nil, %v)", prepared, err, tt.wantErr)
+			}
+			assertMCPDeletionTrace(t, fake, tt.wantTrace...)
+		})
+	}
+}
+
+func TestMCPDeletionProjectIDDeleteErrorAndCancellation(t *testing.T) {
+	t.Run("delete error is returned once without post-read", func(t *testing.T) {
+		deleteErr := errors.New("project delete failed")
+		fake := &mcpDeletionFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 79}, Role: store.RoleMaintainer},
+			deleteErr:      deleteErr,
+		}
+		prepared, err := newMCPDeletionTestService(fake).PrepareProjectID(
+			store.WithUserID(context.Background(), 83),
+			MCPProjectIDDeletionTarget{ProjectSlug: "failure", Mode: store.ModeFull, TagID: 89},
+		)
+		if err != nil {
+			t.Fatalf("PrepareProjectID() error = %v", err)
+		}
+		if err := prepared.Delete(); err != deleteErr {
+			t.Fatalf("Delete() error = %v, want identical %v", err, deleteErr)
+		}
+		assertMCPDeletionTrace(t, fake, "project-access", "project-tag-read", "row-delete")
+	})
+
+	t.Run("cancelled bound context reaches deletion", func(t *testing.T) {
+		fake := &mcpDeletionFake{
+			projectContext: store.ProjectContext{Project: store.Project{ID: 97}, Role: store.RoleMaintainer},
+			contextErrors:  true,
+		}
+		ctx, cancel := context.WithCancel(store.WithUserID(context.Background(), 101))
+		// Preparation collaborators must succeed before cancellation.
+		fake.contextErrors = false
+		prepared, err := newMCPDeletionTestService(fake).PrepareProjectID(ctx, MCPProjectIDDeletionTarget{
+			ProjectSlug: "cancel", Mode: store.ModeFull, TagID: 103,
+		})
+		if err != nil {
+			t.Fatalf("PrepareProjectID() error = %v", err)
+		}
+		fake.contextErrors = true
+		cancel()
+		if err := prepared.Delete(); err != context.Canceled {
+			t.Fatalf("Delete() error = %v, want context.Canceled", err)
+		}
+		assertMCPDeletionTrace(t, fake, "project-access", "project-tag-read", "row-delete")
+		if fake.calls[2].ctx != ctx {
+			t.Fatal("deletion did not use the bound context")
+		}
+	})
+}
+
+func assertMCPDeletionTrace(t *testing.T, fake *mcpDeletionFake, want ...string) {
+	t.Helper()
+	if !reflect.DeepEqual(fake.trace, want) {
+		t.Fatalf("trace = %v, want %v", fake.trace, want)
+	}
+}
+
+func assertMCPDeletionRowCall(
+	t *testing.T,
+	got mcpDeletionCall,
+	wantCtx context.Context,
+	wantActorID, wantTagID int64,
+	wantAnonymous bool,
+) {
+	t.Helper()
+	if got.ctx != wantCtx || got.actorID != wantActorID || got.tagID != wantTagID || got.isAnonymousBoard != wantAnonymous {
+		t.Fatalf("row delete call = %#v, want context/actor/tag/anonymous = %v/%d/%d/%v",
+			got, wantCtx, wantActorID, wantTagID, wantAnonymous)
+	}
+}

--- a/internal/application/tag/mutation.go
+++ b/internal/application/tag/mutation.go
@@ -1,0 +1,263 @@
+// Package tag defines the application-layer vocabulary and persistence
+// capabilities used to converge tag mutations across REST and MCP.
+package tag
+
+import (
+	"context"
+
+	"scrumboy/internal/store"
+)
+
+// ColorIntent preserves the adapter-prepared color value. A nil value means
+// clear; every non-nil value, including an empty or whitespace-only string, is
+// a supplied value whose interpretation remains with the selected store
+// method.
+//
+// ColorIntent owns its value. StoreValue returns a fresh pointer because some
+// existing store methods normalize color values in place.
+type ColorIntent struct {
+	value *string
+}
+
+// NewColorIntent copies value without trimming, normalizing, or validating it.
+func NewColorIntent(value *string) ColorIntent {
+	return ColorIntent{value: cloneString(value)}
+}
+
+// IsClear reports whether the prepared color represents a clear operation.
+func (c ColorIntent) IsClear() bool {
+	return c.value == nil
+}
+
+// StoreValue returns a copy suitable for passing to an existing store method.
+func (c ColorIntent) StoreValue() *string {
+	return cloneString(c.value)
+}
+
+func cloneString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+
+	cloned := *value
+	return &cloned
+}
+
+// ProjectKind records the project distinction already resolved by an adapter
+// or future prepared mutation service.
+type ProjectKind uint8
+
+const (
+	// DurableProject is a persisted project governed by durable membership and
+	// role rules.
+	DurableProject ProjectKind = iota + 1
+	// CreatorOwnedTemporaryBoard is a temporary board whose creator identity is
+	// available to the mutation path.
+	CreatorOwnedTemporaryBoard
+	// AnonymousTemporaryBoard is an unowned temporary board operating under
+	// anonymous-board rules.
+	AnonymousTemporaryBoard
+)
+
+// ResolvedProject identifies a project and the project-kind distinction that
+// later orchestration must preserve. Expiry is not a project kind; the store
+// remains authoritative for temporary-board validity.
+type ResolvedProject struct {
+	ProjectID int64
+	Kind      ProjectKind
+}
+
+// MineIDColorCommand contains prepared values for changing a caller-owned
+// personal tag color by tag ID.
+type MineIDColorCommand struct {
+	ActorUserID int64
+	TagID       int64
+	Color       ColorIntent
+}
+
+// ProjectIDColorCommand contains prepared values for changing a project tag
+// color by tag ID. ViewerUserID is nil for anonymous-board operation.
+type ProjectIDColorCommand struct {
+	Project      ResolvedProject
+	ViewerUserID *int64
+	TagID        int64
+	Color        ColorIntent
+}
+
+// ProjectNameColorCommand contains prepared values for changing a project tag
+// color by name. ViewerUserID is nil for anonymous-board operation.
+type ProjectNameColorCommand struct {
+	Project      ResolvedProject
+	ViewerUserID *int64
+	Name         string
+	Color        ColorIntent
+}
+
+// MineIDDeleteCommand contains prepared values for deleting a caller-owned
+// personal tag by tag ID.
+type MineIDDeleteCommand struct {
+	ActorUserID int64
+	TagID       int64
+}
+
+// ProjectIDDeleteCommand contains prepared values for deleting a project tag
+// by tag ID. ActorUserID is nil for anonymous-board operation.
+type ProjectIDDeleteCommand struct {
+	Project     ResolvedProject
+	ActorUserID *int64
+	TagID       int64
+}
+
+// ProjectNameDeleteCommand contains prepared values for deleting a project tag
+// by name. ActorUserID is nil for anonymous-board operation.
+type ProjectNameDeleteCommand struct {
+	Project     ResolvedProject
+	ActorUserID *int64
+	Name        string
+}
+
+// DeletionResult preserves the affected-project sequence returned by existing
+// store methods while preventing callers from mutating application-owned state.
+type DeletionResult struct {
+	affectedProjectIDs []int64
+}
+
+// NewDeletionResult copies affectedProjectIDs without sorting or deduplicating
+// it. Existing store semantics remain observable to later orchestration.
+func NewDeletionResult(affectedProjectIDs []int64) DeletionResult {
+	return DeletionResult{affectedProjectIDs: cloneProjectIDs(affectedProjectIDs)}
+}
+
+// AffectedProjectIDs returns a defensive copy of the affected project IDs.
+func (r DeletionResult) AffectedProjectIDs() []int64 {
+	return cloneProjectIDs(r.affectedProjectIDs)
+}
+
+func cloneProjectIDs(projectIDs []int64) []int64 {
+	if projectIDs == nil {
+		return nil
+	}
+
+	return append([]int64{}, projectIDs...)
+}
+
+// MineTagReadStore reads the caller-owned tag projection used by mine mutation
+// responses.
+type MineTagReadStore interface {
+	ListUserTags(ctx context.Context, userID int64) ([]store.TagWithColor, error)
+}
+
+// ProjectTagReadStore reads the project tag projection used by project mutation
+// responses.
+type ProjectTagReadStore interface {
+	ListTagCounts(ctx context.Context, pc *store.ProjectContext) ([]store.TagCount, error)
+}
+
+// ProjectScopedTagReadStore reads a project-scoped tag by ID without widening
+// the mutation interfaces below.
+type ProjectScopedTagReadStore interface {
+	GetProjectScopedTagByID(ctx context.Context, projectID, tagID int64) (store.TagWithColor, error)
+}
+
+// BoardScopedTagNameReadStore resolves a board-scoped tag name to its ID.
+type BoardScopedTagNameReadStore interface {
+	GetBoardScopedTagIDByName(ctx context.Context, projectID int64, tagName string) (int64, error)
+}
+
+// PersonalTagNameReadStore resolves a caller-owned personal tag name to its ID.
+type PersonalTagNameReadStore interface {
+	GetTagIDByName(ctx context.Context, userID int64, tagName string) (int64, error)
+}
+
+// MineColorStore mutates the caller-owned personal color preference by tag ID.
+type MineColorStore interface {
+	UpdateMyTagColor(ctx context.Context, userID, tagID int64, color *string) error
+}
+
+// LegacyRowColorStore exposes the existing row-oriented color operation needed
+// to preserve compatibility while orchestration is moved inward.
+type LegacyRowColorStore interface {
+	UpdateTagColor(ctx context.Context, viewerUserID *int64, tagID int64, color *string) error
+}
+
+// DurableProjectIDColorStore mutates a durable-project tag color by tag ID.
+type DurableProjectIDColorStore interface {
+	UpdateTagColorForDurableProjectByID(
+		ctx context.Context,
+		projectID int64,
+		viewerUserID int64,
+		tagID int64,
+		color *string,
+	) error
+}
+
+// TemporaryBoardIDColorStore mutates a temporary-board tag color by tag ID.
+type TemporaryBoardIDColorStore interface {
+	UpdateTagColorForTemporaryBoard(
+		ctx context.Context,
+		projectID int64,
+		viewerUserID *int64,
+		tagID int64,
+		color *string,
+	) error
+}
+
+// DurableProjectNameColorStore mutates a durable-project viewer color by tag
+// name.
+type DurableProjectNameColorStore interface {
+	SetViewerTagColorByName(
+		ctx context.Context,
+		projectID int64,
+		viewerUserID int64,
+		name string,
+		color *string,
+	) error
+}
+
+// TemporaryBoardNameColorStore exposes the existing temporary-board name
+// operation. Later orchestration is responsible for deriving the
+// linkTemporaryBoard flag rather than normalizing this store distinction here.
+type TemporaryBoardNameColorStore interface {
+	UpdateTagColorForProject(
+		ctx context.Context,
+		projectID int64,
+		viewerUserID *int64,
+		tagName string,
+		color *string,
+		linkTemporaryBoard bool,
+	) error
+}
+
+// MineIDDeletionStore deletes a caller-owned personal tag by ID and reports the
+// affected projects in the store-provided order.
+type MineIDDeletionStore interface {
+	DeleteMyTagByID(ctx context.Context, userID, tagID int64) ([]int64, error)
+}
+
+// MineNameDeletionStore deletes a caller-owned personal tag by name in the
+// context of a project and reports the affected projects.
+type MineNameDeletionStore interface {
+	DeleteMyTagByName(
+		ctx context.Context,
+		projectID int64,
+		userID int64,
+		name string,
+	) ([]int64, error)
+}
+
+// DurableProjectIDDeletionStore deletes a durable-project tag by ID and reports
+// the affected projects.
+type DurableProjectIDDeletionStore interface {
+	DeleteTagForDurableProjectByID(
+		ctx context.Context,
+		projectID int64,
+		userID int64,
+		tagID int64,
+	) ([]int64, error)
+}
+
+// LegacyRowDeletionStore exposes the existing row-oriented delete operation.
+// Later orchestration derives isAnonymousBoard from the resolved project kind.
+type LegacyRowDeletionStore interface {
+	DeleteTag(ctx context.Context, userID int64, tagID int64, isAnonymousBoard bool) error
+}

--- a/internal/application/tag/mutation.go
+++ b/internal/application/tag/mutation.go
@@ -9,9 +9,14 @@ import (
 	"scrumboy/internal/store"
 )
 
-// ErrActorRequired reports that a prepared tag mutation requiring an
-// authenticated actor did not receive one.
-var ErrActorRequired = errors.New("tag mutation actor required")
+var (
+	// ErrActorRequired reports that a prepared tag mutation requiring an
+	// authenticated actor did not receive one.
+	ErrActorRequired = errors.New("tag mutation actor required")
+	// ErrMaintainerRequired reports that a prepared tag mutation requiring
+	// durable project authority did not receive it.
+	ErrMaintainerRequired = errors.New("tag mutation maintainer required")
+)
 
 // ColorIntent preserves the adapter-prepared color value. A nil value means
 // clear; every non-nil value, including an empty or whitespace-only string, is
@@ -165,6 +170,16 @@ type MineTagReadStore interface {
 // responses.
 type ProjectTagReadStore interface {
 	ListTagCounts(ctx context.Context, pc *store.ProjectContext) ([]store.TagCount, error)
+}
+
+// MCPProjectAccessStore resolves the project-slug access boundary used by MCP
+// project tag mutations.
+type MCPProjectAccessStore interface {
+	GetProjectContextBySlug(
+		ctx context.Context,
+		slug string,
+		mode store.Mode,
+	) (store.ProjectContext, error)
 }
 
 // ProjectScopedTagReadStore reads a project-scoped tag by ID without widening

--- a/internal/application/tag/mutation.go
+++ b/internal/application/tag/mutation.go
@@ -4,9 +4,14 @@ package tag
 
 import (
 	"context"
+	"errors"
 
 	"scrumboy/internal/store"
 )
+
+// ErrActorRequired reports that a prepared tag mutation requiring an
+// authenticated actor did not receive one.
+var ErrActorRequired = errors.New("tag mutation actor required")
 
 // ColorIntent preserves the adapter-prepared color value. A nil value means
 // clear; every non-nil value, including an empty or whitespace-only string, is
@@ -139,6 +144,15 @@ func cloneProjectIDs(projectIDs []int64) []int64 {
 	}
 
 	return append([]int64{}, projectIDs...)
+}
+
+func cloneInt64(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+
+	cloned := *value
+	return &cloned
 }
 
 // MineTagReadStore reads the caller-owned tag projection used by mine mutation

--- a/internal/application/tag/mutation_test.go
+++ b/internal/application/tag/mutation_test.go
@@ -1,0 +1,223 @@
+package tag
+
+import (
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+var (
+	_ MineTagReadStore              = (*store.Store)(nil)
+	_ ProjectTagReadStore           = (*store.Store)(nil)
+	_ ProjectScopedTagReadStore     = (*store.Store)(nil)
+	_ BoardScopedTagNameReadStore   = (*store.Store)(nil)
+	_ PersonalTagNameReadStore      = (*store.Store)(nil)
+	_ MineColorStore                = (*store.Store)(nil)
+	_ LegacyRowColorStore           = (*store.Store)(nil)
+	_ DurableProjectIDColorStore    = (*store.Store)(nil)
+	_ TemporaryBoardIDColorStore    = (*store.Store)(nil)
+	_ DurableProjectNameColorStore  = (*store.Store)(nil)
+	_ TemporaryBoardNameColorStore  = (*store.Store)(nil)
+	_ MineIDDeletionStore           = (*store.Store)(nil)
+	_ MineNameDeletionStore         = (*store.Store)(nil)
+	_ DurableProjectIDDeletionStore = (*store.Store)(nil)
+	_ LegacyRowDeletionStore        = (*store.Store)(nil)
+)
+
+func TestColorIntentPreservesPreparedValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   *string
+		isClear bool
+		want    *string
+	}{
+		{name: "nil clear", isClear: true},
+		{name: "valid color", value: stringPointer("#12aBcF"), want: stringPointer("#12aBcF")},
+		{name: "surrounding whitespace", value: stringPointer("  #12aBcF  "), want: stringPointer("  #12aBcF  ")},
+		{name: "empty string", value: stringPointer(""), want: stringPointer("")},
+		{name: "whitespace only", value: stringPointer(" \t "), want: stringPointer(" \t ")},
+		{name: "malformed color", value: stringPointer("not-a-color"), want: stringPointer("not-a-color")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			intent := NewColorIntent(tt.value)
+			if got := intent.IsClear(); got != tt.isClear {
+				t.Fatalf("IsClear() = %v, want %v", got, tt.isClear)
+			}
+			if got := intent.StoreValue(); !equalStringPointers(got, tt.want) {
+				t.Fatalf("StoreValue() = %s, want %s", describeStringPointer(got), describeStringPointer(tt.want))
+			}
+		})
+	}
+}
+
+func TestColorIntentOwnsAndReturnsCopies(t *testing.T) {
+	t.Parallel()
+
+	source := "  #12aBcF  "
+	intent := NewColorIntent(&source)
+	source = "changed after construction"
+
+	first := intent.StoreValue()
+	second := intent.StoreValue()
+	if first == nil || second == nil {
+		t.Fatal("StoreValue() returned nil for a supplied color")
+	}
+	if first == second {
+		t.Fatal("StoreValue() returned the same pointer twice")
+	}
+	if got, want := *first, "  #12aBcF  "; got != want {
+		t.Fatalf("first StoreValue() = %q, want %q", got, want)
+	}
+	if got, want := *second, "  #12aBcF  "; got != want {
+		t.Fatalf("second StoreValue() = %q, want %q", got, want)
+	}
+
+	*first = "mutated by store"
+	if got, want := *intent.StoreValue(), "  #12aBcF  "; got != want {
+		t.Fatalf("StoreValue() after caller mutation = %q, want %q", got, want)
+	}
+
+	clear := NewColorIntent(nil)
+	if got := clear.StoreValue(); got != nil {
+		t.Fatalf("clear StoreValue() = %q, want nil", *got)
+	}
+}
+
+func TestDeletionResultOwnsAffectedProjectIDs(t *testing.T) {
+	t.Parallel()
+
+	input := []int64{7, 7, 3}
+	result := NewDeletionResult(input)
+	input[0] = 99
+
+	first := result.AffectedProjectIDs()
+	want := []int64{7, 7, 3}
+	if !reflect.DeepEqual(first, want) {
+		t.Fatalf("AffectedProjectIDs() = %v, want %v", first, want)
+	}
+
+	first[1] = 88
+	if got := result.AffectedProjectIDs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("AffectedProjectIDs() after caller mutation = %v, want %v", got, want)
+	}
+}
+
+func TestProjectKindsAreDistinct(t *testing.T) {
+	t.Parallel()
+
+	kinds := []ProjectKind{
+		DurableProject,
+		CreatorOwnedTemporaryBoard,
+		AnonymousTemporaryBoard,
+	}
+	seen := make(map[ProjectKind]struct{}, len(kinds))
+	for _, kind := range kinds {
+		if kind == 0 {
+			t.Fatal("declared ProjectKind must not use the zero value")
+		}
+		if _, exists := seen[kind]; exists {
+			t.Fatalf("duplicate ProjectKind value %d", kind)
+		}
+		seen[kind] = struct{}{}
+	}
+}
+
+func TestCommandsPreservePreparedIdentityValues(t *testing.T) {
+	t.Parallel()
+
+	actorUserID := int64(-3)
+	viewerUserID := int64(0)
+	project := ResolvedProject{ProjectID: -4, Kind: ProjectKind(99)}
+	color := NewColorIntent(stringPointer(" "))
+
+	mineColor := MineIDColorCommand{
+		ActorUserID: actorUserID,
+		TagID:       -9,
+		Color:       color,
+	}
+	if mineColor.ActorUserID != actorUserID || mineColor.TagID != -9 {
+		t.Fatalf("MineIDColorCommand changed prepared identity values: %#v", mineColor)
+	}
+	assertColorValue(t, mineColor.Color, " ")
+
+	projectIDColor := ProjectIDColorCommand{
+		Project:      project,
+		ViewerUserID: &viewerUserID,
+		TagID:        -9,
+		Color:        color,
+	}
+	if projectIDColor.Project != project || projectIDColor.ViewerUserID == nil || *projectIDColor.ViewerUserID != viewerUserID || projectIDColor.TagID != -9 {
+		t.Fatalf("ProjectIDColorCommand changed prepared identity values: %#v", projectIDColor)
+	}
+	assertColorValue(t, projectIDColor.Color, " ")
+
+	projectNameColor := ProjectNameColorCommand{
+		Project:      project,
+		ViewerUserID: nil,
+		Name:         "",
+		Color:        color,
+	}
+	if projectNameColor.Project != project || projectNameColor.ViewerUserID != nil || projectNameColor.Name != "" {
+		t.Fatalf("ProjectNameColorCommand changed prepared identity values: %#v", projectNameColor)
+	}
+	assertColorValue(t, projectNameColor.Color, " ")
+
+	mineDelete := MineIDDeleteCommand{ActorUserID: actorUserID, TagID: -9}
+	if mineDelete.ActorUserID != actorUserID || mineDelete.TagID != -9 {
+		t.Fatalf("MineIDDeleteCommand changed prepared identity values: %#v", mineDelete)
+	}
+
+	projectIDDelete := ProjectIDDeleteCommand{
+		Project:     project,
+		ActorUserID: &actorUserID,
+		TagID:       -9,
+	}
+	if projectIDDelete.Project != project || projectIDDelete.ActorUserID == nil || *projectIDDelete.ActorUserID != actorUserID || projectIDDelete.TagID != -9 {
+		t.Fatalf("ProjectIDDeleteCommand changed prepared identity values: %#v", projectIDDelete)
+	}
+
+	projectNameDelete := ProjectNameDeleteCommand{
+		Project:     project,
+		ActorUserID: nil,
+		Name:        "",
+	}
+	if projectNameDelete.Project != project || projectNameDelete.ActorUserID != nil || projectNameDelete.Name != "" {
+		t.Fatalf("ProjectNameDeleteCommand changed prepared identity values: %#v", projectNameDelete)
+	}
+}
+
+func assertColorValue(t *testing.T, intent ColorIntent, want string) {
+	t.Helper()
+
+	got := intent.StoreValue()
+	if got == nil || *got != want {
+		t.Fatalf("ColorIntent.StoreValue() = %s, want %q", describeStringPointer(got), want)
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+func equalStringPointers(left, right *string) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+
+	return *left == *right
+}
+
+func describeStringPointer(value *string) string {
+	if value == nil {
+		return "nil"
+	}
+
+	return `"` + *value + `"`
+}

--- a/internal/application/tag/mutation_test.go
+++ b/internal/application/tag/mutation_test.go
@@ -10,6 +10,7 @@ import (
 var (
 	_ MineTagReadStore              = (*store.Store)(nil)
 	_ ProjectTagReadStore           = (*store.Store)(nil)
+	_ MCPProjectAccessStore         = (*store.Store)(nil)
 	_ ProjectScopedTagReadStore     = (*store.Store)(nil)
 	_ BoardScopedTagNameReadStore   = (*store.Store)(nil)
 	_ PersonalTagNameReadStore      = (*store.Store)(nil)

--- a/internal/application/tag/rest_color.go
+++ b/internal/application/tag/rest_color.go
@@ -1,0 +1,234 @@
+package tag
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrInvalidProjectKind reports an unknown project-kind value in an already
+// prepared REST project command.
+var ErrInvalidProjectKind = errors.New("invalid tag color project kind")
+
+// RESTColorPublisher publishes the semantic invalidation required after a
+// successful REST project color mutation. An empty name identifies an
+// ID-addressed mutation.
+type RESTColorPublisher interface {
+	PublishTagColorUpdated(ctx context.Context, projectID int64, name string)
+}
+
+type nopRESTColorPublisher struct{}
+
+func (nopRESTColorPublisher) PublishTagColorUpdated(context.Context, int64, string) {}
+
+// RESTColorServiceDependencies contains only the persistence and publication
+// capabilities used by REST tag color operations.
+type RESTColorServiceDependencies struct {
+	MineColor          MineColorStore
+	DurableIDColor     DurableProjectIDColorStore
+	TemporaryIDColor   TemporaryBoardIDColorStore
+	DurableNameColor   DurableProjectNameColorStore
+	TemporaryNameColor TemporaryBoardNameColorStore
+	Publisher          RESTColorPublisher
+}
+
+// RESTColorService prepares REST-specific tag color operations. It performs no
+// project lookup or tag read because those are not part of the current REST
+// mutation sequences.
+type RESTColorService struct {
+	mineColor          MineColorStore
+	durableIDColor     DurableProjectIDColorStore
+	temporaryIDColor   TemporaryBoardIDColorStore
+	durableNameColor   DurableProjectNameColorStore
+	temporaryNameColor TemporaryBoardNameColorStore
+	publisher          RESTColorPublisher
+}
+
+// NewRESTColorService constructs the additive REST color application service.
+func NewRESTColorService(deps RESTColorServiceDependencies) *RESTColorService {
+	publisher := deps.Publisher
+	if publisher == nil {
+		publisher = nopRESTColorPublisher{}
+	}
+
+	return &RESTColorService{
+		mineColor:          deps.MineColor,
+		durableIDColor:     deps.DurableIDColor,
+		temporaryIDColor:   deps.TemporaryIDColor,
+		durableNameColor:   deps.DurableNameColor,
+		temporaryNameColor: deps.TemporaryNameColor,
+		publisher:          publisher,
+	}
+}
+
+// PreparedRESTMineIDColor binds the exact context and adapter-prepared mine
+// command used by one personal-library color mutation.
+type PreparedRESTMineIDColor struct {
+	ctx     context.Context
+	service *RESTColorService
+	actorID int64
+	tagID   int64
+	color   ColorIntent
+}
+
+// PrepareMineID binds a mine color command without adding reads,
+// authorization, or publication.
+func (s *RESTColorService) PrepareMineID(
+	ctx context.Context,
+	command MineIDColorCommand,
+) *PreparedRESTMineIDColor {
+	return &PreparedRESTMineIDColor{
+		ctx:     ctx,
+		service: s,
+		actorID: command.ActorUserID,
+		tagID:   command.TagID,
+		color:   command.Color,
+	}
+}
+
+// Update performs the prepared mine color mutation exactly once and never
+// publishes a project invalidation.
+func (p *PreparedRESTMineIDColor) Update() error {
+	return p.service.mineColor.UpdateMyTagColor(
+		p.ctx,
+		p.actorID,
+		p.tagID,
+		p.color.StoreValue(),
+	)
+}
+
+// PreparedRESTProjectIDColor binds one resolved REST project-ID color
+// operation, including a copied optional viewer identity.
+type PreparedRESTProjectIDColor struct {
+	ctx      context.Context
+	service  *RESTColorService
+	project  ResolvedProject
+	viewerID *int64
+	tagID    int64
+	color    ColorIntent
+}
+
+// PrepareProjectID validates only project-kind combinations owned by the
+// application boundary and binds all adapter-prepared values.
+func (s *RESTColorService) PrepareProjectID(
+	ctx context.Context,
+	command ProjectIDColorCommand,
+) (*PreparedRESTProjectIDColor, error) {
+	switch command.Project.Kind {
+	case DurableProject:
+		if command.ViewerUserID == nil {
+			return nil, ErrActorRequired
+		}
+	case CreatorOwnedTemporaryBoard, AnonymousTemporaryBoard:
+		// Temporary REST paths preserve their optional viewer identity.
+	default:
+		return nil, ErrInvalidProjectKind
+	}
+
+	return &PreparedRESTProjectIDColor{
+		ctx:      ctx,
+		service:  s,
+		project:  command.Project,
+		viewerID: cloneInt64(command.ViewerUserID),
+		tagID:    command.TagID,
+		color:    command.Color,
+	}, nil
+}
+
+// Update dispatches to the durable or temporary ID capability exactly once,
+// then publishes the project invalidation after success.
+func (p *PreparedRESTProjectIDColor) Update() error {
+	var err error
+	switch p.project.Kind {
+	case DurableProject:
+		err = p.service.durableIDColor.UpdateTagColorForDurableProjectByID(
+			p.ctx,
+			p.project.ProjectID,
+			*p.viewerID,
+			p.tagID,
+			p.color.StoreValue(),
+		)
+	case CreatorOwnedTemporaryBoard, AnonymousTemporaryBoard:
+		err = p.service.temporaryIDColor.UpdateTagColorForTemporaryBoard(
+			p.ctx,
+			p.project.ProjectID,
+			cloneInt64(p.viewerID),
+			p.tagID,
+			p.color.StoreValue(),
+		)
+	}
+	if err != nil {
+		return err
+	}
+
+	p.service.publisher.PublishTagColorUpdated(p.ctx, p.project.ProjectID, "")
+	return nil
+}
+
+// PreparedRESTProjectNameColor binds one resolved REST project-name color
+// operation, including a copied optional viewer identity.
+type PreparedRESTProjectNameColor struct {
+	ctx      context.Context
+	service  *RESTColorService
+	project  ResolvedProject
+	viewerID *int64
+	name     string
+	color    ColorIntent
+}
+
+// PrepareProjectName validates only project-kind combinations owned by the
+// application boundary and binds all adapter-prepared values.
+func (s *RESTColorService) PrepareProjectName(
+	ctx context.Context,
+	command ProjectNameColorCommand,
+) (*PreparedRESTProjectNameColor, error) {
+	switch command.Project.Kind {
+	case DurableProject:
+		if command.ViewerUserID == nil {
+			return nil, ErrActorRequired
+		}
+	case CreatorOwnedTemporaryBoard, AnonymousTemporaryBoard:
+		// Temporary REST paths preserve their optional viewer identity.
+	default:
+		return nil, ErrInvalidProjectKind
+	}
+
+	return &PreparedRESTProjectNameColor{
+		ctx:      ctx,
+		service:  s,
+		project:  command.Project,
+		viewerID: cloneInt64(command.ViewerUserID),
+		name:     command.Name,
+		color:    command.Color,
+	}, nil
+}
+
+// Update dispatches to the durable or temporary name capability exactly once,
+// then publishes the exact prepared name after success.
+func (p *PreparedRESTProjectNameColor) Update() error {
+	var err error
+	switch p.project.Kind {
+	case DurableProject:
+		err = p.service.durableNameColor.SetViewerTagColorByName(
+			p.ctx,
+			p.project.ProjectID,
+			*p.viewerID,
+			p.name,
+			p.color.StoreValue(),
+		)
+	case CreatorOwnedTemporaryBoard, AnonymousTemporaryBoard:
+		err = p.service.temporaryNameColor.UpdateTagColorForProject(
+			p.ctx,
+			p.project.ProjectID,
+			cloneInt64(p.viewerID),
+			p.name,
+			p.color.StoreValue(),
+			true,
+		)
+	}
+	if err != nil {
+		return err
+	}
+
+	p.service.publisher.PublishTagColorUpdated(p.ctx, p.project.ProjectID, p.name)
+	return nil
+}

--- a/internal/application/tag/rest_color_test.go
+++ b/internal/application/tag/rest_color_test.go
@@ -1,0 +1,470 @@
+package tag
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type restColorCall struct {
+	ctx                context.Context
+	projectID          int64
+	viewerUserID       *int64
+	actorUserID        int64
+	tagID              int64
+	name               string
+	color              *string
+	linkTemporaryBoard bool
+}
+
+type restColorFake struct {
+	trace            []string
+	mutationErr      error
+	returnContextErr bool
+	calls            []restColorCall
+	publications     []restColorCall
+}
+
+func (f *restColorFake) UpdateMyTagColor(
+	ctx context.Context,
+	userID, tagID int64,
+	color *string,
+) error {
+	f.recordMutation("mine-color", restColorCall{
+		ctx: ctx, actorUserID: userID, tagID: tagID, color: cloneString(color),
+	})
+	return f.result(ctx)
+}
+
+func (f *restColorFake) UpdateTagColorForDurableProjectByID(
+	ctx context.Context,
+	projectID, viewerUserID, tagID int64,
+	color *string,
+) error {
+	f.recordMutation("durable-id-color", restColorCall{
+		ctx: ctx, projectID: projectID, viewerUserID: cloneInt64(&viewerUserID), tagID: tagID, color: cloneString(color),
+	})
+	return f.result(ctx)
+}
+
+func (f *restColorFake) UpdateTagColorForTemporaryBoard(
+	ctx context.Context,
+	projectID int64,
+	viewerUserID *int64,
+	tagID int64,
+	color *string,
+) error {
+	f.recordMutation("temporary-id-color", restColorCall{
+		ctx: ctx, projectID: projectID, viewerUserID: cloneInt64(viewerUserID), tagID: tagID, color: cloneString(color),
+	})
+	return f.result(ctx)
+}
+
+func (f *restColorFake) SetViewerTagColorByName(
+	ctx context.Context,
+	projectID, viewerUserID int64,
+	name string,
+	color *string,
+) error {
+	f.recordMutation("durable-name-color", restColorCall{
+		ctx: ctx, projectID: projectID, viewerUserID: cloneInt64(&viewerUserID), name: name, color: cloneString(color),
+	})
+	return f.result(ctx)
+}
+
+func (f *restColorFake) UpdateTagColorForProject(
+	ctx context.Context,
+	projectID int64,
+	viewerUserID *int64,
+	name string,
+	color *string,
+	linkTemporaryBoard bool,
+) error {
+	f.recordMutation("temporary-name-color", restColorCall{
+		ctx:                ctx,
+		projectID:          projectID,
+		viewerUserID:       cloneInt64(viewerUserID),
+		name:               name,
+		color:              cloneString(color),
+		linkTemporaryBoard: linkTemporaryBoard,
+	})
+	return f.result(ctx)
+}
+
+func (f *restColorFake) PublishTagColorUpdated(ctx context.Context, projectID int64, name string) {
+	f.trace = append(f.trace, "publish")
+	f.publications = append(f.publications, restColorCall{ctx: ctx, projectID: projectID, name: name})
+}
+
+func (f *restColorFake) recordMutation(name string, call restColorCall) {
+	f.trace = append(f.trace, name)
+	f.calls = append(f.calls, call)
+}
+
+func (f *restColorFake) result(ctx context.Context) error {
+	if f.returnContextErr {
+		return ctx.Err()
+	}
+	return f.mutationErr
+}
+
+func newRESTColorTestService(fake *restColorFake) *RESTColorService {
+	return NewRESTColorService(RESTColorServiceDependencies{
+		MineColor:          fake,
+		DurableIDColor:     fake,
+		TemporaryIDColor:   fake,
+		DurableNameColor:   fake,
+		TemporaryNameColor: fake,
+		Publisher:          fake,
+	})
+}
+
+func TestRESTColorMineIDSequenceAndErrors(t *testing.T) {
+	t.Run("success preserves prepared values without publication", func(t *testing.T) {
+		fake := &restColorFake{}
+		ctx := context.WithValue(context.Background(), restColorContextKey{}, "mine")
+		color := "  #aBcDeF  "
+		prepared := newRESTColorTestService(fake).PrepareMineID(ctx, MineIDColorCommand{
+			ActorUserID: 17,
+			TagID:       29,
+			Color:       NewColorIntent(&color),
+		})
+		color = "changed after preparation"
+
+		if err := prepared.Update(); err != nil {
+			t.Fatalf("Update() error = %v", err)
+		}
+		assertRESTColorTrace(t, fake, "mine-color")
+		if len(fake.calls) != 1 || len(fake.publications) != 0 {
+			t.Fatalf("calls = %d, publications = %d, want 1 and 0", len(fake.calls), len(fake.publications))
+		}
+		call := fake.calls[0]
+		if call.ctx != ctx || call.actorUserID != 17 || call.tagID != 29 {
+			t.Fatalf("mine call = %#v", call)
+		}
+		assertRESTColorStringPointer(t, call.color, "  #aBcDeF  ")
+	})
+
+	t.Run("mutation failure is unchanged and does not publish", func(t *testing.T) {
+		mutationErr := errors.New("mine mutation failed")
+		fake := &restColorFake{mutationErr: mutationErr}
+		prepared := newRESTColorTestService(fake).PrepareMineID(context.Background(), MineIDColorCommand{
+			ActorUserID: 31,
+			TagID:       37,
+			Color:       NewColorIntent(nil),
+		})
+
+		if err := prepared.Update(); err != mutationErr {
+			t.Fatalf("Update() error = %v, want identical %v", err, mutationErr)
+		}
+		assertRESTColorTrace(t, fake, "mine-color")
+		if len(fake.publications) != 0 {
+			t.Fatalf("publications = %d, want 0", len(fake.publications))
+		}
+	})
+}
+
+func TestRESTColorProjectIDDispatchAndPublication(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       ProjectKind
+		viewerID   *int64
+		wantViewer *int64
+		wantTrace  []string
+	}{
+		{
+			name:       "durable",
+			kind:       DurableProject,
+			viewerID:   int64Pointer(41),
+			wantViewer: int64Pointer(41),
+			wantTrace:  []string{"durable-id-color", "publish"},
+		},
+		{
+			name:       "creator temporary",
+			kind:       CreatorOwnedTemporaryBoard,
+			viewerID:   int64Pointer(43),
+			wantViewer: int64Pointer(43),
+			wantTrace:  []string{"temporary-id-color", "publish"},
+		},
+		{
+			name:      "anonymous temporary",
+			kind:      AnonymousTemporaryBoard,
+			wantTrace: []string{"temporary-id-color", "publish"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &restColorFake{}
+			ctx := context.WithValue(context.Background(), restColorContextKey{}, tt.name)
+			viewerSource := tt.viewerID
+			prepared, err := newRESTColorTestService(fake).PrepareProjectID(ctx, ProjectIDColorCommand{
+				Project:      ResolvedProject{ProjectID: 47, Kind: tt.kind},
+				ViewerUserID: viewerSource,
+				TagID:        53,
+				Color:        NewColorIntent(stringPointer("#123456")),
+			})
+			if err != nil {
+				t.Fatalf("PrepareProjectID() error = %v", err)
+			}
+			if viewerSource != nil {
+				*viewerSource = 999
+			}
+
+			if err := prepared.Update(); err != nil {
+				t.Fatalf("Update() error = %v", err)
+			}
+			assertRESTColorTrace(t, fake, tt.wantTrace...)
+			if len(fake.calls) != 1 || len(fake.publications) != 1 {
+				t.Fatalf("calls = %d, publications = %d, want 1 and 1", len(fake.calls), len(fake.publications))
+			}
+			call := fake.calls[0]
+			if call.ctx != ctx || call.projectID != 47 || call.tagID != 53 || !equalInt64Pointers(call.viewerUserID, tt.wantViewer) {
+				t.Fatalf("mutation call = %#v, want viewer %v", call, tt.wantViewer)
+			}
+			assertRESTColorStringPointer(t, call.color, "#123456")
+			publication := fake.publications[0]
+			if publication.ctx != ctx || publication.projectID != 47 || publication.name != "" {
+				t.Fatalf("publication = %#v", publication)
+			}
+		})
+	}
+}
+
+func TestRESTColorProjectNameDispatchAndPublication(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       ProjectKind
+		viewerID   *int64
+		wantViewer *int64
+		wantTrace  []string
+		wantLink   bool
+	}{
+		{
+			name:       "durable",
+			kind:       DurableProject,
+			viewerID:   int64Pointer(59),
+			wantViewer: int64Pointer(59),
+			wantTrace:  []string{"durable-name-color", "publish"},
+		},
+		{
+			name:       "creator temporary",
+			kind:       CreatorOwnedTemporaryBoard,
+			viewerID:   int64Pointer(61),
+			wantViewer: int64Pointer(61),
+			wantTrace:  []string{"temporary-name-color", "publish"},
+			wantLink:   true,
+		},
+		{
+			name:      "anonymous temporary",
+			kind:      AnonymousTemporaryBoard,
+			wantTrace: []string{"temporary-name-color", "publish"},
+			wantLink:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &restColorFake{}
+			ctx := context.WithValue(context.Background(), restColorContextKey{}, tt.name)
+			viewerSource := tt.viewerID
+			prepared, err := newRESTColorTestService(fake).PrepareProjectName(ctx, ProjectNameColorCommand{
+				Project:      ResolvedProject{ProjectID: 67, Kind: tt.kind},
+				ViewerUserID: viewerSource,
+				Name:         " Name With Spaces ",
+				Color:        NewColorIntent(stringPointer("#abcdef")),
+			})
+			if err != nil {
+				t.Fatalf("PrepareProjectName() error = %v", err)
+			}
+			if viewerSource != nil {
+				*viewerSource = 999
+			}
+
+			if err := prepared.Update(); err != nil {
+				t.Fatalf("Update() error = %v", err)
+			}
+			assertRESTColorTrace(t, fake, tt.wantTrace...)
+			if len(fake.calls) != 1 || len(fake.publications) != 1 {
+				t.Fatalf("calls = %d, publications = %d, want 1 and 1", len(fake.calls), len(fake.publications))
+			}
+			call := fake.calls[0]
+			if call.ctx != ctx || call.projectID != 67 || call.name != " Name With Spaces " ||
+				!equalInt64Pointers(call.viewerUserID, tt.wantViewer) || call.linkTemporaryBoard != tt.wantLink {
+				t.Fatalf("mutation call = %#v", call)
+			}
+			assertRESTColorStringPointer(t, call.color, "#abcdef")
+			publication := fake.publications[0]
+			if publication.ctx != ctx || publication.projectID != 67 || publication.name != " Name With Spaces " {
+				t.Fatalf("publication = %#v", publication)
+			}
+		})
+	}
+}
+
+func TestRESTColorProjectMutationFailuresNeverPublish(t *testing.T) {
+	mutationErr := errors.New("project mutation failed")
+	tests := []struct {
+		name      string
+		kind      ProjectKind
+		byName    bool
+		viewerID  *int64
+		wantTrace string
+	}{
+		{name: "durable ID", kind: DurableProject, viewerID: int64Pointer(71), wantTrace: "durable-id-color"},
+		{name: "creator temporary ID", kind: CreatorOwnedTemporaryBoard, viewerID: int64Pointer(73), wantTrace: "temporary-id-color"},
+		{name: "anonymous temporary ID", kind: AnonymousTemporaryBoard, wantTrace: "temporary-id-color"},
+		{name: "durable name", kind: DurableProject, byName: true, viewerID: int64Pointer(79), wantTrace: "durable-name-color"},
+		{name: "creator temporary name", kind: CreatorOwnedTemporaryBoard, byName: true, viewerID: int64Pointer(83), wantTrace: "temporary-name-color"},
+		{name: "anonymous temporary name", kind: AnonymousTemporaryBoard, byName: true, wantTrace: "temporary-name-color"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &restColorFake{mutationErr: mutationErr}
+			service := newRESTColorTestService(fake)
+			var err error
+			if tt.byName {
+				prepared, prepareErr := service.PrepareProjectName(context.Background(), ProjectNameColorCommand{
+					Project:      ResolvedProject{ProjectID: 89, Kind: tt.kind},
+					ViewerUserID: tt.viewerID,
+					Name:         "failure-name",
+					Color:        NewColorIntent(nil),
+				})
+				if prepareErr != nil {
+					t.Fatalf("PrepareProjectName() error = %v", prepareErr)
+				}
+				err = prepared.Update()
+			} else {
+				prepared, prepareErr := service.PrepareProjectID(context.Background(), ProjectIDColorCommand{
+					Project:      ResolvedProject{ProjectID: 89, Kind: tt.kind},
+					ViewerUserID: tt.viewerID,
+					TagID:        97,
+					Color:        NewColorIntent(nil),
+				})
+				if prepareErr != nil {
+					t.Fatalf("PrepareProjectID() error = %v", prepareErr)
+				}
+				err = prepared.Update()
+			}
+
+			if err != mutationErr {
+				t.Fatalf("Update() error = %v, want identical %v", err, mutationErr)
+			}
+			assertRESTColorTrace(t, fake, tt.wantTrace)
+			if len(fake.publications) != 0 {
+				t.Fatalf("publications = %d, want 0", len(fake.publications))
+			}
+		})
+	}
+}
+
+func TestRESTColorRejectsInvalidPreparedProjectCombinations(t *testing.T) {
+	tests := []struct {
+		name    string
+		byName  bool
+		kind    ProjectKind
+		viewer  *int64
+		wantErr error
+	}{
+		{name: "ID unknown kind", kind: ProjectKind(99), wantErr: ErrInvalidProjectKind},
+		{name: "name zero kind", byName: true, wantErr: ErrInvalidProjectKind},
+		{name: "durable ID missing actor", kind: DurableProject, wantErr: ErrActorRequired},
+		{name: "durable name missing actor", byName: true, kind: DurableProject, wantErr: ErrActorRequired},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &restColorFake{}
+			service := newRESTColorTestService(fake)
+			if tt.byName {
+				prepared, err := service.PrepareProjectName(context.Background(), ProjectNameColorCommand{
+					Project: ResolvedProject{ProjectID: 101, Kind: tt.kind}, ViewerUserID: tt.viewer,
+				})
+				if prepared != nil || !errors.Is(err, tt.wantErr) {
+					t.Fatalf("PrepareProjectName() = (%v, %v), want (nil, %v)", prepared, err, tt.wantErr)
+				}
+			} else {
+				prepared, err := service.PrepareProjectID(context.Background(), ProjectIDColorCommand{
+					Project: ResolvedProject{ProjectID: 101, Kind: tt.kind}, ViewerUserID: tt.viewer,
+				})
+				if prepared != nil || !errors.Is(err, tt.wantErr) {
+					t.Fatalf("PrepareProjectID() = (%v, %v), want (nil, %v)", prepared, err, tt.wantErr)
+				}
+			}
+			assertRESTColorTrace(t, fake)
+		})
+	}
+}
+
+func TestRESTColorPreparedProjectUsesCancelledBoundContext(t *testing.T) {
+	fake := &restColorFake{returnContextErr: true}
+	ctx, cancel := context.WithCancel(context.Background())
+	prepared, err := newRESTColorTestService(fake).PrepareProjectID(ctx, ProjectIDColorCommand{
+		Project:      ResolvedProject{ProjectID: 103, Kind: DurableProject},
+		ViewerUserID: int64Pointer(107),
+		TagID:        109,
+		Color:        NewColorIntent(nil),
+	})
+	if err != nil {
+		t.Fatalf("PrepareProjectID() error = %v", err)
+	}
+	cancel()
+
+	if err := prepared.Update(); err != context.Canceled {
+		t.Fatalf("Update() error = %v, want context.Canceled", err)
+	}
+	assertRESTColorTrace(t, fake, "durable-id-color")
+	if len(fake.calls) != 1 || fake.calls[0].ctx != ctx {
+		t.Fatalf("calls = %#v, want exact bound context", fake.calls)
+	}
+	if len(fake.publications) != 0 {
+		t.Fatalf("publications = %d, want 0", len(fake.publications))
+	}
+}
+
+func TestRESTColorNilPublisherIsNoOp(t *testing.T) {
+	fake := &restColorFake{}
+	service := NewRESTColorService(RESTColorServiceDependencies{
+		DurableIDColor: fake,
+	})
+	prepared, err := service.PrepareProjectID(context.Background(), ProjectIDColorCommand{
+		Project:      ResolvedProject{ProjectID: 113, Kind: DurableProject},
+		ViewerUserID: int64Pointer(127),
+		TagID:        131,
+	})
+	if err != nil {
+		t.Fatalf("PrepareProjectID() error = %v", err)
+	}
+	if err := prepared.Update(); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+}
+
+type restColorContextKey struct{}
+
+func assertRESTColorTrace(t *testing.T, fake *restColorFake, want ...string) {
+	t.Helper()
+	if !reflect.DeepEqual(fake.trace, want) {
+		t.Fatalf("trace = %v, want %v", fake.trace, want)
+	}
+}
+
+func assertRESTColorStringPointer(t *testing.T, got *string, want string) {
+	t.Helper()
+	if got == nil || *got != want {
+		t.Fatalf("color = %s, want %q", describeStringPointer(got), want)
+	}
+}
+
+func int64Pointer(value int64) *int64 {
+	return &value
+}
+
+func equalInt64Pointers(left, right *int64) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}

--- a/internal/application/tag/rest_deletion.go
+++ b/internal/application/tag/rest_deletion.go
@@ -1,0 +1,293 @@
+package tag
+
+import (
+	"context"
+	"errors"
+
+	"scrumboy/internal/store"
+)
+
+var (
+	// ErrInvalidDeletionProjectKind reports an unknown project-kind value in an
+	// already prepared REST deletion command.
+	ErrInvalidDeletionProjectKind = errors.New("invalid tag deletion project kind")
+	// ErrNameDeletionNotAllowed reports the characterized creator-owned
+	// temporary-board rejection for REST name-addressed deletion.
+	ErrNameDeletionNotAllowed = errors.New("tag name deletion not allowed for project kind")
+)
+
+// RESTDeletionPublisher publishes the semantic invalidation required after a
+// successful REST tag deletion. An empty name identifies an ID-addressed
+// deletion.
+type RESTDeletionPublisher interface {
+	PublishTagDeleted(ctx context.Context, projectID int64, name string)
+}
+
+type nopRESTDeletionPublisher struct{}
+
+func (nopRESTDeletionPublisher) PublishTagDeleted(context.Context, int64, string) {}
+
+// RESTDeletionServiceDependencies contains only the lookup, deletion, and
+// publication capabilities required by REST tag deletion operations.
+type RESTDeletionServiceDependencies struct {
+	MineID        MineIDDeletionStore
+	MineName      MineNameDeletionStore
+	DurableID     DurableProjectIDDeletionStore
+	Rows          LegacyRowDeletionStore
+	BoardNames    BoardScopedTagNameReadStore
+	PersonalNames PersonalTagNameReadStore
+	Publisher     RESTDeletionPublisher
+}
+
+// RESTDeletionService prepares REST-specific tag deletion operations and owns
+// their post-success refresh fanout.
+type RESTDeletionService struct {
+	mineID        MineIDDeletionStore
+	mineName      MineNameDeletionStore
+	durableID     DurableProjectIDDeletionStore
+	rows          LegacyRowDeletionStore
+	boardNames    BoardScopedTagNameReadStore
+	personalNames PersonalTagNameReadStore
+	publisher     RESTDeletionPublisher
+}
+
+// NewRESTDeletionService constructs the additive REST deletion service.
+func NewRESTDeletionService(deps RESTDeletionServiceDependencies) *RESTDeletionService {
+	publisher := deps.Publisher
+	if publisher == nil {
+		publisher = nopRESTDeletionPublisher{}
+	}
+
+	return &RESTDeletionService{
+		mineID:        deps.MineID,
+		mineName:      deps.MineName,
+		durableID:     deps.DurableID,
+		rows:          deps.Rows,
+		boardNames:    deps.BoardNames,
+		personalNames: deps.PersonalNames,
+		publisher:     publisher,
+	}
+}
+
+// PreparedRESTMineIDDeletion binds one caller-owned personal tag deletion.
+type PreparedRESTMineIDDeletion struct {
+	ctx     context.Context
+	service *RESTDeletionService
+	actorID int64
+	tagID   int64
+}
+
+// PrepareMineID binds a global mine deletion without adding a pre-read or
+// project origin.
+func (s *RESTDeletionService) PrepareMineID(
+	ctx context.Context,
+	command MineIDDeleteCommand,
+) *PreparedRESTMineIDDeletion {
+	return &PreparedRESTMineIDDeletion{
+		ctx:     ctx,
+		service: s,
+		actorID: command.ActorUserID,
+		tagID:   command.TagID,
+	}
+}
+
+// Delete performs the personal deletion once and publishes only the distinct
+// affected projects returned by the store.
+func (p *PreparedRESTMineIDDeletion) Delete() error {
+	affected, err := p.service.mineID.DeleteMyTagByID(p.ctx, p.actorID, p.tagID)
+	if err != nil {
+		return err
+	}
+
+	p.service.publishAffected(p.ctx, nil, NewDeletionResult(affected), "")
+	return nil
+}
+
+// PreparedRESTProjectIDDeletion binds one resolved REST project-ID deletion,
+// including a copied optional actor identity.
+type PreparedRESTProjectIDDeletion struct {
+	ctx     context.Context
+	service *RESTDeletionService
+	project ResolvedProject
+	actorID *int64
+	tagID   int64
+}
+
+// PrepareProjectID preserves durable actor requirements while retaining the
+// optional actor used by both temporary-board paths.
+func (s *RESTDeletionService) PrepareProjectID(
+	ctx context.Context,
+	command ProjectIDDeleteCommand,
+) (*PreparedRESTProjectIDDeletion, error) {
+	switch command.Project.Kind {
+	case DurableProject:
+		if command.ActorUserID == nil {
+			return nil, ErrActorRequired
+		}
+	case CreatorOwnedTemporaryBoard, AnonymousTemporaryBoard:
+		// Temporary REST deletion passes an optional actor through to the
+		// legacy row operation. The store remains authoritative.
+	default:
+		return nil, ErrInvalidDeletionProjectKind
+	}
+
+	return &PreparedRESTProjectIDDeletion{
+		ctx:     ctx,
+		service: s,
+		project: command.Project,
+		actorID: cloneInt64(command.ActorUserID),
+		tagID:   command.TagID,
+	}, nil
+}
+
+// Delete dispatches exactly one durable or temporary ID deletion and
+// publishes the characterized fanout only after success.
+func (p *PreparedRESTProjectIDDeletion) Delete() error {
+	switch p.project.Kind {
+	case DurableProject:
+		affected, err := p.service.durableID.DeleteTagForDurableProjectByID(
+			p.ctx,
+			p.project.ProjectID,
+			*p.actorID,
+			p.tagID,
+		)
+		if err != nil {
+			return err
+		}
+		origin := p.project.ProjectID
+		p.service.publishAffected(p.ctx, &origin, NewDeletionResult(affected), "")
+		return nil
+	case CreatorOwnedTemporaryBoard, AnonymousTemporaryBoard:
+		actorID := int64(0)
+		if p.actorID != nil {
+			actorID = *p.actorID
+		}
+		isAnonymousBoard := p.project.Kind == AnonymousTemporaryBoard
+		if err := p.service.rows.DeleteTag(p.ctx, actorID, p.tagID, isAnonymousBoard); err != nil {
+			return err
+		}
+		p.service.publisher.PublishTagDeleted(p.ctx, p.project.ProjectID, "")
+		return nil
+	default:
+		return ErrInvalidDeletionProjectKind
+	}
+}
+
+// PreparedRESTProjectNameDeletion binds one resolved REST project-name
+// deletion, including a copied optional actor identity and exact name.
+type PreparedRESTProjectNameDeletion struct {
+	ctx     context.Context
+	service *RESTDeletionService
+	project ResolvedProject
+	actorID *int64
+	name    string
+}
+
+// PrepareProjectName preserves durable personal-name deletion, rejects the
+// creator-owned temporary name route, and retains optional anonymous fallback
+// identity.
+func (s *RESTDeletionService) PrepareProjectName(
+	ctx context.Context,
+	command ProjectNameDeleteCommand,
+) (*PreparedRESTProjectNameDeletion, error) {
+	switch command.Project.Kind {
+	case DurableProject:
+		if command.ActorUserID == nil {
+			return nil, ErrActorRequired
+		}
+	case CreatorOwnedTemporaryBoard:
+		return nil, ErrNameDeletionNotAllowed
+	case AnonymousTemporaryBoard:
+		// Actor absence is checked only if the board-scoped lookup misses.
+	default:
+		return nil, ErrInvalidDeletionProjectKind
+	}
+
+	return &PreparedRESTProjectNameDeletion{
+		ctx:     ctx,
+		service: s,
+		project: command.Project,
+		actorID: cloneInt64(command.ActorUserID),
+		name:    command.Name,
+	}, nil
+}
+
+// Delete performs exactly one durable personal-name or anonymous row deletion
+// and publishes only after that deletion succeeds.
+func (p *PreparedRESTProjectNameDeletion) Delete() error {
+	switch p.project.Kind {
+	case DurableProject:
+		affected, err := p.service.mineName.DeleteMyTagByName(
+			p.ctx,
+			p.project.ProjectID,
+			*p.actorID,
+			p.name,
+		)
+		if err != nil {
+			return err
+		}
+		origin := p.project.ProjectID
+		p.service.publishAffected(p.ctx, &origin, NewDeletionResult(affected), p.name)
+		return nil
+	case AnonymousTemporaryBoard:
+		return p.deleteAnonymousName()
+	case CreatorOwnedTemporaryBoard:
+		return ErrNameDeletionNotAllowed
+	default:
+		return ErrInvalidDeletionProjectKind
+	}
+}
+
+func (p *PreparedRESTProjectNameDeletion) deleteAnonymousName() error {
+	tagID, err := p.service.boardNames.GetBoardScopedTagIDByName(
+		p.ctx,
+		p.project.ProjectID,
+		p.name,
+	)
+	if err == nil {
+		if err := p.service.rows.DeleteTag(p.ctx, 0, tagID, true); err != nil {
+			return err
+		}
+		p.service.publisher.PublishTagDeleted(p.ctx, p.project.ProjectID, p.name)
+		return nil
+	}
+	if !errors.Is(err, store.ErrNotFound) {
+		return err
+	}
+	if p.actorID == nil {
+		return ErrActorRequired
+	}
+
+	tagID, err = p.service.personalNames.GetTagIDByName(p.ctx, *p.actorID, p.name)
+	if err != nil {
+		return err
+	}
+	if err := p.service.rows.DeleteTag(p.ctx, *p.actorID, tagID, true); err != nil {
+		return err
+	}
+	p.service.publisher.PublishTagDeleted(p.ctx, p.project.ProjectID, p.name)
+	return nil
+}
+
+func (s *RESTDeletionService) publishAffected(
+	ctx context.Context,
+	originProjectID *int64,
+	result DeletionResult,
+	name string,
+) {
+	seen := make(map[int64]struct{})
+	publish := func(projectID int64) {
+		if _, exists := seen[projectID]; exists {
+			return
+		}
+		seen[projectID] = struct{}{}
+		s.publisher.PublishTagDeleted(ctx, projectID, name)
+	}
+
+	if originProjectID != nil {
+		publish(*originProjectID)
+	}
+	for _, projectID := range result.AffectedProjectIDs() {
+		publish(projectID)
+	}
+}

--- a/internal/application/tag/rest_deletion_test.go
+++ b/internal/application/tag/rest_deletion_test.go
@@ -1,0 +1,597 @@
+package tag
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"scrumboy/internal/store"
+)
+
+type restDeletionCall struct {
+	ctx              context.Context
+	projectID        int64
+	actorID          int64
+	tagID            int64
+	name             string
+	isAnonymousBoard bool
+}
+
+type restDeletionFake struct {
+	trace           []string
+	calls           []restDeletionCall
+	publications    []restDeletionCall
+	affected        []int64
+	operationErrors map[string]error
+	boardTagID      int64
+	boardNameErr    error
+	personalTagID   int64
+	personalNameErr error
+	contextErrors   bool
+}
+
+func (f *restDeletionFake) DeleteMyTagByID(
+	ctx context.Context,
+	userID, tagID int64,
+) ([]int64, error) {
+	f.record("mine-id-delete", restDeletionCall{ctx: ctx, actorID: userID, tagID: tagID})
+	if err := f.result(ctx, "mine-id-delete"); err != nil {
+		return nil, err
+	}
+	return f.affected, nil
+}
+
+func (f *restDeletionFake) DeleteMyTagByName(
+	ctx context.Context,
+	projectID, userID int64,
+	name string,
+) ([]int64, error) {
+	f.record("mine-name-delete", restDeletionCall{
+		ctx: ctx, projectID: projectID, actorID: userID, name: name,
+	})
+	if err := f.result(ctx, "mine-name-delete"); err != nil {
+		return nil, err
+	}
+	return f.affected, nil
+}
+
+func (f *restDeletionFake) DeleteTagForDurableProjectByID(
+	ctx context.Context,
+	projectID, userID, tagID int64,
+) ([]int64, error) {
+	f.record("durable-id-delete", restDeletionCall{
+		ctx: ctx, projectID: projectID, actorID: userID, tagID: tagID,
+	})
+	if err := f.result(ctx, "durable-id-delete"); err != nil {
+		return nil, err
+	}
+	return f.affected, nil
+}
+
+func (f *restDeletionFake) DeleteTag(
+	ctx context.Context,
+	userID, tagID int64,
+	isAnonymousBoard bool,
+) error {
+	f.record("row-delete", restDeletionCall{
+		ctx: ctx, actorID: userID, tagID: tagID, isAnonymousBoard: isAnonymousBoard,
+	})
+	return f.result(ctx, "row-delete")
+}
+
+func (f *restDeletionFake) GetBoardScopedTagIDByName(
+	ctx context.Context,
+	projectID int64,
+	name string,
+) (int64, error) {
+	f.record("board-name-read", restDeletionCall{ctx: ctx, projectID: projectID, name: name})
+	if f.contextErrors {
+		return 0, ctx.Err()
+	}
+	if f.boardNameErr != nil {
+		return 0, f.boardNameErr
+	}
+	return f.boardTagID, nil
+}
+
+func (f *restDeletionFake) GetTagIDByName(
+	ctx context.Context,
+	userID int64,
+	name string,
+) (int64, error) {
+	f.record("personal-name-read", restDeletionCall{ctx: ctx, actorID: userID, name: name})
+	if f.contextErrors {
+		return 0, ctx.Err()
+	}
+	if f.personalNameErr != nil {
+		return 0, f.personalNameErr
+	}
+	return f.personalTagID, nil
+}
+
+func (f *restDeletionFake) PublishTagDeleted(ctx context.Context, projectID int64, name string) {
+	f.trace = append(f.trace, "publish")
+	f.publications = append(f.publications, restDeletionCall{ctx: ctx, projectID: projectID, name: name})
+}
+
+func (f *restDeletionFake) record(operation string, call restDeletionCall) {
+	f.trace = append(f.trace, operation)
+	f.calls = append(f.calls, call)
+}
+
+func (f *restDeletionFake) result(ctx context.Context, operation string) error {
+	if f.contextErrors {
+		return ctx.Err()
+	}
+	return f.operationErrors[operation]
+}
+
+func newRESTDeletionTestService(fake *restDeletionFake) *RESTDeletionService {
+	return NewRESTDeletionService(RESTDeletionServiceDependencies{
+		MineID:        fake,
+		MineName:      fake,
+		DurableID:     fake,
+		Rows:          fake,
+		BoardNames:    fake,
+		PersonalNames: fake,
+		Publisher:     fake,
+	})
+}
+
+func TestRESTDeletionMineIDFanout(t *testing.T) {
+	t.Run("deduplicates affected projects without inventing an origin", func(t *testing.T) {
+		fake := &restDeletionFake{affected: []int64{7, 7, 3, 11, 3}}
+		ctx := context.WithValue(context.Background(), restDeletionContextKey{}, "mine")
+		prepared := newRESTDeletionTestService(fake).PrepareMineID(ctx, MineIDDeleteCommand{
+			ActorUserID: 17,
+			TagID:       19,
+		})
+
+		if err := prepared.Delete(); err != nil {
+			t.Fatalf("Delete() error = %v", err)
+		}
+		assertRESTDeletionTrace(t, fake, "mine-id-delete", "publish", "publish", "publish")
+		assertRESTDeletionMutation(t, fake.calls[0], ctx, 0, 17, 19, "", false)
+		assertRESTDeletionPublications(t, fake, ctx, "", 7, 3, 11)
+	})
+
+	t.Run("zero affected projects publishes nothing", func(t *testing.T) {
+		fake := &restDeletionFake{}
+		prepared := newRESTDeletionTestService(fake).PrepareMineID(context.Background(), MineIDDeleteCommand{
+			ActorUserID: 23,
+			TagID:       29,
+		})
+		if err := prepared.Delete(); err != nil {
+			t.Fatalf("Delete() error = %v", err)
+		}
+		assertRESTDeletionTrace(t, fake, "mine-id-delete")
+	})
+
+	t.Run("failure preserves identity and publishes nothing", func(t *testing.T) {
+		deleteErr := errors.New("mine delete failed")
+		fake := &restDeletionFake{operationErrors: map[string]error{"mine-id-delete": deleteErr}}
+		prepared := newRESTDeletionTestService(fake).PrepareMineID(context.Background(), MineIDDeleteCommand{
+			ActorUserID: 31,
+			TagID:       37,
+		})
+		if err := prepared.Delete(); err != deleteErr {
+			t.Fatalf("Delete() error = %v, want identical %v", err, deleteErr)
+		}
+		assertRESTDeletionTrace(t, fake, "mine-id-delete")
+		if len(fake.publications) != 0 {
+			t.Fatalf("publications = %d, want 0", len(fake.publications))
+		}
+	})
+}
+
+func TestRESTDeletionProjectIDDispatchAndPublication(t *testing.T) {
+	t.Run("durable uses compatibility method and origin-first affected fanout", func(t *testing.T) {
+		fake := &restDeletionFake{affected: []int64{47, 53, 47, 59, 53}}
+		ctx := context.WithValue(context.Background(), restDeletionContextKey{}, "durable")
+		actorSource := int64Pointer(41)
+		prepared, err := newRESTDeletionTestService(fake).PrepareProjectID(ctx, ProjectIDDeleteCommand{
+			Project:     ResolvedProject{ProjectID: 47, Kind: DurableProject},
+			ActorUserID: actorSource,
+			TagID:       43,
+		})
+		if err != nil {
+			t.Fatalf("PrepareProjectID() error = %v", err)
+		}
+		*actorSource = 999
+
+		if err := prepared.Delete(); err != nil {
+			t.Fatalf("Delete() error = %v", err)
+		}
+		assertRESTDeletionTrace(t, fake, "durable-id-delete", "publish", "publish", "publish")
+		assertRESTDeletionMutation(t, fake.calls[0], ctx, 47, 41, 43, "", false)
+		assertRESTDeletionPublications(t, fake, ctx, "", 47, 53, 59)
+	})
+
+	tests := []struct {
+		name          string
+		kind          ProjectKind
+		actorSource   *int64
+		wantActor     int64
+		wantAnonymous bool
+	}{
+		{name: "creator temporary with actor", kind: CreatorOwnedTemporaryBoard, actorSource: int64Pointer(61), wantActor: 61},
+		{name: "creator temporary without actor", kind: CreatorOwnedTemporaryBoard},
+		{name: "anonymous temporary with actor", kind: AnonymousTemporaryBoard, actorSource: int64Pointer(67), wantActor: 67, wantAnonymous: true},
+		{name: "anonymous temporary without actor", kind: AnonymousTemporaryBoard, wantAnonymous: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &restDeletionFake{}
+			ctx := context.WithValue(context.Background(), restDeletionContextKey{}, tt.name)
+			prepared, err := newRESTDeletionTestService(fake).PrepareProjectID(ctx, ProjectIDDeleteCommand{
+				Project:     ResolvedProject{ProjectID: 71, Kind: tt.kind},
+				ActorUserID: tt.actorSource,
+				TagID:       73,
+			})
+			if err != nil {
+				t.Fatalf("PrepareProjectID() error = %v", err)
+			}
+			if tt.actorSource != nil {
+				*tt.actorSource = 999
+			}
+
+			if err := prepared.Delete(); err != nil {
+				t.Fatalf("Delete() error = %v", err)
+			}
+			assertRESTDeletionTrace(t, fake, "row-delete", "publish")
+			assertRESTDeletionMutation(t, fake.calls[0], ctx, 0, tt.wantActor, 73, "", tt.wantAnonymous)
+			assertRESTDeletionPublications(t, fake, ctx, "", 71)
+		})
+	}
+}
+
+func TestRESTDeletionProjectIDFailureSilence(t *testing.T) {
+	deleteErr := errors.New("project ID delete failed")
+	tests := []struct {
+		name      string
+		kind      ProjectKind
+		actor     *int64
+		operation string
+	}{
+		{name: "durable", kind: DurableProject, actor: int64Pointer(79), operation: "durable-id-delete"},
+		{name: "creator temporary", kind: CreatorOwnedTemporaryBoard, actor: int64Pointer(83), operation: "row-delete"},
+		{name: "anonymous temporary", kind: AnonymousTemporaryBoard, operation: "row-delete"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &restDeletionFake{operationErrors: map[string]error{tt.operation: deleteErr}}
+			prepared, err := newRESTDeletionTestService(fake).PrepareProjectID(context.Background(), ProjectIDDeleteCommand{
+				Project:     ResolvedProject{ProjectID: 89, Kind: tt.kind},
+				ActorUserID: tt.actor,
+				TagID:       97,
+			})
+			if err != nil {
+				t.Fatalf("PrepareProjectID() error = %v", err)
+			}
+			if err := prepared.Delete(); err != deleteErr {
+				t.Fatalf("Delete() error = %v, want identical %v", err, deleteErr)
+			}
+			assertRESTDeletionTrace(t, fake, tt.operation)
+		})
+	}
+}
+
+func TestRESTDeletionProjectNameDurableAndCreatorTemporary(t *testing.T) {
+	t.Run("durable deletes personal name and fans out exact name", func(t *testing.T) {
+		fake := &restDeletionFake{affected: []int64{103, 107, 103, 109}}
+		ctx := context.WithValue(context.Background(), restDeletionContextKey{}, "durable-name")
+		actorSource := int64Pointer(101)
+		prepared, err := newRESTDeletionTestService(fake).PrepareProjectName(ctx, ProjectNameDeleteCommand{
+			Project:     ResolvedProject{ProjectID: 103, Kind: DurableProject},
+			ActorUserID: actorSource,
+			Name:        " Name With Spaces ",
+		})
+		if err != nil {
+			t.Fatalf("PrepareProjectName() error = %v", err)
+		}
+		*actorSource = 999
+
+		if err := prepared.Delete(); err != nil {
+			t.Fatalf("Delete() error = %v", err)
+		}
+		assertRESTDeletionTrace(t, fake, "mine-name-delete", "publish", "publish", "publish")
+		assertRESTDeletionMutation(t, fake.calls[0], ctx, 103, 101, 0, " Name With Spaces ", false)
+		assertRESTDeletionPublications(t, fake, ctx, " Name With Spaces ", 103, 107, 109)
+	})
+
+	t.Run("durable failure preserves identity and publishes nothing", func(t *testing.T) {
+		deleteErr := errors.New("durable name delete failed")
+		fake := &restDeletionFake{operationErrors: map[string]error{"mine-name-delete": deleteErr}}
+		prepared, err := newRESTDeletionTestService(fake).PrepareProjectName(context.Background(), ProjectNameDeleteCommand{
+			Project:     ResolvedProject{ProjectID: 109, Kind: DurableProject},
+			ActorUserID: int64Pointer(107),
+			Name:        "failed-name",
+		})
+		if err != nil {
+			t.Fatalf("PrepareProjectName() error = %v", err)
+		}
+		if err := prepared.Delete(); err != deleteErr {
+			t.Fatalf("Delete() error = %v, want identical %v", err, deleteErr)
+		}
+		assertRESTDeletionTrace(t, fake, "mine-name-delete")
+	})
+
+	t.Run("creator temporary is rejected before every collaborator", func(t *testing.T) {
+		fake := &restDeletionFake{}
+		prepared, err := newRESTDeletionTestService(fake).PrepareProjectName(context.Background(), ProjectNameDeleteCommand{
+			Project: ResolvedProject{ProjectID: 113, Kind: CreatorOwnedTemporaryBoard},
+			Name:    "blocked",
+		})
+		if prepared != nil || !errors.Is(err, ErrNameDeletionNotAllowed) {
+			t.Fatalf("PrepareProjectName() = (%v, %v), want (nil, ErrNameDeletionNotAllowed)", prepared, err)
+		}
+		assertRESTDeletionTrace(t, fake)
+	})
+
+	t.Run("board-scoped row delete failure never publishes", func(t *testing.T) {
+		deleteErr := errors.New("board row delete failed")
+		fake := &restDeletionFake{
+			boardTagID: 133,
+			operationErrors: map[string]error{
+				"row-delete": deleteErr,
+			},
+		}
+		prepared, err := newRESTDeletionTestService(fake).PrepareProjectName(context.Background(), ProjectNameDeleteCommand{
+			Project: ResolvedProject{ProjectID: 137, Kind: AnonymousTemporaryBoard},
+			Name:    "board-delete-error",
+		})
+		if err != nil {
+			t.Fatalf("PrepareProjectName() error = %v", err)
+		}
+		if err := prepared.Delete(); err != deleteErr {
+			t.Fatalf("Delete() error = %v, want identical %v", err, deleteErr)
+		}
+		assertRESTDeletionTrace(t, fake, "board-name-read", "row-delete")
+	})
+}
+
+func TestRESTDeletionAnonymousNameResolution(t *testing.T) {
+	t.Run("board-scoped row wins and deletes as user zero", func(t *testing.T) {
+		fake := &restDeletionFake{boardTagID: 127}
+		ctx := context.WithValue(context.Background(), restDeletionContextKey{}, "board-row")
+		prepared, err := newRESTDeletionTestService(fake).PrepareProjectName(ctx, ProjectNameDeleteCommand{
+			Project:     ResolvedProject{ProjectID: 131, Kind: AnonymousTemporaryBoard},
+			ActorUserID: int64Pointer(137),
+			Name:        "board-name",
+		})
+		if err != nil {
+			t.Fatalf("PrepareProjectName() error = %v", err)
+		}
+
+		if err := prepared.Delete(); err != nil {
+			t.Fatalf("Delete() error = %v", err)
+		}
+		assertRESTDeletionTrace(t, fake, "board-name-read", "row-delete", "publish")
+		assertRESTDeletionMutation(t, fake.calls[1], ctx, 0, 0, 127, "", true)
+		assertRESTDeletionPublications(t, fake, ctx, "board-name", 131)
+	})
+
+	t.Run("personal fallback lookup failure never deletes or publishes", func(t *testing.T) {
+		lookupErr := errors.New("personal lookup failed")
+		fake := &restDeletionFake{
+			boardNameErr:    store.ErrNotFound,
+			personalNameErr: lookupErr,
+		}
+		prepared, err := newRESTDeletionTestService(fake).PrepareProjectName(context.Background(), ProjectNameDeleteCommand{
+			Project:     ResolvedProject{ProjectID: 181, Kind: AnonymousTemporaryBoard},
+			ActorUserID: int64Pointer(179),
+			Name:        "personal-lookup-error",
+		})
+		if err != nil {
+			t.Fatalf("PrepareProjectName() error = %v", err)
+		}
+		if err := prepared.Delete(); err != lookupErr {
+			t.Fatalf("Delete() error = %v, want identical %v", err, lookupErr)
+		}
+		assertRESTDeletionTrace(t, fake, "board-name-read", "personal-name-read")
+	})
+
+	t.Run("not found falls back to copied actor personal row", func(t *testing.T) {
+		fake := &restDeletionFake{
+			boardNameErr:  store.ErrNotFound,
+			personalTagID: 139,
+		}
+		ctx := context.WithValue(context.Background(), restDeletionContextKey{}, "personal-row")
+		actorSource := int64Pointer(149)
+		prepared, err := newRESTDeletionTestService(fake).PrepareProjectName(ctx, ProjectNameDeleteCommand{
+			Project:     ResolvedProject{ProjectID: 151, Kind: AnonymousTemporaryBoard},
+			ActorUserID: actorSource,
+			Name:        "personal-name",
+		})
+		if err != nil {
+			t.Fatalf("PrepareProjectName() error = %v", err)
+		}
+		*actorSource = 999
+
+		if err := prepared.Delete(); err != nil {
+			t.Fatalf("Delete() error = %v", err)
+		}
+		assertRESTDeletionTrace(t, fake, "board-name-read", "personal-name-read", "row-delete", "publish")
+		assertRESTDeletionMutation(t, fake.calls[1], ctx, 0, 149, 0, "personal-name", false)
+		assertRESTDeletionMutation(t, fake.calls[2], ctx, 0, 149, 139, "", true)
+		assertRESTDeletionPublications(t, fake, ctx, "personal-name", 151)
+	})
+
+	t.Run("missing actor is checked only after board miss", func(t *testing.T) {
+		fake := &restDeletionFake{boardNameErr: store.ErrNotFound}
+		prepared, err := newRESTDeletionTestService(fake).PrepareProjectName(context.Background(), ProjectNameDeleteCommand{
+			Project: ResolvedProject{ProjectID: 157, Kind: AnonymousTemporaryBoard},
+			Name:    "missing-actor",
+		})
+		if err != nil {
+			t.Fatalf("PrepareProjectName() error = %v", err)
+		}
+		if err := prepared.Delete(); !errors.Is(err, ErrActorRequired) {
+			t.Fatalf("Delete() error = %v, want ErrActorRequired", err)
+		}
+		assertRESTDeletionTrace(t, fake, "board-name-read")
+	})
+
+	t.Run("non-not-found board error does not fall back", func(t *testing.T) {
+		lookupErr := errors.New("board lookup failed")
+		fake := &restDeletionFake{boardNameErr: lookupErr, personalTagID: 163}
+		prepared, err := newRESTDeletionTestService(fake).PrepareProjectName(context.Background(), ProjectNameDeleteCommand{
+			Project:     ResolvedProject{ProjectID: 167, Kind: AnonymousTemporaryBoard},
+			ActorUserID: int64Pointer(173),
+			Name:        "lookup-error",
+		})
+		if err != nil {
+			t.Fatalf("PrepareProjectName() error = %v", err)
+		}
+		if err := prepared.Delete(); err != lookupErr {
+			t.Fatalf("Delete() error = %v, want identical %v", err, lookupErr)
+		}
+		assertRESTDeletionTrace(t, fake, "board-name-read")
+	})
+
+	t.Run("selected row delete failure never publishes", func(t *testing.T) {
+		deleteErr := errors.New("row delete failed")
+		fake := &restDeletionFake{
+			boardNameErr:  store.ErrNotFound,
+			personalTagID: 179,
+			operationErrors: map[string]error{
+				"row-delete": deleteErr,
+			},
+		}
+		prepared, err := newRESTDeletionTestService(fake).PrepareProjectName(context.Background(), ProjectNameDeleteCommand{
+			Project:     ResolvedProject{ProjectID: 181, Kind: AnonymousTemporaryBoard},
+			ActorUserID: int64Pointer(191),
+			Name:        "delete-error",
+		})
+		if err != nil {
+			t.Fatalf("PrepareProjectName() error = %v", err)
+		}
+		if err := prepared.Delete(); err != deleteErr {
+			t.Fatalf("Delete() error = %v, want identical %v", err, deleteErr)
+		}
+		assertRESTDeletionTrace(t, fake, "board-name-read", "personal-name-read", "row-delete")
+	})
+}
+
+func TestRESTDeletionRejectsInvalidPreparedCombinations(t *testing.T) {
+	tests := []struct {
+		name    string
+		byName  bool
+		kind    ProjectKind
+		actorID *int64
+		wantErr error
+	}{
+		{name: "durable ID missing actor", kind: DurableProject, wantErr: ErrActorRequired},
+		{name: "durable name missing actor", byName: true, kind: DurableProject, wantErr: ErrActorRequired},
+		{name: "unknown ID kind", kind: ProjectKind(99), wantErr: ErrInvalidDeletionProjectKind},
+		{name: "unknown name kind", byName: true, kind: ProjectKind(99), wantErr: ErrInvalidDeletionProjectKind},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &restDeletionFake{}
+			service := newRESTDeletionTestService(fake)
+			if tt.byName {
+				prepared, err := service.PrepareProjectName(context.Background(), ProjectNameDeleteCommand{
+					Project: ResolvedProject{ProjectID: 193, Kind: tt.kind}, ActorUserID: tt.actorID,
+				})
+				if prepared != nil || !errors.Is(err, tt.wantErr) {
+					t.Fatalf("PrepareProjectName() = (%v, %v), want (nil, %v)", prepared, err, tt.wantErr)
+				}
+			} else {
+				prepared, err := service.PrepareProjectID(context.Background(), ProjectIDDeleteCommand{
+					Project: ResolvedProject{ProjectID: 193, Kind: tt.kind}, ActorUserID: tt.actorID,
+				})
+				if prepared != nil || !errors.Is(err, tt.wantErr) {
+					t.Fatalf("PrepareProjectID() = (%v, %v), want (nil, %v)", prepared, err, tt.wantErr)
+				}
+			}
+			assertRESTDeletionTrace(t, fake)
+		})
+	}
+}
+
+func TestRESTDeletionUsesCancelledBoundContext(t *testing.T) {
+	fake := &restDeletionFake{contextErrors: true}
+	ctx, cancel := context.WithCancel(context.Background())
+	prepared, err := newRESTDeletionTestService(fake).PrepareProjectID(ctx, ProjectIDDeleteCommand{
+		Project:     ResolvedProject{ProjectID: 197, Kind: DurableProject},
+		ActorUserID: int64Pointer(199),
+		TagID:       211,
+	})
+	if err != nil {
+		t.Fatalf("PrepareProjectID() error = %v", err)
+	}
+	cancel()
+
+	if err := prepared.Delete(); err != context.Canceled {
+		t.Fatalf("Delete() error = %v, want context.Canceled", err)
+	}
+	assertRESTDeletionTrace(t, fake, "durable-id-delete")
+	if fake.calls[0].ctx != ctx {
+		t.Fatal("deletion did not use the bound context")
+	}
+}
+
+func TestRESTDeletionNilPublisherIsNoOp(t *testing.T) {
+	fake := &restDeletionFake{}
+	service := NewRESTDeletionService(RESTDeletionServiceDependencies{DurableID: fake})
+	prepared, err := service.PrepareProjectID(context.Background(), ProjectIDDeleteCommand{
+		Project:     ResolvedProject{ProjectID: 223, Kind: DurableProject},
+		ActorUserID: int64Pointer(227),
+		TagID:       229,
+	})
+	if err != nil {
+		t.Fatalf("PrepareProjectID() error = %v", err)
+	}
+	if err := prepared.Delete(); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+}
+
+type restDeletionContextKey struct{}
+
+func assertRESTDeletionTrace(t *testing.T, fake *restDeletionFake, want ...string) {
+	t.Helper()
+	if !reflect.DeepEqual(fake.trace, want) {
+		t.Fatalf("trace = %v, want %v", fake.trace, want)
+	}
+}
+
+func assertRESTDeletionMutation(
+	t *testing.T,
+	got restDeletionCall,
+	wantCtx context.Context,
+	wantProjectID, wantActorID, wantTagID int64,
+	wantName string,
+	wantAnonymous bool,
+) {
+	t.Helper()
+	if got.ctx != wantCtx || got.projectID != wantProjectID || got.actorID != wantActorID ||
+		got.tagID != wantTagID || got.name != wantName || got.isAnonymousBoard != wantAnonymous {
+		t.Fatalf("call = %#v, want context/project/actor/tag/name/anonymous = %v/%d/%d/%d/%q/%v",
+			got, wantCtx, wantProjectID, wantActorID, wantTagID, wantName, wantAnonymous)
+	}
+}
+
+func assertRESTDeletionPublications(
+	t *testing.T,
+	fake *restDeletionFake,
+	wantCtx context.Context,
+	wantName string,
+	wantProjectIDs ...int64,
+) {
+	t.Helper()
+	if len(fake.publications) != len(wantProjectIDs) {
+		t.Fatalf("publications = %#v, want project IDs %v", fake.publications, wantProjectIDs)
+	}
+	for i, wantProjectID := range wantProjectIDs {
+		got := fake.publications[i]
+		if got.ctx != wantCtx || got.projectID != wantProjectID || got.name != wantName {
+			t.Fatalf("publication[%d] = %#v, want context/project/name = %v/%d/%q", i, got, wantCtx, wantProjectID, wantName)
+		}
+	}
+}

--- a/internal/httpapi/email_notify_entity_test.go
+++ b/internal/httpapi/email_notify_entity_test.go
@@ -365,52 +365,44 @@ func (c *capturingEventConsumer) OnEvent(_ context.Context, e eventbus.Event) {
 	c.events = append(c.events, e)
 }
 
-func TestEmitTagDeletedRefreshFansSameEntityAndDedupesProjects(t *testing.T) {
+func TestTagDeletionPublisherPassesNameEntity(t *testing.T) {
 	cap := &capturingEventConsumer{}
 	s := &Server{fanout: eventbus.NewFanout(cap)}
-	s.emitTagDeletedRefresh(context.Background(), 7, []int64{7, 9, 9, 11}, refresh.Entity{Name: "blocked"})
-	if len(cap.events) != 3 {
-		t.Fatalf("events=%d, want 3 unique projects", len(cap.events))
+	tagDeletionPublisher{server: s}.PublishTagDeleted(context.Background(), 7, "blocked")
+	if len(cap.events) != 1 {
+		t.Fatalf("events=%d, want 1", len(cap.events))
 	}
-	seen := map[int64]bool{}
-	for _, e := range cap.events {
-		if e.Type != "board.refresh_needed" {
-			t.Fatalf("type=%q", e.Type)
-		}
-		if seen[e.ProjectID] {
-			t.Fatalf("duplicate project %d", e.ProjectID)
-		}
-		seen[e.ProjectID] = true
-		var p refreshNeededPayload
-		if err := json.Unmarshal(e.Payload, &p); err != nil {
-			t.Fatal(err)
-		}
-		if p.Reason != "tag_deleted" || p.Name != "blocked" {
-			t.Fatalf("payload=%+v, want tag_deleted name=blocked", p)
-		}
+	e := cap.events[0]
+	if e.Type != "board.refresh_needed" {
+		t.Fatalf("type=%q", e.Type)
 	}
-	if !seen[7] || !seen[9] || !seen[11] {
-		t.Fatalf("projects=%v, want 7,9,11", seen)
+	if e.ProjectID != 7 {
+		t.Fatalf("project=%d, want 7", e.ProjectID)
+	}
+	var p refreshNeededPayload
+	if err := json.Unmarshal(e.Payload, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Reason != "tag_deleted" || p.Name != "blocked" {
+		t.Fatalf("payload=%+v, want tag_deleted name=blocked", p)
 	}
 }
 
-func TestEmitTagDeletedRefreshIDBasedPassesZeroEntity(t *testing.T) {
+func TestTagDeletionPublisherIDBasedPassesZeroEntity(t *testing.T) {
 	cap := &capturingEventConsumer{}
 	s := &Server{fanout: eventbus.NewFanout(cap)}
-	s.emitTagDeletedRefresh(context.Background(), 7, []int64{9}, refresh.Entity{})
-	if len(cap.events) != 2 {
-		t.Fatalf("events=%d, want 2", len(cap.events))
+	tagDeletionPublisher{server: s}.PublishTagDeleted(context.Background(), 7, "")
+	if len(cap.events) != 1 {
+		t.Fatalf("events=%d, want 1", len(cap.events))
 	}
-	for _, e := range cap.events {
-		var p refreshNeededPayload
-		if err := json.Unmarshal(e.Payload, &p); err != nil {
-			t.Fatal(err)
-		}
-		if p.Name != "" || p.LocalID != 0 || p.Title != "" {
-			t.Fatalf("expected zero entity, got %+v", p)
-		}
-		assertRefreshNeededEntityOmitted(t, e.Payload)
+	var p refreshNeededPayload
+	if err := json.Unmarshal(cap.events[0].Payload, &p); err != nil {
+		t.Fatal(err)
 	}
+	if p.Name != "" || p.LocalID != 0 || p.Title != "" {
+		t.Fatalf("expected zero entity, got %+v", p)
+	}
+	assertRefreshNeededEntityOmitted(t, cap.events[0].Payload)
 }
 
 func assertRefreshNeededEntityOmitted(t *testing.T, payload []byte) {

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -33,6 +33,16 @@ func (p tagColorPublisher) PublishTagColorUpdated(ctx context.Context, projectID
 	p.server.emitRefreshNeeded(ctx, projectID, "tag_color_updated", refresh.Entity{Name: name})
 }
 
+type tagDeletionPublisher struct {
+	server *Server
+}
+
+var _ tagapp.RESTDeletionPublisher = tagDeletionPublisher{}
+
+func (p tagDeletionPublisher) PublishTagDeleted(ctx context.Context, projectID int64, name string) {
+	p.server.emitRefreshNeeded(ctx, projectID, "tag_deleted", refresh.Entity{Name: name})
+}
+
 type sprintDefinitionPublisher struct {
 	server *Server
 }
@@ -140,23 +150,6 @@ func (s *Server) emitRefreshNeeded(ctx context.Context, projectID int64, reason 
 		ProjectID: projectID,
 		Payload:   payload,
 	})
-}
-
-// emitTagDeletedRefresh emits a "tag_deleted" refresh for the current project plus
-// every other project affected by a cross-project personal-tag deletion. Deleting a
-// personal tag row removes it from every project that reused it, so all their boards
-// must refresh, not only the one the request targeted.
-func (s *Server) emitTagDeletedRefresh(ctx context.Context, projectID int64, affectedProjectIDs []int64, entity refresh.Entity) {
-	emitted := make(map[int64]struct{}, len(affectedProjectIDs)+1)
-	s.emitRefreshNeeded(ctx, projectID, "tag_deleted", entity)
-	emitted[projectID] = struct{}{}
-	for _, pid := range affectedProjectIDs {
-		if _, ok := emitted[pid]; ok {
-			continue
-		}
-		emitted[pid] = struct{}{}
-		s.emitRefreshNeeded(ctx, pid, "tag_deleted", entity)
-	}
 }
 
 func (s *Server) emitProjectDeleted(ctx context.Context, deleted store.DeletedProjectSnapshot) {

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -7,6 +7,7 @@ import (
 	membershipapp "scrumboy/internal/application/membership"
 	"scrumboy/internal/application/refresh"
 	sprintapp "scrumboy/internal/application/sprint"
+	tagapp "scrumboy/internal/application/tag"
 	todolinkapp "scrumboy/internal/application/todolink"
 	"scrumboy/internal/eventbus"
 	"scrumboy/internal/store"
@@ -20,6 +21,16 @@ var _ todolinkapp.RESTMutationPublisher = todoLinkMutationPublisher{}
 
 func (p todoLinkMutationPublisher) PublishTodoLinksUpdated(ctx context.Context, projectID int64) {
 	p.server.emitRefreshNeeded(ctx, projectID, "todo_links_updated", refresh.Entity{})
+}
+
+type tagColorPublisher struct {
+	server *Server
+}
+
+var _ tagapp.RESTColorPublisher = tagColorPublisher{}
+
+func (p tagColorPublisher) PublishTagColorUpdated(ctx context.Context, projectID int64, name string) {
+	p.server.emitRefreshNeeded(ctx, projectID, "tag_color_updated", refresh.Entity{Name: name})
 }
 
 type sprintDefinitionPublisher struct {

--- a/internal/httpapi/routing_board.go
+++ b/internal/httpapi/routing_board.go
@@ -51,6 +51,19 @@ func writeTagColorPrepareError(w http.ResponseWriter, err error) {
 	}
 }
 
+func writeTagDeletionError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, tagapp.ErrActorRequired):
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
+	case errors.Is(err, tagapp.ErrNameDeletionNotAllowed):
+		writeValidationError(w, "name-based delete not allowed for durable projects; use /tags/id/{tagId}", "name_based_tag_route_not_allowed", nil)
+	case errors.Is(err, tagapp.ErrInvalidDeletionProjectKind):
+		writeInternal(w, err)
+	default:
+		writeStoreErr(w, err, true)
+	}
+}
+
 func resolvedRESTTagProject(project store.Project) tagapp.ResolvedProject {
 	kind := tagapp.DurableProject
 	if project.ExpiresAt != nil {
@@ -1310,7 +1323,6 @@ func (s *Server) handleBoardTagRoutes(w http.ResponseWriter, r *http.Request, re
 	}
 
 	// DELETE /api/board/{slug}/tags/id/{tagId} - delete by tag_id (preferred; authority by tag_id).
-	isAnonymousBoard := project.ExpiresAt != nil && project.CreatorUserID == nil
 	if len(rest) == 4 && rest[1] == "tags" && rest[2] == "id" && r.Method == http.MethodDelete {
 		ctx := s.requestContext(r)
 		var tagID int64
@@ -1318,28 +1330,23 @@ func (s *Server) handleBoardTagRoutes(w http.ResponseWriter, r *http.Request, re
 			writeValidationError(w, "invalid tagId", "invalid_tag_id", map[string]any{"field": "tagId"})
 			return true
 		}
-		if project.ExpiresAt != nil {
-			// Temporary/anonymous boards keep the previous DeleteTag path.
-			userID, _ := store.UserIDFromContext(ctx)
-			if err := s.store.DeleteTag(ctx, userID, tagID, isAnonymousBoard); err != nil {
-				writeStoreErr(w, err, true)
-				return true
-			}
-			s.emitRefreshNeeded(s.requestContext(r), project.ID, "tag_deleted", refresh.Entity{})
-			w.WriteHeader(http.StatusNoContent)
-			return true
+		var actorUserID *int64
+		if userID, ok := store.UserIDFromContext(ctx); ok {
+			actorUserID = &userID
 		}
-		userID, ok := store.UserIDFromContext(ctx)
-		if !ok {
-			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
-			return true
-		}
-		affected, err := s.store.DeleteTagForDurableProjectByID(ctx, project.ID, userID, tagID)
+		prepared, err := s.tagDeletions.PrepareProjectID(ctx, tagapp.ProjectIDDeleteCommand{
+			Project:     resolvedRESTTagProject(project),
+			ActorUserID: actorUserID,
+			TagID:       tagID,
+		})
 		if err != nil {
-			writeStoreErr(w, err, true)
+			writeTagDeletionError(w, err)
 			return true
 		}
-		s.emitTagDeletedRefresh(s.requestContext(r), project.ID, affected, refresh.Entity{})
+		if err := prepared.Delete(); err != nil {
+			writeTagDeletionError(w, err)
+			return true
+		}
 		w.WriteHeader(http.StatusNoContent)
 		return true
 	}
@@ -1349,59 +1356,25 @@ func (s *Server) handleBoardTagRoutes(w http.ResponseWriter, r *http.Request, re
 	// (grouped label persists if other members still use it). Anonymous/temporary
 	// boards keep the board-scoped resolution below.
 	if len(rest) == 3 && rest[1] == "tags" && r.Method == http.MethodDelete {
-		if !isAnonymousBoard && project.ExpiresAt == nil {
-			ctx := s.requestContext(r)
-			userID, ok := store.UserIDFromContext(ctx)
-			if !ok {
-				writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
-				return true
-			}
-			affected, err := s.store.DeleteMyTagByName(ctx, project.ID, userID, rest[2])
-			if err != nil {
-				writeStoreErr(w, err, true)
-				return true
-			}
-			s.emitTagDeletedRefresh(s.requestContext(r), project.ID, affected, refresh.Entity{Name: rest[2]})
-			w.WriteHeader(http.StatusNoContent)
-			return true
-		}
-		if !isAnonymousBoard {
-			writeValidationError(w, "name-based delete not allowed for durable projects; use /tags/id/{tagId}", "name_based_tag_route_not_allowed", nil)
-			return true
-		}
 		ctx := s.requestContext(r)
 		tagName := rest[2]
-		userID, hasUserID := store.UserIDFromContext(ctx)
-
-		boardTagID, err := s.store.GetBoardScopedTagIDByName(ctx, project.ID, tagName)
-		if err == nil {
-			if err := s.store.DeleteTag(ctx, 0, boardTagID, isAnonymousBoard); err != nil {
-				writeStoreErr(w, err, true)
-				return true
-			}
-			s.emitRefreshNeeded(s.requestContext(r), project.ID, "tag_deleted", refresh.Entity{Name: tagName})
-			w.WriteHeader(http.StatusNoContent)
-			return true
+		var actorUserID *int64
+		if userID, ok := store.UserIDFromContext(ctx); ok {
+			actorUserID = &userID
 		}
-		if !errors.Is(err, store.ErrNotFound) {
-			writeStoreErr(w, err, true)
-			return true
-		}
-
-		if !hasUserID {
-			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
-			return true
-		}
-		tagID, err := s.store.GetTagIDByName(ctx, userID, tagName)
+		prepared, err := s.tagDeletions.PrepareProjectName(ctx, tagapp.ProjectNameDeleteCommand{
+			Project:     resolvedRESTTagProject(project),
+			ActorUserID: actorUserID,
+			Name:        tagName,
+		})
 		if err != nil {
-			writeStoreErr(w, err, true)
+			writeTagDeletionError(w, err)
 			return true
 		}
-		if err := s.store.DeleteTag(ctx, userID, tagID, isAnonymousBoard); err != nil {
-			writeStoreErr(w, err, true)
+		if err := prepared.Delete(); err != nil {
+			writeTagDeletionError(w, err)
 			return true
 		}
-		s.emitRefreshNeeded(s.requestContext(r), project.ID, "tag_deleted", refresh.Entity{Name: tagName})
 		w.WriteHeader(http.StatusNoContent)
 		return true
 	}

--- a/internal/httpapi/routing_board.go
+++ b/internal/httpapi/routing_board.go
@@ -13,6 +13,7 @@ import (
 	projectsettingsapp "scrumboy/internal/application/projectsettings"
 	"scrumboy/internal/application/refresh"
 	sprintapp "scrumboy/internal/application/sprint"
+	tagapp "scrumboy/internal/application/tag"
 	todoapp "scrumboy/internal/application/todo"
 	todolinkapp "scrumboy/internal/application/todolink"
 	workflowapp "scrumboy/internal/application/workflow"
@@ -39,6 +40,27 @@ func writePriorityMutationPrepareError(w http.ResponseWriter, err error) {
 	default:
 		writeInternal(w, err)
 	}
+}
+
+func writeTagColorPrepareError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, tagapp.ErrActorRequired):
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
+	default:
+		writeInternal(w, err)
+	}
+}
+
+func resolvedRESTTagProject(project store.Project) tagapp.ResolvedProject {
+	kind := tagapp.DurableProject
+	if project.ExpiresAt != nil {
+		kind = tagapp.AnonymousTemporaryBoard
+		if project.CreatorUserID != nil {
+			kind = tagapp.CreatorOwnedTemporaryBoard
+		}
+	}
+
+	return tagapp.ResolvedProject{ProjectID: project.ID, Kind: kind}
 }
 
 func writeSprintDefinitionPrepareError(w http.ResponseWriter, err error) {
@@ -1209,26 +1231,33 @@ func (s *Server) handleBoardTagRoutes(w http.ResponseWriter, r *http.Request, re
 		if err := readJSON(w, r, s.maxBody, &in); err != nil {
 			return true
 		}
-		var patchColorErr error
+		var viewerUserID *int64
 		if project.ExpiresAt != nil {
-			var viewerUserID *int64
 			if userID, ok := store.UserIDFromContext(ctx); ok {
 				viewerUserID = &userID
 			}
-			patchColorErr = s.store.UpdateTagColorForTemporaryBoard(ctx, project.ID, viewerUserID, tagID, in.Color)
 		} else {
 			userID, ok := store.UserIDFromContext(ctx)
 			if !ok {
 				writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
 				return true
 			}
-			patchColorErr = s.store.UpdateTagColorForDurableProjectByID(ctx, project.ID, userID, tagID, in.Color)
+			viewerUserID = &userID
 		}
-		if patchColorErr != nil {
-			writeStoreErr(w, patchColorErr, true)
+		prepared, err := s.tagColors.PrepareProjectID(ctx, tagapp.ProjectIDColorCommand{
+			Project:      resolvedRESTTagProject(project),
+			ViewerUserID: viewerUserID,
+			TagID:        tagID,
+			Color:        tagapp.NewColorIntent(in.Color),
+		})
+		if err != nil {
+			writeTagColorPrepareError(w, err)
 			return true
 		}
-		s.emitRefreshNeeded(s.requestContext(r), project.ID, "tag_color_updated", refresh.Entity{})
+		if err := prepared.Update(); err != nil {
+			writeStoreErr(w, err, true)
+			return true
+		}
 		w.WriteHeader(http.StatusNoContent)
 		return true
 	}
@@ -1246,6 +1275,7 @@ func (s *Server) handleBoardTagRoutes(w http.ResponseWriter, r *http.Request, re
 			return true
 		}
 
+		var viewerUserID *int64
 		if project.ExpiresAt == nil {
 			// Durable project: name-based personal color for any authenticated member.
 			// SetViewerTagColorByName enforces membership. Same known limitation as the
@@ -1256,26 +1286,25 @@ func (s *Server) handleBoardTagRoutes(w http.ResponseWriter, r *http.Request, re
 				writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized", nil)
 				return true
 			}
-			if err := s.store.SetViewerTagColorByName(ctx, project.ID, userID, tagName, in.Color); err != nil {
-				writeStoreErr(w, err, true)
-				return true
-			}
-			s.emitRefreshNeeded(s.requestContext(r), project.ID, "tag_color_updated", refresh.Entity{Name: tagName})
-			w.WriteHeader(http.StatusNoContent)
-			return true
-		}
-
-		linkTemporaryBoard := true
-		var viewerUserID *int64
-		if userID, ok := store.UserIDFromContext(ctx); ok {
+			viewerUserID = &userID
+		} else if userID, ok := store.UserIDFromContext(ctx); ok {
 			viewerUserID = &userID
 		}
 
-		if err := s.store.UpdateTagColorForProject(ctx, project.ID, viewerUserID, tagName, in.Color, linkTemporaryBoard); err != nil {
+		prepared, err := s.tagColors.PrepareProjectName(ctx, tagapp.ProjectNameColorCommand{
+			Project:      resolvedRESTTagProject(project),
+			ViewerUserID: viewerUserID,
+			Name:         tagName,
+			Color:        tagapp.NewColorIntent(in.Color),
+		})
+		if err != nil {
+			writeTagColorPrepareError(w, err)
+			return true
+		}
+		if err := prepared.Update(); err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}
-		s.emitRefreshNeeded(s.requestContext(r), project.ID, "tag_color_updated", refresh.Entity{Name: tagName})
 		w.WriteHeader(http.StatusNoContent)
 		return true
 	}

--- a/internal/httpapi/routing_misc.go
+++ b/internal/httpapi/routing_misc.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"scrumboy/internal/application/refresh"
 	tagapp "scrumboy/internal/application/tag"
 	"scrumboy/internal/store"
 	"scrumboy/internal/version"
@@ -64,13 +63,13 @@ func (s *Server) handleTags(w http.ResponseWriter, r *http.Request, rest []strin
 			writeValidationError(w, "invalid tagId", "invalid_tag_id", map[string]any{"field": "tagId"})
 			return
 		}
-		affected, err := s.store.DeleteMyTagByID(ctx, userID, tagID)
-		if err != nil {
-			writeStoreErr(w, err, true)
+		prepared := s.tagDeletions.PrepareMineID(ctx, tagapp.MineIDDeleteCommand{
+			ActorUserID: userID,
+			TagID:       tagID,
+		})
+		if err := prepared.Delete(); err != nil {
+			writeTagDeletionError(w, err)
 			return
-		}
-		for _, pid := range affected {
-			s.emitRefreshNeeded(ctx, pid, "tag_deleted", refresh.Entity{})
 		}
 		w.WriteHeader(http.StatusNoContent)
 		return

--- a/internal/httpapi/routing_misc.go
+++ b/internal/httpapi/routing_misc.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"scrumboy/internal/application/refresh"
+	tagapp "scrumboy/internal/application/tag"
 	"scrumboy/internal/store"
 	"scrumboy/internal/version"
 )
@@ -42,7 +43,12 @@ func (s *Server) handleTags(w http.ResponseWriter, r *http.Request, rest []strin
 		if err := readJSON(w, r, s.maxBody, &in); err != nil {
 			return
 		}
-		if err := s.store.UpdateMyTagColor(ctx, userID, tagID, in.Color); err != nil {
+		prepared := s.tagColors.PrepareMineID(ctx, tagapp.MineIDColorCommand{
+			ActorUserID: userID,
+			TagID:       tagID,
+			Color:       tagapp.NewColorIntent(in.Color),
+		})
+		if err := prepared.Update(); err != nil {
 			writeStoreErr(w, err, true)
 			return
 		}

--- a/internal/httpapi/routing_projects.go
+++ b/internal/httpapi/routing_projects.go
@@ -10,6 +10,7 @@ import (
 	boardapp "scrumboy/internal/application/board"
 	membershipapp "scrumboy/internal/application/membership"
 	"scrumboy/internal/application/refresh"
+	tagapp "scrumboy/internal/application/tag"
 	"scrumboy/internal/projectcolor"
 	"scrumboy/internal/store"
 )
@@ -506,11 +507,20 @@ func (s *Server) handleProjectsProjectTags(w http.ResponseWriter, r *http.Reques
 			return true
 		}
 		// Durable numeric project route: project-aware membership + role checks.
-		if err := s.store.UpdateTagColorForDurableProjectByID(ctx, projectID, userID, tagID, in.Color); err != nil {
+		prepared, err := s.tagColors.PrepareProjectID(ctx, tagapp.ProjectIDColorCommand{
+			Project:      tagapp.ResolvedProject{ProjectID: projectID, Kind: tagapp.DurableProject},
+			ViewerUserID: &userID,
+			TagID:        tagID,
+			Color:        tagapp.NewColorIntent(in.Color),
+		})
+		if err != nil {
+			writeTagColorPrepareError(w, err)
+			return true
+		}
+		if err := prepared.Update(); err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}
-		s.emitRefreshNeeded(s.requestContext(r), projectID, "tag_color_updated", refresh.Entity{})
 		w.WriteHeader(http.StatusNoContent)
 		return true
 	}
@@ -539,11 +549,20 @@ func (s *Server) handleProjectsProjectTags(w http.ResponseWriter, r *http.Reques
 		if err := readJSON(w, r, s.maxBody, &in); err != nil {
 			return true
 		}
-		if err := s.store.SetViewerTagColorByName(ctx, projectID, userID, tagName, in.Color); err != nil {
+		prepared, err := s.tagColors.PrepareProjectName(ctx, tagapp.ProjectNameColorCommand{
+			Project:      tagapp.ResolvedProject{ProjectID: projectID, Kind: tagapp.DurableProject},
+			ViewerUserID: &userID,
+			Name:         tagName,
+			Color:        tagapp.NewColorIntent(in.Color),
+		})
+		if err != nil {
+			writeTagColorPrepareError(w, err)
+			return true
+		}
+		if err := prepared.Update(); err != nil {
 			writeStoreErr(w, err, true)
 			return true
 		}
-		s.emitRefreshNeeded(s.requestContext(r), projectID, "tag_color_updated", refresh.Entity{Name: tagName})
 		w.WriteHeader(http.StatusNoContent)
 		return true
 	}

--- a/internal/httpapi/routing_projects.go
+++ b/internal/httpapi/routing_projects.go
@@ -579,12 +579,19 @@ func (s *Server) handleProjectsProjectTags(w http.ResponseWriter, r *http.Reques
 			writeValidationError(w, "invalid tagId", "invalid_tag_id", map[string]any{"field": "tagId"})
 			return true
 		}
-		affected, err := s.store.DeleteTagForDurableProjectByID(ctx, projectID, userID, tagID)
+		prepared, err := s.tagDeletions.PrepareProjectID(ctx, tagapp.ProjectIDDeleteCommand{
+			Project:     tagapp.ResolvedProject{ProjectID: projectID, Kind: tagapp.DurableProject},
+			ActorUserID: &userID,
+			TagID:       tagID,
+		})
 		if err != nil {
-			writeStoreErr(w, err, true)
+			writeTagDeletionError(w, err)
 			return true
 		}
-		s.emitTagDeletedRefresh(s.requestContext(r), projectID, affected, refresh.Entity{})
+		if err := prepared.Delete(); err != nil {
+			writeTagDeletionError(w, err)
+			return true
+		}
 		w.WriteHeader(http.StatusNoContent)
 		return true
 	}
@@ -601,12 +608,19 @@ func (s *Server) handleProjectsProjectTags(w http.ResponseWriter, r *http.Reques
 			return true
 		}
 		tagName := rest[2]
-		affected, err := s.store.DeleteMyTagByName(ctx, projectID, userID, tagName)
+		prepared, err := s.tagDeletions.PrepareProjectName(ctx, tagapp.ProjectNameDeleteCommand{
+			Project:     tagapp.ResolvedProject{ProjectID: projectID, Kind: tagapp.DurableProject},
+			ActorUserID: &userID,
+			Name:        tagName,
+		})
 		if err != nil {
-			writeStoreErr(w, err, true)
+			writeTagDeletionError(w, err)
 			return true
 		}
-		s.emitTagDeletedRefresh(s.requestContext(r), projectID, affected, refresh.Entity{Name: tagName})
+		if err := prepared.Delete(); err != nil {
+			writeTagDeletionError(w, err)
+			return true
+		}
 		w.WriteHeader(http.StatusNoContent)
 		return true
 	}

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -140,6 +140,7 @@ type Server struct {
 	agenda                        *calendarapp.AgendaService
 	membershipMutations           *membershipapp.RESTMutationService
 	tagColors                     *tagapp.RESTColorService
+	tagDeletions                  *tagapp.RESTDeletionService
 
 	logger                  *log.Logger
 	maxBody                 int64
@@ -739,6 +740,15 @@ func NewServer(st storeAPI, opts Options) *Server {
 		DurableNameColor:   st,
 		TemporaryNameColor: st,
 		Publisher:          tagColorPublisher{server: server},
+	})
+	server.tagDeletions = tagapp.NewRESTDeletionService(tagapp.RESTDeletionServiceDependencies{
+		MineID:        st,
+		MineName:      st,
+		DurableID:     st,
+		Rows:          st,
+		BoardNames:    st,
+		PersonalNames: st,
+		Publisher:     tagDeletionPublisher{server: server},
 	})
 	if opts.MCPHandler != nil {
 		opts.MCPHandler.BindCreatorNotificationRequestPublisher(creatorRequestPublisher)

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -18,6 +18,7 @@ import (
 	projectsettingsapp "scrumboy/internal/application/projectsettings"
 	"scrumboy/internal/application/refresh"
 	sprintapp "scrumboy/internal/application/sprint"
+	tagapp "scrumboy/internal/application/tag"
 	todoapp "scrumboy/internal/application/todo"
 	todolinkapp "scrumboy/internal/application/todolink"
 	workflowapp "scrumboy/internal/application/workflow"
@@ -138,6 +139,7 @@ type Server struct {
 	boardSettings                 *projectsettingsapp.RESTService
 	agenda                        *calendarapp.AgendaService
 	membershipMutations           *membershipapp.RESTMutationService
+	tagColors                     *tagapp.RESTColorService
 
 	logger                  *log.Logger
 	maxBody                 int64
@@ -729,6 +731,14 @@ func NewServer(st storeAPI, opts Options) *Server {
 		Mutations: st,
 		Members:   st,
 		Publisher: membershipMutationPublisher{server: server},
+	})
+	server.tagColors = tagapp.NewRESTColorService(tagapp.RESTColorServiceDependencies{
+		MineColor:          st,
+		DurableIDColor:     st,
+		TemporaryIDColor:   st,
+		DurableNameColor:   st,
+		TemporaryNameColor: st,
+		Publisher:          tagColorPublisher{server: server},
 	})
 	if opts.MCPHandler != nil {
 		opts.MCPHandler.BindCreatorNotificationRequestPublisher(creatorRequestPublisher)

--- a/internal/httpapi/tag_color_migration_test.go
+++ b/internal/httpapi/tag_color_migration_test.go
@@ -1,0 +1,367 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	tagapp "scrumboy/internal/application/tag"
+	"scrumboy/internal/store"
+)
+
+type tagColorRESTCall struct {
+	method             string
+	projectID          int64
+	viewerUserID       *int64
+	tagID              int64
+	name               string
+	color              *string
+	linkTemporaryBoard bool
+}
+
+type tagColorRESTRecorder struct {
+	calls []tagColorRESTCall
+}
+
+var (
+	_ tagapp.MineColorStore               = (*tagColorRESTRecorder)(nil)
+	_ tagapp.DurableProjectIDColorStore   = (*tagColorRESTRecorder)(nil)
+	_ tagapp.TemporaryBoardIDColorStore   = (*tagColorRESTRecorder)(nil)
+	_ tagapp.DurableProjectNameColorStore = (*tagColorRESTRecorder)(nil)
+	_ tagapp.TemporaryBoardNameColorStore = (*tagColorRESTRecorder)(nil)
+)
+
+func cloneTagColorTestInt64(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneTagColorTestString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func (r *tagColorRESTRecorder) record(call tagColorRESTCall) error {
+	call.viewerUserID = cloneTagColorTestInt64(call.viewerUserID)
+	call.color = cloneTagColorTestString(call.color)
+	r.calls = append(r.calls, call)
+	return nil
+}
+
+func (r *tagColorRESTRecorder) UpdateMyTagColor(_ context.Context, userID, tagID int64, color *string) error {
+	return r.record(tagColorRESTCall{
+		method:       "mine-id",
+		viewerUserID: &userID,
+		tagID:        tagID,
+		color:        color,
+	})
+}
+
+func (r *tagColorRESTRecorder) UpdateTagColorForDurableProjectByID(
+	_ context.Context,
+	projectID int64,
+	viewerUserID int64,
+	tagID int64,
+	color *string,
+) error {
+	return r.record(tagColorRESTCall{
+		method:       "durable-id",
+		projectID:    projectID,
+		viewerUserID: &viewerUserID,
+		tagID:        tagID,
+		color:        color,
+	})
+}
+
+func (r *tagColorRESTRecorder) UpdateTagColorForTemporaryBoard(
+	_ context.Context,
+	projectID int64,
+	viewerUserID *int64,
+	tagID int64,
+	color *string,
+) error {
+	return r.record(tagColorRESTCall{
+		method:       "temporary-id",
+		projectID:    projectID,
+		viewerUserID: viewerUserID,
+		tagID:        tagID,
+		color:        color,
+	})
+}
+
+func (r *tagColorRESTRecorder) SetViewerTagColorByName(
+	_ context.Context,
+	projectID int64,
+	viewerUserID int64,
+	name string,
+	color *string,
+) error {
+	return r.record(tagColorRESTCall{
+		method:       "durable-name",
+		projectID:    projectID,
+		viewerUserID: &viewerUserID,
+		name:         name,
+		color:        color,
+	})
+}
+
+func (r *tagColorRESTRecorder) UpdateTagColorForProject(
+	_ context.Context,
+	projectID int64,
+	viewerUserID *int64,
+	tagName string,
+	color *string,
+	linkTemporaryBoard bool,
+) error {
+	return r.record(tagColorRESTCall{
+		method:             "temporary-name",
+		projectID:          projectID,
+		viewerUserID:       viewerUserID,
+		name:               tagName,
+		color:              color,
+		linkTemporaryBoard: linkTemporaryBoard,
+	})
+}
+
+func TestTagColorRESTHandlersDelegateToApplicationService(t *testing.T) {
+	fx := newTagMutationRESTFixture(t)
+	if fx.server.tagColors == nil {
+		t.Fatal("NewServer did not compose the REST tag color service")
+	}
+
+	durableProjectID, durableSlug := createProjectAPI(t, fx.client, fx.ts, "REST Color Migration Durable")
+	creatorSlug := createAnonBoardViaHTTP(t, fx.client, fx.ts)
+	creatorProjectID := projectIDBySlug(t, fx.db, creatorSlug)
+	anonymousClient := newCookieClient(t)
+	anonymousSlug := createAnonBoardViaHTTP(t, anonymousClient, fx.ts)
+	anonymousProjectID := projectIDBySlug(t, fx.db, anonymousSlug)
+
+	recorder := &tagColorRESTRecorder{}
+	fx.server.tagColors = tagapp.NewRESTColorService(tagapp.RESTColorServiceDependencies{
+		MineColor:          recorder,
+		DurableIDColor:     recorder,
+		TemporaryIDColor:   recorder,
+		DurableNameColor:   recorder,
+		TemporaryNameColor: recorder,
+		Publisher:          tagColorPublisher{server: fx.server},
+	})
+
+	ownerID := fx.ownerID
+	rawColor := "  #123456  "
+	tests := []struct {
+		name               string
+		client             *http.Client
+		path               string
+		wantMethod         string
+		wantProjectID      int64
+		wantViewerUserID   *int64
+		wantTagID          int64
+		wantName           string
+		wantTemporaryLink  bool
+		wantRefresh        bool
+		wantRefreshActorID int64
+	}{
+		{
+			name:             "mine ID",
+			client:           fx.client,
+			path:             "/api/tags/mine/101/color",
+			wantMethod:       "mine-id",
+			wantViewerUserID: &ownerID,
+			wantTagID:        101,
+		},
+		{
+			name:               "durable board ID",
+			client:             fx.client,
+			path:               "/api/board/" + durableSlug + "/tags/id/102/color",
+			wantMethod:         "durable-id",
+			wantProjectID:      durableProjectID,
+			wantViewerUserID:   &ownerID,
+			wantTagID:          102,
+			wantRefresh:        true,
+			wantRefreshActorID: ownerID,
+		},
+		{
+			name:               "durable board name",
+			client:             fx.client,
+			path:               "/api/board/" + durableSlug + "/tags/durable-board-name/color",
+			wantMethod:         "durable-name",
+			wantProjectID:      durableProjectID,
+			wantViewerUserID:   &ownerID,
+			wantName:           "durable-board-name",
+			wantRefresh:        true,
+			wantRefreshActorID: ownerID,
+		},
+		{
+			name:               "numeric project ID",
+			client:             fx.client,
+			path:               "/api/projects/" + strconv.FormatInt(durableProjectID, 10) + "/tags/id/103/color",
+			wantMethod:         "durable-id",
+			wantProjectID:      durableProjectID,
+			wantViewerUserID:   &ownerID,
+			wantTagID:          103,
+			wantRefresh:        true,
+			wantRefreshActorID: ownerID,
+		},
+		{
+			name:               "numeric project name",
+			client:             fx.client,
+			path:               "/api/projects/" + strconv.FormatInt(durableProjectID, 10) + "/tags/numeric-name/color",
+			wantMethod:         "durable-name",
+			wantProjectID:      durableProjectID,
+			wantViewerUserID:   &ownerID,
+			wantName:           "numeric-name",
+			wantRefresh:        true,
+			wantRefreshActorID: ownerID,
+		},
+		{
+			name:               "creator temporary board ID",
+			client:             fx.client,
+			path:               "/api/board/" + creatorSlug + "/tags/id/104/color",
+			wantMethod:         "temporary-id",
+			wantProjectID:      creatorProjectID,
+			wantViewerUserID:   &ownerID,
+			wantTagID:          104,
+			wantRefresh:        true,
+			wantRefreshActorID: ownerID,
+		},
+		{
+			name:               "creator temporary board name",
+			client:             fx.client,
+			path:               "/api/board/" + creatorSlug + "/tags/creator-name/color",
+			wantMethod:         "temporary-name",
+			wantProjectID:      creatorProjectID,
+			wantViewerUserID:   &ownerID,
+			wantName:           "creator-name",
+			wantTemporaryLink:  true,
+			wantRefresh:        true,
+			wantRefreshActorID: ownerID,
+		},
+		{
+			name:          "anonymous temporary board ID",
+			client:        anonymousClient,
+			path:          "/api/board/" + anonymousSlug + "/tags/id/105/color",
+			wantMethod:    "temporary-id",
+			wantProjectID: anonymousProjectID,
+			wantTagID:     105,
+			wantRefresh:   true,
+		},
+		{
+			name:              "anonymous temporary board name",
+			client:            anonymousClient,
+			path:              "/api/board/" + anonymousSlug + "/tags/anonymous-name/color",
+			wantMethod:        "temporary-name",
+			wantProjectID:     anonymousProjectID,
+			wantName:          "anonymous-name",
+			wantTemporaryLink: true,
+			wantRefresh:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder.calls = nil
+			fx.resetEvents()
+
+			resp, body := doJSON(
+				t,
+				tc.client,
+				http.MethodPatch,
+				fx.ts+tc.path,
+				map[string]any{"color": rawColor},
+				nil,
+			)
+			assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+
+			if len(recorder.calls) != 1 {
+				t.Fatalf("calls=%+v want exactly one application-selected mutation", recorder.calls)
+			}
+			call := recorder.calls[0]
+			if call.method != tc.wantMethod ||
+				call.projectID != tc.wantProjectID ||
+				call.tagID != tc.wantTagID ||
+				call.name != tc.wantName ||
+				call.linkTemporaryBoard != tc.wantTemporaryLink {
+				t.Fatalf("call=%+v does not match expected route projection", call)
+			}
+			if tc.wantViewerUserID == nil {
+				if call.viewerUserID != nil {
+					t.Fatalf("viewer=%v want nil", *call.viewerUserID)
+				}
+			} else if call.viewerUserID == nil || *call.viewerUserID != *tc.wantViewerUserID {
+				t.Fatalf("viewer=%v want %d", call.viewerUserID, *tc.wantViewerUserID)
+			}
+			if call.color == nil || *call.color != rawColor {
+				t.Fatalf("color=%v want exact unnormalized %q", call.color, rawColor)
+			}
+
+			if !tc.wantRefresh {
+				if len(fx.collector.events) != 0 {
+					t.Fatalf("mine color published events: %+v", fx.collector.events)
+				}
+				return
+			}
+			if len(fx.collector.events) != 1 {
+				t.Fatalf("events=%+v want exactly one refresh", fx.collector.events)
+			}
+			event := fx.collector.events[0]
+			if event.ProjectID != tc.wantProjectID || event.Type != "board.refresh_needed" {
+				t.Fatalf("event=%+v want one refresh for project %d", event, tc.wantProjectID)
+			}
+			var payload refreshNeededPayload
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				t.Fatalf("decode refresh payload: %v", err)
+			}
+			if payload.Reason != "tag_color_updated" ||
+				payload.Name != tc.wantName ||
+				payload.ActorUserID != tc.wantRefreshActorID ||
+				payload.LocalID != 0 ||
+				payload.Title != "" {
+				t.Fatalf("payload=%+v does not match route publication", payload)
+			}
+		})
+	}
+}
+
+func TestResolvedRESTTagProjectPreservesProjectKinds(t *testing.T) {
+	expiresAt := time.Now().UTC().Add(time.Hour)
+	creatorUserID := int64(42)
+
+	tests := []struct {
+		name    string
+		project store.Project
+		want    tagapp.ResolvedProject
+	}{
+		{
+			name:    "durable",
+			project: store.Project{ID: 1},
+			want:    tagapp.ResolvedProject{ProjectID: 1, Kind: tagapp.DurableProject},
+		},
+		{
+			name:    "creator-owned temporary",
+			project: store.Project{ID: 2, CreatorUserID: &creatorUserID, ExpiresAt: &expiresAt},
+			want:    tagapp.ResolvedProject{ProjectID: 2, Kind: tagapp.CreatorOwnedTemporaryBoard},
+		},
+		{
+			name:    "anonymous temporary",
+			project: store.Project{ID: 3, ExpiresAt: &expiresAt},
+			want:    tagapp.ResolvedProject{ProjectID: 3, Kind: tagapp.AnonymousTemporaryBoard},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolvedRESTTagProject(tc.project); got != tc.want {
+				t.Fatalf("resolved=%+v want=%+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/httpapi/tag_deletion_migration_test.go
+++ b/internal/httpapi/tag_deletion_migration_test.go
@@ -1,0 +1,453 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+
+	tagapp "scrumboy/internal/application/tag"
+	"scrumboy/internal/eventbus"
+	"scrumboy/internal/store"
+)
+
+type tagDeletionRESTCall struct {
+	method         string
+	projectID      int64
+	actorUserID    int64
+	tagID          int64
+	name           string
+	anonymousBoard bool
+}
+
+type tagDeletionRESTRecorder struct {
+	calls             []tagDeletionRESTCall
+	affectedProjects  []int64
+	mutationErr       error
+	boardNameTagID    int64
+	boardNameErr      error
+	personalNameTagID int64
+	personalNameErr   error
+}
+
+var (
+	_ tagapp.MineIDDeletionStore           = (*tagDeletionRESTRecorder)(nil)
+	_ tagapp.MineNameDeletionStore         = (*tagDeletionRESTRecorder)(nil)
+	_ tagapp.DurableProjectIDDeletionStore = (*tagDeletionRESTRecorder)(nil)
+	_ tagapp.LegacyRowDeletionStore        = (*tagDeletionRESTRecorder)(nil)
+	_ tagapp.BoardScopedTagNameReadStore   = (*tagDeletionRESTRecorder)(nil)
+	_ tagapp.PersonalTagNameReadStore      = (*tagDeletionRESTRecorder)(nil)
+)
+
+func (r *tagDeletionRESTRecorder) reset() {
+	r.calls = nil
+	r.affectedProjects = nil
+	r.mutationErr = nil
+	r.boardNameTagID = 0
+	r.boardNameErr = nil
+	r.personalNameTagID = 0
+	r.personalNameErr = nil
+}
+
+func (r *tagDeletionRESTRecorder) record(call tagDeletionRESTCall) {
+	r.calls = append(r.calls, call)
+}
+
+func (r *tagDeletionRESTRecorder) DeleteMyTagByID(
+	_ context.Context,
+	userID int64,
+	tagID int64,
+) ([]int64, error) {
+	r.record(tagDeletionRESTCall{method: "mine-id", actorUserID: userID, tagID: tagID})
+	return append([]int64(nil), r.affectedProjects...), r.mutationErr
+}
+
+func (r *tagDeletionRESTRecorder) DeleteMyTagByName(
+	_ context.Context,
+	projectID int64,
+	userID int64,
+	name string,
+) ([]int64, error) {
+	r.record(tagDeletionRESTCall{
+		method: "durable-name", projectID: projectID, actorUserID: userID, name: name,
+	})
+	return append([]int64(nil), r.affectedProjects...), r.mutationErr
+}
+
+func (r *tagDeletionRESTRecorder) DeleteTagForDurableProjectByID(
+	_ context.Context,
+	projectID int64,
+	userID int64,
+	tagID int64,
+) ([]int64, error) {
+	r.record(tagDeletionRESTCall{
+		method: "durable-id", projectID: projectID, actorUserID: userID, tagID: tagID,
+	})
+	return append([]int64(nil), r.affectedProjects...), r.mutationErr
+}
+
+func (r *tagDeletionRESTRecorder) DeleteTag(
+	_ context.Context,
+	userID int64,
+	tagID int64,
+	isAnonymousBoard bool,
+) error {
+	r.record(tagDeletionRESTCall{
+		method: "row-delete", actorUserID: userID, tagID: tagID, anonymousBoard: isAnonymousBoard,
+	})
+	return r.mutationErr
+}
+
+func (r *tagDeletionRESTRecorder) GetBoardScopedTagIDByName(
+	_ context.Context,
+	projectID int64,
+	name string,
+) (int64, error) {
+	r.record(tagDeletionRESTCall{method: "board-name-read", projectID: projectID, name: name})
+	return r.boardNameTagID, r.boardNameErr
+}
+
+func (r *tagDeletionRESTRecorder) GetTagIDByName(
+	_ context.Context,
+	userID int64,
+	name string,
+) (int64, error) {
+	r.record(tagDeletionRESTCall{method: "personal-name-read", actorUserID: userID, name: name})
+	return r.personalNameTagID, r.personalNameErr
+}
+
+func newTagDeletionRESTService(server *Server, recorder *tagDeletionRESTRecorder) *tagapp.RESTDeletionService {
+	return tagapp.NewRESTDeletionService(tagapp.RESTDeletionServiceDependencies{
+		MineID:        recorder,
+		MineName:      recorder,
+		DurableID:     recorder,
+		Rows:          recorder,
+		BoardNames:    recorder,
+		PersonalNames: recorder,
+		Publisher:     tagDeletionPublisher{server: server},
+	})
+}
+
+func TestTagDeletionRESTHandlersDelegateToApplicationService(t *testing.T) {
+	fx := newTagMutationRESTFixture(t)
+	if fx.server.tagDeletions == nil {
+		t.Fatal("NewServer did not compose the REST tag deletion service")
+	}
+
+	durableProjectID, durableSlug := createProjectAPI(t, fx.client, fx.ts, "REST Deletion Migration Durable")
+	creatorSlug := createAnonBoardViaHTTP(t, fx.client, fx.ts)
+	creatorProjectID := projectIDBySlug(t, fx.db, creatorSlug)
+	anonymousClient := newCookieClient(t)
+	anonymousSlug := createAnonBoardViaHTTP(t, anonymousClient, fx.ts)
+	anonymousProjectID := projectIDBySlug(t, fx.db, anonymousSlug)
+
+	recorder := &tagDeletionRESTRecorder{}
+	fx.server.tagDeletions = newTagDeletionRESTService(fx.server, recorder)
+
+	tests := []struct {
+		name             string
+		client           *http.Client
+		path             string
+		affectedProjects []int64
+		wantCall         tagDeletionRESTCall
+		wantProjects     []int64
+		wantRefreshName  string
+		wantActorUserID  int64
+	}{
+		{
+			name:             "mine ID",
+			client:           fx.client,
+			path:             "/api/tags/mine/101",
+			affectedProjects: []int64{durableProjectID, durableProjectID},
+			wantCall:         tagDeletionRESTCall{method: "mine-id", actorUserID: fx.ownerID, tagID: 101},
+			wantProjects:     []int64{durableProjectID},
+			wantActorUserID:  fx.ownerID,
+		},
+		{
+			name:             "durable board ID",
+			client:           fx.client,
+			path:             "/api/board/" + durableSlug + "/tags/id/102",
+			affectedProjects: []int64{durableProjectID, 909, 909},
+			wantCall: tagDeletionRESTCall{
+				method: "durable-id", projectID: durableProjectID, actorUserID: fx.ownerID, tagID: 102,
+			},
+			wantProjects:    []int64{durableProjectID, 909},
+			wantActorUserID: fx.ownerID,
+		},
+		{
+			name:             "durable board name",
+			client:           fx.client,
+			path:             "/api/board/" + durableSlug + "/tags/durable-board-name",
+			affectedProjects: []int64{durableProjectID, 910, 910},
+			wantCall: tagDeletionRESTCall{
+				method: "durable-name", projectID: durableProjectID, actorUserID: fx.ownerID, name: "durable-board-name",
+			},
+			wantProjects:    []int64{durableProjectID, 910},
+			wantRefreshName: "durable-board-name",
+			wantActorUserID: fx.ownerID,
+		},
+		{
+			name:             "numeric project ID",
+			client:           fx.client,
+			path:             "/api/projects/" + strconv.FormatInt(durableProjectID, 10) + "/tags/id/103",
+			affectedProjects: []int64{durableProjectID},
+			wantCall: tagDeletionRESTCall{
+				method: "durable-id", projectID: durableProjectID, actorUserID: fx.ownerID, tagID: 103,
+			},
+			wantProjects:    []int64{durableProjectID},
+			wantActorUserID: fx.ownerID,
+		},
+		{
+			name:             "numeric project name",
+			client:           fx.client,
+			path:             "/api/projects/" + strconv.FormatInt(durableProjectID, 10) + "/tags/numeric-name",
+			affectedProjects: []int64{durableProjectID},
+			wantCall: tagDeletionRESTCall{
+				method: "durable-name", projectID: durableProjectID, actorUserID: fx.ownerID, name: "numeric-name",
+			},
+			wantProjects:    []int64{durableProjectID},
+			wantRefreshName: "numeric-name",
+			wantActorUserID: fx.ownerID,
+		},
+		{
+			name:   "creator temporary board ID",
+			client: fx.client,
+			path:   "/api/board/" + creatorSlug + "/tags/id/104",
+			wantCall: tagDeletionRESTCall{
+				method: "row-delete", actorUserID: fx.ownerID, tagID: 104,
+			},
+			wantProjects:    []int64{creatorProjectID},
+			wantActorUserID: fx.ownerID,
+		},
+		{
+			name:   "anonymous temporary board ID",
+			client: anonymousClient,
+			path:   "/api/board/" + anonymousSlug + "/tags/id/105",
+			wantCall: tagDeletionRESTCall{
+				method: "row-delete", tagID: 105, anonymousBoard: true,
+			},
+			wantProjects: []int64{anonymousProjectID},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder.reset()
+			recorder.affectedProjects = append([]int64(nil), tc.affectedProjects...)
+			fx.resetEvents()
+
+			resp, body := doJSON(t, tc.client, http.MethodDelete, fx.ts+tc.path, nil, nil)
+			assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+			if len(body) != 0 {
+				t.Fatalf("204 response body=%q, want empty", body)
+			}
+
+			if len(recorder.calls) != 1 || recorder.calls[0] != tc.wantCall {
+				t.Fatalf("calls=%+v want exactly %+v", recorder.calls, tc.wantCall)
+			}
+			assertTagDeletionRESTRefreshes(
+				t,
+				fx.collector.events,
+				tc.wantProjects,
+				tc.wantRefreshName,
+				tc.wantActorUserID,
+			)
+		})
+	}
+}
+
+func TestTagDeletionRESTAnonymousNameResolutionDelegatesInOrder(t *testing.T) {
+	fx := newTagMutationRESTFixture(t)
+	anonymousClient := newCookieClient(t)
+	anonymousSlug := createAnonBoardViaHTTP(t, anonymousClient, fx.ts)
+	anonymousProjectID := projectIDBySlug(t, fx.db, anonymousSlug)
+	recorder := &tagDeletionRESTRecorder{}
+	fx.server.tagDeletions = newTagDeletionRESTService(fx.server, recorder)
+
+	t.Run("board-scoped row wins without actor", func(t *testing.T) {
+		recorder.reset()
+		recorder.boardNameTagID = 201
+		fx.resetEvents()
+
+		resp, body := doJSON(
+			t,
+			anonymousClient,
+			http.MethodDelete,
+			fx.ts+"/api/board/"+anonymousSlug+"/tags/board-name",
+			nil,
+			nil,
+		)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		if len(body) != 0 {
+			t.Fatalf("204 response body=%q, want empty", body)
+		}
+		wantCalls := []tagDeletionRESTCall{
+			{method: "board-name-read", projectID: anonymousProjectID, name: "board-name"},
+			{method: "row-delete", tagID: 201, anonymousBoard: true},
+		}
+		assertTagDeletionRESTCalls(t, recorder.calls, wantCalls)
+		assertTagDeletionRESTRefreshes(t, fx.collector.events, []int64{anonymousProjectID}, "board-name", 0)
+	})
+
+	t.Run("signed caller deleting board-scoped row keeps mutation and event identities distinct", func(t *testing.T) {
+		recorder.reset()
+		recorder.boardNameTagID = 202
+		fx.resetEvents()
+
+		resp, body := doJSON(
+			t,
+			fx.client,
+			http.MethodDelete,
+			fx.ts+"/api/board/"+anonymousSlug+"/tags/signed-board-name",
+			nil,
+			nil,
+		)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		if len(body) != 0 {
+			t.Fatalf("204 response body=%q, want empty", body)
+		}
+		wantCalls := []tagDeletionRESTCall{
+			{method: "board-name-read", projectID: anonymousProjectID, name: "signed-board-name"},
+			{method: "row-delete", tagID: 202, anonymousBoard: true},
+		}
+		assertTagDeletionRESTCalls(t, recorder.calls, wantCalls)
+		assertTagDeletionRESTRefreshes(
+			t,
+			fx.collector.events,
+			[]int64{anonymousProjectID},
+			"signed-board-name",
+			fx.ownerID,
+		)
+	})
+
+	t.Run("signed caller falls back to personal row", func(t *testing.T) {
+		recorder.reset()
+		recorder.boardNameErr = store.ErrNotFound
+		recorder.personalNameTagID = 203
+		fx.resetEvents()
+
+		resp, body := doJSON(
+			t,
+			fx.client,
+			http.MethodDelete,
+			fx.ts+"/api/board/"+anonymousSlug+"/tags/personal-name",
+			nil,
+			nil,
+		)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		if len(body) != 0 {
+			t.Fatalf("204 response body=%q, want empty", body)
+		}
+		wantCalls := []tagDeletionRESTCall{
+			{method: "board-name-read", projectID: anonymousProjectID, name: "personal-name"},
+			{method: "personal-name-read", actorUserID: fx.ownerID, name: "personal-name"},
+			{method: "row-delete", actorUserID: fx.ownerID, tagID: 203, anonymousBoard: true},
+		}
+		assertTagDeletionRESTCalls(t, recorder.calls, wantCalls)
+		assertTagDeletionRESTRefreshes(
+			t,
+			fx.collector.events,
+			[]int64{anonymousProjectID},
+			"personal-name",
+			fx.ownerID,
+		)
+	})
+}
+
+func TestTagDeletionRESTCreatorTemporaryNameRejectionStaysPubliclyStable(t *testing.T) {
+	fx := newTagMutationRESTFixture(t)
+	creatorSlug := createAnonBoardViaHTTP(t, fx.client, fx.ts)
+	recorder := &tagDeletionRESTRecorder{}
+	fx.server.tagDeletions = newTagDeletionRESTService(fx.server, recorder)
+	fx.resetEvents()
+
+	var out apiErrorEnvelope
+	resp, body := doJSON(
+		t,
+		fx.client,
+		http.MethodDelete,
+		fx.ts+"/api/board/"+creatorSlug+"/tags/refused-name",
+		nil,
+		&out,
+	)
+	assertTagMutationRESTStatus(t, resp, body, http.StatusBadRequest)
+	assertAPIError(t, out, "VALIDATION_ERROR", "", "name_based_tag_route_not_allowed")
+	if len(recorder.calls) != 0 {
+		t.Fatalf("rejected preparation reached persistence: %+v", recorder.calls)
+	}
+	if len(fx.collector.events) != 0 {
+		t.Fatalf("rejected preparation published events: %+v", fx.collector.events)
+	}
+}
+
+func TestTagDeletionRESTFailedMutationPublishesNoRefresh(t *testing.T) {
+	fx := newTagMutationRESTFixture(t)
+	projectID, _ := createProjectAPI(t, fx.client, fx.ts, "REST Deletion Failure")
+	recorder := &tagDeletionRESTRecorder{mutationErr: store.ErrNotFound}
+	fx.server.tagDeletions = newTagDeletionRESTService(fx.server, recorder)
+	fx.resetEvents()
+
+	var out apiErrorEnvelope
+	resp, body := doJSON(
+		t,
+		fx.client,
+		http.MethodDelete,
+		fx.ts+"/api/projects/"+strconv.FormatInt(projectID, 10)+"/tags/id/404",
+		nil,
+		&out,
+	)
+	assertTagMutationRESTStatus(t, resp, body, http.StatusNotFound)
+	assertAPIError(t, out, "NOT_FOUND", "")
+	wantCall := tagDeletionRESTCall{
+		method: "durable-id", projectID: projectID, actorUserID: fx.ownerID, tagID: 404,
+	}
+	if len(recorder.calls) != 1 || recorder.calls[0] != wantCall {
+		t.Fatalf("calls=%+v want exactly %+v", recorder.calls, wantCall)
+	}
+	if len(fx.collector.events) != 0 {
+		t.Fatalf("failed mutation published events: %+v", fx.collector.events)
+	}
+}
+
+func assertTagDeletionRESTCalls(t *testing.T, got, want []tagDeletionRESTCall) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("calls=%+v want=%+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("calls[%d]=%+v want=%+v; all calls=%+v", i, got[i], want[i], got)
+		}
+	}
+}
+
+func assertTagDeletionRESTRefreshes(
+	t *testing.T,
+	events []eventbus.Event,
+	wantProjects []int64,
+	wantName string,
+	wantActorUserID int64,
+) {
+	t.Helper()
+	if len(events) != len(wantProjects) {
+		t.Fatalf("events=%+v want projects=%v", events, wantProjects)
+	}
+	for i, projectID := range wantProjects {
+		event := events[i]
+		if event.Type != "board.refresh_needed" || event.ProjectID != projectID {
+			t.Fatalf("event[%d]=%+v want refresh for project %d", i, event, projectID)
+		}
+		var payload refreshNeededPayload
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			t.Fatalf("decode event[%d]: %v", i, err)
+		}
+		if payload.Reason != "tag_deleted" ||
+			payload.Name != wantName ||
+			payload.ActorUserID != wantActorUserID ||
+			payload.LocalID != 0 ||
+			payload.Title != "" {
+			t.Fatalf("payload[%d]=%+v", i, payload)
+		}
+	}
+}

--- a/internal/httpapi/tag_mutation_characterization_test.go
+++ b/internal/httpapi/tag_mutation_characterization_test.go
@@ -1,0 +1,521 @@
+package httpapi
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"scrumboy/internal/eventbus"
+)
+
+type tagMutationRESTFixture struct {
+	ts        string
+	db        *sql.DB
+	client    *http.Client
+	ownerID   int64
+	collector *capturingEventConsumer
+}
+
+func newTagMutationRESTFixture(t *testing.T) *tagMutationRESTFixture {
+	t.Helper()
+	ts, sqlDB, cleanup := newTestHTTPServer(t, "full")
+	t.Cleanup(cleanup)
+	collector := &capturingEventConsumer{}
+	ts.Config.Handler.(*Server).fanout = eventbus.NewFanout(collector)
+	client := newCookieClient(t)
+	owner := bootstrapUserClient(t, client, ts.URL, "Tag Owner", "tag-mutation-owner@example.com", "password123")
+	return &tagMutationRESTFixture{
+		ts: ts.URL, db: sqlDB, client: client,
+		ownerID: int64(owner["id"].(float64)), collector: collector,
+	}
+}
+
+func (fx *tagMutationRESTFixture) resetEvents() {
+	fx.collector.events = nil
+}
+
+func tagMutationPersonalID(t *testing.T, sqlDB *sql.DB, ownerID int64, name string) int64 {
+	t.Helper()
+	var tagID int64
+	if err := sqlDB.QueryRow(`SELECT id FROM tags WHERE user_id = ? AND name = ?`, ownerID, name).Scan(&tagID); err != nil {
+		t.Fatalf("lookup personal tag %q: %v", name, err)
+	}
+	return tagID
+}
+
+func insertTagMutationBoardTag(t *testing.T, sqlDB *sql.DB, projectID int64, name string) int64 {
+	t.Helper()
+	result, err := sqlDB.Exec(`
+INSERT INTO tags(user_id, name, created_at, project_id, color)
+VALUES (NULL, ?, ?, ?, NULL)`, name, time.Now().UTC().UnixMilli(), projectID)
+	if err != nil {
+		t.Fatalf("insert board tag %q: %v", name, err)
+	}
+	tagID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("board tag id %q: %v", name, err)
+	}
+	return tagID
+}
+
+func assertTagMutationRESTStatus(t *testing.T, response *http.Response, body []byte, want int) {
+	t.Helper()
+	if response.StatusCode != want {
+		t.Fatalf("status=%d want=%d body=%s", response.StatusCode, want, body)
+	}
+}
+
+func assertTagMutationRefreshes(t *testing.T, events []eventbus.Event, reason string, wantProjects []int64, wantName string) {
+	t.Helper()
+	if len(events) != len(wantProjects) {
+		t.Fatalf("events=%+v want exactly %d refreshes", events, len(wantProjects))
+	}
+	want := make(map[int64]int, len(wantProjects))
+	for _, projectID := range wantProjects {
+		want[projectID]++
+	}
+	for _, event := range events {
+		if event.Type != "board.refresh_needed" {
+			t.Fatalf("event type=%q want board.refresh_needed; events=%+v", event.Type, events)
+		}
+		var payload refreshNeededPayload
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			t.Fatalf("decode refresh payload: %v", err)
+		}
+		if payload.Reason != reason || payload.Name != wantName || payload.LocalID != 0 || payload.Title != "" {
+			t.Fatalf("payload=%+v want reason=%q name=%q and zero id/title", payload, reason, wantName)
+		}
+		if payload.ActorUserID == 0 {
+			t.Fatalf("authenticated REST mutation omitted actor metadata: %+v", payload)
+		}
+		if want[event.ProjectID] == 0 {
+			t.Fatalf("unexpected project %d in events=%+v; want=%v", event.ProjectID, events, wantProjects)
+		}
+		want[event.ProjectID]--
+	}
+	for projectID, remaining := range want {
+		if remaining != 0 {
+			t.Fatalf("project %d refresh count mismatch: remaining=%d events=%+v", projectID, remaining, events)
+		}
+	}
+}
+
+func doTagMutationRawJSON(t *testing.T, client *http.Client, method, url, body string, out any) (*http.Response, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(method, url, bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Scrumboy", "1")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if out != nil && len(payload) != 0 {
+		if err := json.Unmarshal(payload, out); err != nil {
+			t.Fatalf("decode response %s: %v", payload, err)
+		}
+	}
+	return resp, payload
+}
+
+// TestTagMutationRESTSelectedSurface freezes all ten mutation routes, including the
+// exact refresh reason, affected projects, entity projection, deduplication, and the
+// deliberate absence of refresh publication for the mine color route.
+func TestTagMutationRESTSelectedSurface(t *testing.T) {
+	fx := newTagMutationRESTFixture(t)
+	projectA, slugA := createProjectAPI(t, fx.client, fx.ts, "Tag Mutation A")
+	projectB, slugB := createProjectAPI(t, fx.client, fx.ts, "Tag Mutation B")
+
+	for _, name := range []string{
+		"mine-color", "board-name-color", "numeric-name-color",
+		"mine-delete", "board-name-delete", "numeric-name-delete",
+	} {
+		createTodoAPI(t, fx.client, fx.ts, slugA, "A "+name, name)
+	}
+	for _, name := range []string{"mine-delete", "board-name-delete", "numeric-name-delete"} {
+		createTodoAPI(t, fx.client, fx.ts, slugB, "B "+name, name)
+	}
+	boardSlugColorID := insertTagMutationBoardTag(t, fx.db, projectA, "board-slug-color-id")
+	projectColorID := insertTagMutationBoardTag(t, fx.db, projectA, "project-color-id")
+	boardSlugDeleteID := insertTagMutationBoardTag(t, fx.db, projectA, "board-slug-delete-id")
+	projectDeleteID := insertTagMutationBoardTag(t, fx.db, projectA, "project-delete-id")
+	pid := strconv.FormatInt(projectA, 10)
+
+	t.Run("PATCH /api/tags/mine/{tagId}/color", func(t *testing.T) {
+		fx.resetEvents()
+		tagID := tagMutationPersonalID(t, fx.db, fx.ownerID, "mine-color")
+		resp, body := doJSON(t, fx.client, http.MethodPatch, fx.ts+"/api/tags/mine/"+strconv.FormatInt(tagID, 10)+"/color", map[string]any{"color": "#111111"}, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		assertTagMutationRefreshes(t, fx.collector.events, "tag_color_updated", nil, "")
+	})
+
+	t.Run("PATCH /api/board/{slug}/tags/id/{tagId}/color", func(t *testing.T) {
+		fx.resetEvents()
+		resp, body := doJSON(t, fx.client, http.MethodPatch, fx.ts+"/api/board/"+slugA+"/tags/id/"+strconv.FormatInt(boardSlugColorID, 10)+"/color", map[string]any{"color": "#222222"}, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		assertTagMutationRefreshes(t, fx.collector.events, "tag_color_updated", []int64{projectA}, "")
+	})
+
+	t.Run("PATCH /api/board/{slug}/tags/{tagName}/color", func(t *testing.T) {
+		fx.resetEvents()
+		resp, body := doJSON(t, fx.client, http.MethodPatch, fx.ts+"/api/board/"+slugA+"/tags/board-name-color/color", map[string]any{"color": "#333333"}, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		assertTagMutationRefreshes(t, fx.collector.events, "tag_color_updated", []int64{projectA}, "board-name-color")
+	})
+
+	t.Run("PATCH /api/projects/{id}/tags/id/{tagId}/color", func(t *testing.T) {
+		fx.resetEvents()
+		resp, body := doJSON(t, fx.client, http.MethodPatch, fx.ts+"/api/projects/"+pid+"/tags/id/"+strconv.FormatInt(projectColorID, 10)+"/color", map[string]any{"color": "#444444"}, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		assertTagMutationRefreshes(t, fx.collector.events, "tag_color_updated", []int64{projectA}, "")
+	})
+
+	t.Run("PATCH /api/projects/{id}/tags/{tagName}/color", func(t *testing.T) {
+		fx.resetEvents()
+		resp, body := doJSON(t, fx.client, http.MethodPatch, fx.ts+"/api/projects/"+pid+"/tags/numeric-name-color/color", map[string]any{"color": "#555555"}, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		assertTagMutationRefreshes(t, fx.collector.events, "tag_color_updated", []int64{projectA}, "numeric-name-color")
+	})
+
+	t.Run("DELETE /api/tags/mine/{tagId}", func(t *testing.T) {
+		fx.resetEvents()
+		tagID := tagMutationPersonalID(t, fx.db, fx.ownerID, "mine-delete")
+		resp, body := doJSON(t, fx.client, http.MethodDelete, fx.ts+"/api/tags/mine/"+strconv.FormatInt(tagID, 10), nil, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		assertTagMutationRefreshes(t, fx.collector.events, "tag_deleted", []int64{projectA, projectB}, "")
+	})
+
+	t.Run("DELETE /api/board/{slug}/tags/id/{tagId}", func(t *testing.T) {
+		fx.resetEvents()
+		resp, body := doJSON(t, fx.client, http.MethodDelete, fx.ts+"/api/board/"+slugA+"/tags/id/"+strconv.FormatInt(boardSlugDeleteID, 10), nil, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		assertTagMutationRefreshes(t, fx.collector.events, "tag_deleted", []int64{projectA}, "")
+	})
+
+	t.Run("DELETE /api/board/{slug}/tags/{tagName}", func(t *testing.T) {
+		fx.resetEvents()
+		resp, body := doJSON(t, fx.client, http.MethodDelete, fx.ts+"/api/board/"+slugA+"/tags/board-name-delete", nil, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		assertTagMutationRefreshes(t, fx.collector.events, "tag_deleted", []int64{projectA, projectB}, "board-name-delete")
+	})
+
+	t.Run("DELETE /api/projects/{id}/tags/id/{tagId}", func(t *testing.T) {
+		fx.resetEvents()
+		resp, body := doJSON(t, fx.client, http.MethodDelete, fx.ts+"/api/projects/"+pid+"/tags/id/"+strconv.FormatInt(projectDeleteID, 10), nil, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		assertTagMutationRefreshes(t, fx.collector.events, "tag_deleted", []int64{projectA}, "")
+	})
+
+	t.Run("DELETE /api/projects/{id}/tags/{tagName}", func(t *testing.T) {
+		fx.resetEvents()
+		resp, body := doJSON(t, fx.client, http.MethodDelete, fx.ts+"/api/projects/"+pid+"/tags/numeric-name-delete", nil, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		assertTagMutationRefreshes(t, fx.collector.events, "tag_deleted", []int64{projectA, projectB}, "numeric-name-delete")
+	})
+}
+
+// TestTagMutationRESTColorInputContracts pins the currently inconsistent clear
+// behavior at each distinct REST/store boundary. These differences are compatibility
+// evidence for extraction, not an endorsement of convergence during Phase 23.0.
+func TestTagMutationRESTColorInputContracts(t *testing.T) {
+	fx := newTagMutationRESTFixture(t)
+	projectID, slug := createProjectAPI(t, fx.client, fx.ts, "Tag Color Inputs")
+	createTodoAPI(t, fx.client, fx.ts, slug, "personal", "personal-color")
+	personalID := tagMutationPersonalID(t, fx.db, fx.ownerID, "personal-color")
+	boardID := insertTagMutationBoardTag(t, fx.db, projectID, "board-color")
+	mineURL := fx.ts + "/api/tags/mine/" + strconv.FormatInt(personalID, 10) + "/color"
+	nameURL := fx.ts + "/api/projects/" + strconv.FormatInt(projectID, 10) + "/tags/personal-color/color"
+	idURL := fx.ts + "/api/projects/" + strconv.FormatInt(projectID, 10) + "/tags/id/" + strconv.FormatInt(boardID, 10) + "/color"
+
+	for _, tc := range []struct {
+		name       string
+		url        string
+		value      any
+		wantStatus int
+		wantReason string
+	}{
+		{"mine trims valid hex", mineURL, "  #a1b2c3  ", http.StatusNoContent, ""},
+		{"mine null clear", mineURL, nil, http.StatusNoContent, ""},
+		{"mine missing preference null clear", mineURL, nil, http.StatusNoContent, ""},
+		{"mine empty clear", mineURL, "", http.StatusNoContent, ""},
+		{"mine whitespace invalid", mineURL, "   ", http.StatusBadRequest, "invalid_tag_color"},
+		{"mine malformed invalid", mineURL, "blue", http.StatusBadRequest, "invalid_tag_color"},
+		{"name trims valid hex", nameURL, "  #b1c2d3  ", http.StatusNoContent, ""},
+		{"name null clear", nameURL, nil, http.StatusNoContent, ""},
+		{"name missing preference null clear", nameURL, nil, http.StatusNoContent, ""},
+		{"name empty clear", nameURL, "", http.StatusNoContent, ""},
+		{"name whitespace clear", nameURL, "   ", http.StatusNoContent, ""},
+		{"name malformed invalid", nameURL, "blue", http.StatusBadRequest, "invalid_tag_color"},
+		{"board id trims valid hex", idURL, "  #c1d2e3  ", http.StatusNoContent, ""},
+		{"board id null clear", idURL, nil, http.StatusNoContent, ""},
+		{"board id missing preference null clear", idURL, nil, http.StatusNoContent, ""},
+		{"board id empty clear", idURL, "", http.StatusNoContent, ""},
+		{"board id whitespace invalid", idURL, "   ", http.StatusBadRequest, "invalid_tag_color"},
+		{"board id malformed invalid", idURL, "blue", http.StatusBadRequest, "invalid_tag_color"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx.resetEvents()
+			var out apiErrorEnvelope
+			resp, body := doJSON(t, fx.client, http.MethodPatch, tc.url, map[string]any{"color": tc.value}, &out)
+			assertTagMutationRESTStatus(t, resp, body, tc.wantStatus)
+			if tc.wantReason != "" {
+				assertAPIError(t, out, "VALIDATION_ERROR", "", tc.wantReason)
+				if len(fx.collector.events) != 0 {
+					t.Fatalf("failed mutation published events: %+v", fx.collector.events)
+				}
+			}
+		})
+	}
+}
+
+func TestTagMutationRESTPersonalColorCrossProjectEffects(t *testing.T) {
+	fx := newTagMutationRESTFixture(t)
+	projectA, slugA := createProjectAPI(t, fx.client, fx.ts, "Tag Color Cross Project A")
+	projectB, slugB := createProjectAPI(t, fx.client, fx.ts, "Tag Color Cross Project B")
+	createTodoAPI(t, fx.client, fx.ts, slugA, "A", "cross-project")
+	createTodoAPI(t, fx.client, fx.ts, slugB, "B", "cross-project")
+	tagID := tagMutationPersonalID(t, fx.db, fx.ownerID, "cross-project")
+
+	fx.resetEvents()
+	resp, body := doJSON(t, fx.client, http.MethodPatch, fx.ts+"/api/projects/"+strconv.FormatInt(projectA, 10)+"/tags/cross-project/color", map[string]any{"color": "#123456"}, nil)
+	assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+	assertTagMutationRefreshes(t, fx.collector.events, "tag_color_updated", []int64{projectA}, "cross-project")
+	for _, projectID := range []int64{projectA, projectB} {
+		tag := findWireTag(listProjectTags(t, fx.client, fx.ts, projectID), "cross-project")
+		if tag == nil || tag.Color == nil || *tag.Color != "#123456" {
+			t.Fatalf("project %d color=%+v want cross-project preference #123456", projectID, tag)
+		}
+	}
+
+	fx.resetEvents()
+	resp, body = doJSON(t, fx.client, http.MethodPatch, fx.ts+"/api/tags/mine/"+strconv.FormatInt(tagID, 10)+"/color", map[string]any{"color": "#654321"}, nil)
+	assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+	assertTagMutationRefreshes(t, fx.collector.events, "tag_color_updated", nil, "")
+	for _, projectID := range []int64{projectA, projectB} {
+		tag := findWireTag(listProjectTags(t, fx.client, fx.ts, projectID), "cross-project")
+		if tag == nil || tag.Color == nil || *tag.Color != "#654321" {
+			t.Fatalf("project %d color=%+v want cross-project mine preference #654321", projectID, tag)
+		}
+	}
+}
+
+func TestTagMutationRESTDeleteUnusedMinePublishesNoRefresh(t *testing.T) {
+	fx := newTagMutationRESTFixture(t)
+	result, err := fx.db.Exec(`INSERT INTO tags(user_id, name, created_at, project_id, color) VALUES (?, 'unused-mine', ?, NULL, NULL)`, fx.ownerID, time.Now().UTC().UnixMilli())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tagID, _ := result.LastInsertId()
+	fx.resetEvents()
+	resp, body := doJSON(t, fx.client, http.MethodDelete, fx.ts+"/api/tags/mine/"+strconv.FormatInt(tagID, 10), nil, nil)
+	assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+	assertTagMutationRefreshes(t, fx.collector.events, "tag_deleted", nil, "")
+}
+
+func TestTagMutationRESTFailedSelectedRoutesPublishNothing(t *testing.T) {
+	fx := newTagMutationRESTFixture(t)
+	projectID, slug := createProjectAPI(t, fx.client, fx.ts, "Tag Failed Routes")
+	pid := strconv.FormatInt(projectID, 10)
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+		body   any
+	}{
+		{"mine color", http.MethodPatch, "/api/tags/mine/999999/color", map[string]any{"color": "#123456"}},
+		{"board id color", http.MethodPatch, "/api/board/" + slug + "/tags/id/999999/color", map[string]any{"color": "#123456"}},
+		{"board name color", http.MethodPatch, "/api/board/" + slug + "/tags/missing/color", map[string]any{"color": "#123456"}},
+		{"project id color", http.MethodPatch, "/api/projects/" + pid + "/tags/id/999999/color", map[string]any{"color": "#123456"}},
+		{"project name color", http.MethodPatch, "/api/projects/" + pid + "/tags/missing/color", map[string]any{"color": "#123456"}},
+		{"mine delete", http.MethodDelete, "/api/tags/mine/999999", nil},
+		{"board id delete", http.MethodDelete, "/api/board/" + slug + "/tags/id/999999", nil},
+		{"board name delete", http.MethodDelete, "/api/board/" + slug + "/tags/missing", nil},
+		{"project id delete", http.MethodDelete, "/api/projects/" + pid + "/tags/id/999999", nil},
+		{"project name delete", http.MethodDelete, "/api/projects/" + pid + "/tags/missing", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx.resetEvents()
+			resp, body := doJSON(t, fx.client, tc.method, fx.ts+tc.path, tc.body, nil)
+			assertTagMutationRESTStatus(t, resp, body, http.StatusNotFound)
+			if len(fx.collector.events) != 0 {
+				t.Fatalf("failed selected route published events: %+v", fx.collector.events)
+			}
+		})
+	}
+}
+
+// TestTagMutationRESTErrorPrecedence freezes transport ordering that an application
+// extraction must retain. Every failure is also asserted to publish no refresh.
+func TestTagMutationRESTErrorPrecedence(t *testing.T) {
+	fx := newTagMutationRESTFixture(t)
+	projectA, _ := createProjectAPI(t, fx.client, fx.ts, "Tag Ordering A")
+	projectB, _ := createProjectAPI(t, fx.client, fx.ts, "Tag Ordering B")
+	foreignTagID := insertTagMutationBoardTag(t, fx.db, projectB, "foreign")
+	pidA := strconv.FormatInt(projectA, 10)
+	unauthenticated := &http.Client{}
+
+	for _, tc := range []struct {
+		name       string
+		client     *http.Client
+		method     string
+		url        string
+		body       string
+		wantStatus int
+		wantCode   string
+		wantReason string
+	}{
+		{"mine auth before malformed id", unauthenticated, http.MethodPatch, fx.ts + "/api/tags/mine/not-an-id/color", `{`, http.StatusUnauthorized, "UNAUTHORIZED", ""},
+		{"numeric auth before malformed id", unauthenticated, http.MethodPatch, fx.ts + "/api/projects/" + pidA + "/tags/id/not-an-id/color", `{`, http.StatusUnauthorized, "UNAUTHORIZED", ""},
+		{"inaccessible slug before malformed body", fx.client, http.MethodPatch, fx.ts + "/api/board/missing-board/tags/id/1/color", `{`, http.StatusNotFound, "NOT_FOUND", ""},
+		{"wrong project before board role", fx.client, http.MethodPatch, fx.ts + "/api/projects/" + pidA + "/tags/id/" + strconv.FormatInt(foreignTagID, 10) + "/color", `{"color":"#123456"}`, http.StatusNotFound, "NOT_FOUND", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx.resetEvents()
+			var out apiErrorEnvelope
+			resp, body := doTagMutationRawJSON(t, tc.client, tc.method, tc.url, tc.body, &out)
+			assertTagMutationRESTStatus(t, resp, body, tc.wantStatus)
+			assertAPIError(t, out, tc.wantCode, "", tc.wantReason)
+			if len(fx.collector.events) != 0 {
+				t.Fatalf("failed mutation published events: %+v", fx.collector.events)
+			}
+		})
+	}
+
+	t.Run("creator temporary board name delete refused", func(t *testing.T) {
+		slug := createAnonBoardViaHTTP(t, fx.client, fx.ts)
+		createTodoAPI(t, fx.client, fx.ts, slug, "temporary", "temporary-name")
+		fx.resetEvents()
+		var out apiErrorEnvelope
+		resp, body := doJSON(t, fx.client, http.MethodDelete, fx.ts+"/api/board/"+slug+"/tags/temporary-name", nil, &out)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusBadRequest)
+		assertAPIError(t, out, "VALIDATION_ERROR", "", "name_based_tag_route_not_allowed")
+		if len(fx.collector.events) != 0 {
+			t.Fatalf("refused temporary name delete published events: %+v", fx.collector.events)
+		}
+	})
+
+	t.Run("expired board hides missing tag", func(t *testing.T) {
+		slug := createAnonBoardViaHTTP(t, fx.client, fx.ts)
+		projectID := projectIDBySlug(t, fx.db, slug)
+		if _, err := fx.db.Exec(`UPDATE projects SET expires_at = ? WHERE id = ?`, time.Now().UTC().Add(-time.Hour).UnixMilli(), projectID); err != nil {
+			t.Fatalf("expire board: %v", err)
+		}
+		fx.resetEvents()
+		var out apiErrorEnvelope
+		resp, body := doJSON(t, fx.client, http.MethodDelete, fx.ts+"/api/board/"+slug+"/tags/id/999999", nil, &out)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNotFound)
+		assertAPIError(t, out, "NOT_FOUND", "")
+		if len(fx.collector.events) != 0 {
+			t.Fatalf("expired-board failure published events: %+v", fx.collector.events)
+		}
+	})
+}
+
+// TestTagMutationRESTTemporaryAndAnonymousNameResolution distinguishes creator-owned
+// temporary boards from unowned anonymous boards and freezes the anonymous name
+// resolution order (board-scoped row first, signed-in personal fallback second).
+func TestTagMutationRESTTemporaryAndAnonymousNameResolution(t *testing.T) {
+	fx := newTagMutationRESTFixture(t)
+
+	t.Run("creator-owned temporary id and name color", func(t *testing.T) {
+		slug := createAnonBoardViaHTTP(t, fx.client, fx.ts)
+		projectID := projectIDBySlug(t, fx.db, slug)
+		createTodoAPI(t, fx.client, fx.ts, slug, "temporary", "creator-tag")
+		tagID := tagMutationPersonalID(t, fx.db, fx.ownerID, "creator-tag")
+
+		fx.resetEvents()
+		resp, body := doJSON(t, fx.client, http.MethodPatch, fx.ts+"/api/board/"+slug+"/tags/id/"+strconv.FormatInt(tagID, 10)+"/color", map[string]any{"color": "#123456"}, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		assertTagMutationRefreshes(t, fx.collector.events, "tag_color_updated", []int64{projectID}, "")
+
+		fx.resetEvents()
+		resp, body = doJSON(t, fx.client, http.MethodPatch, fx.ts+"/api/board/"+slug+"/tags/creator-tag/color", map[string]any{"color": "#654321"}, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		assertTagMutationRefreshes(t, fx.collector.events, "tag_color_updated", []int64{projectID}, "creator-tag")
+	})
+
+	t.Run("anonymous board-scoped name wins", func(t *testing.T) {
+		anonymousClient := newCookieClient(t)
+		slug := createAnonBoardViaHTTP(t, anonymousClient, fx.ts)
+		projectID := projectIDBySlug(t, fx.db, slug)
+		createTodoAPI(t, anonymousClient, fx.ts, slug, "anonymous", "board-name")
+
+		fx.resetEvents()
+		resp, body := doJSON(t, anonymousClient, http.MethodPatch, fx.ts+"/api/board/"+slug+"/tags/board-name/color", map[string]any{"color": "#abcdef"}, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		// Anonymous requests intentionally have no actor metadata, so assert the wire
+		// dimensions directly instead of using the authenticated helper.
+		if len(fx.collector.events) != 1 || fx.collector.events[0].ProjectID != projectID {
+			t.Fatalf("anonymous color events=%+v", fx.collector.events)
+		}
+
+		fx.resetEvents()
+		resp, body = doJSON(t, anonymousClient, http.MethodDelete, fx.ts+"/api/board/"+slug+"/tags/board-name", nil, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		if len(fx.collector.events) != 1 || fx.collector.events[0].ProjectID != projectID {
+			t.Fatalf("anonymous delete events=%+v", fx.collector.events)
+		}
+	})
+
+	t.Run("anonymous board personal fallback requires signed-in owner", func(t *testing.T) {
+		anonymousClient := newCookieClient(t)
+		slug := createAnonBoardViaHTTP(t, anonymousClient, fx.ts)
+		projectID := projectIDBySlug(t, fx.db, slug)
+		createTodoAPI(t, anonymousClient, fx.ts, slug, "empty")
+		var todoID int64
+		if err := fx.db.QueryRow(`SELECT id FROM todos WHERE project_id = ? ORDER BY id DESC LIMIT 1`, projectID).Scan(&todoID); err != nil {
+			t.Fatalf("lookup anonymous todo: %v", err)
+		}
+		result, err := fx.db.Exec(`INSERT INTO tags(user_id, name, created_at, project_id, color) VALUES (?, 'personal-fallback', ?, NULL, NULL)`, fx.ownerID, time.Now().UTC().UnixMilli())
+		if err != nil {
+			t.Fatalf("insert personal fallback tag: %v", err)
+		}
+		tagID, _ := result.LastInsertId()
+		if _, err := fx.db.Exec(`INSERT INTO todo_tags(todo_id, tag_id) VALUES (?, ?)`, todoID, tagID); err != nil {
+			t.Fatalf("link personal fallback tag: %v", err)
+		}
+
+		fx.resetEvents()
+		var unauthErr apiErrorEnvelope
+		resp, body := doJSON(t, anonymousClient, http.MethodDelete, fx.ts+"/api/board/"+slug+"/tags/personal-fallback", nil, &unauthErr)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusUnauthorized)
+		assertAPIError(t, unauthErr, "UNAUTHORIZED", "")
+		if len(fx.collector.events) != 0 {
+			t.Fatalf("unauthenticated fallback published events: %+v", fx.collector.events)
+		}
+
+		resp, body = doJSON(t, fx.client, http.MethodDelete, fx.ts+"/api/board/"+slug+"/tags/personal-fallback", nil, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNoContent)
+		assertTagMutationRefreshes(t, fx.collector.events, "tag_deleted", []int64{projectID}, "personal-fallback")
+	})
+}
+
+func TestTagMutationRESTAnonymousModeNumericRoutesUnavailable(t *testing.T) {
+	ts, _, cleanup := newTestHTTPServer(t, "anonymous")
+	defer cleanup()
+	for _, tc := range []struct {
+		method string
+		path   string
+		body   any
+	}{
+		{http.MethodPatch, "/api/projects/1/tags/id/1/color", map[string]any{"color": "#123456"}},
+		{http.MethodPatch, "/api/projects/1/tags/name/color", map[string]any{"color": "#123456"}},
+		{http.MethodDelete, "/api/projects/1/tags/id/1", nil},
+		{http.MethodDelete, "/api/projects/1/tags/name", nil},
+	} {
+		resp, body := doJSON(t, ts.Client(), tc.method, ts.URL+tc.path, tc.body, nil)
+		assertTagMutationRESTStatus(t, resp, body, http.StatusNotFound)
+	}
+}

--- a/internal/httpapi/tag_mutation_characterization_test.go
+++ b/internal/httpapi/tag_mutation_characterization_test.go
@@ -18,6 +18,7 @@ type tagMutationRESTFixture struct {
 	db        *sql.DB
 	client    *http.Client
 	ownerID   int64
+	server    *Server
 	collector *capturingEventConsumer
 }
 
@@ -31,7 +32,7 @@ func newTagMutationRESTFixture(t *testing.T) *tagMutationRESTFixture {
 	owner := bootstrapUserClient(t, client, ts.URL, "Tag Owner", "tag-mutation-owner@example.com", "password123")
 	return &tagMutationRESTFixture{
 		ts: ts.URL, db: sqlDB, client: client,
-		ownerID: int64(owner["id"].(float64)), collector: collector,
+		ownerID: int64(owner["id"].(float64)), server: ts.Config.Handler.(*Server), collector: collector,
 	}
 }
 

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -14,6 +14,7 @@ import (
 	membershipapp "scrumboy/internal/application/membership"
 	priorityapp "scrumboy/internal/application/priority"
 	sprintapp "scrumboy/internal/application/sprint"
+	tagapp "scrumboy/internal/application/tag"
 	todoapp "scrumboy/internal/application/todo"
 	todolinkapp "scrumboy/internal/application/todolink"
 	workflowapp "scrumboy/internal/application/workflow"
@@ -100,6 +101,7 @@ type Adapter struct {
 	sprintDefinitions    *sprintapp.MCPDefinitionService
 	sprintLifecycle      *sprintapp.MCPLifecycleService
 	sprintDeletions      *sprintapp.MCPDeletionService
+	tagColors            *tagapp.MCPColorService
 	mode                 string
 	tools                toolRegistry
 	publicOrigin         *publicorigin.Resolver
@@ -178,6 +180,15 @@ func New(st storeAPI, opts Options) *Adapter {
 			Roles:     st,
 			Sprints:   st,
 			Deletions: st,
+		}),
+		tagColors: tagapp.NewMCPColorService(tagapp.MCPColorServiceDependencies{
+			Access:           st,
+			MineRead:         st,
+			ProjectRead:      st,
+			MineColor:        st,
+			DurableIDColor:   st,
+			TemporaryIDColor: st,
+			DurableNameColor: st,
 		}),
 		mode:         mode,
 		tools:        make(toolRegistry),

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -102,6 +102,7 @@ type Adapter struct {
 	sprintLifecycle      *sprintapp.MCPLifecycleService
 	sprintDeletions      *sprintapp.MCPDeletionService
 	tagColors            *tagapp.MCPColorService
+	tagDeletions         *tagapp.MCPDeletionService
 	mode                 string
 	tools                toolRegistry
 	publicOrigin         *publicorigin.Resolver
@@ -189,6 +190,12 @@ func New(st storeAPI, opts Options) *Adapter {
 			DurableIDColor:   st,
 			TemporaryIDColor: st,
 			DurableNameColor: st,
+		}),
+		tagDeletions: tagapp.NewMCPDeletionService(tagapp.MCPDeletionServiceDependencies{
+			Access:        st,
+			MineRead:      st,
+			ProjectScoped: st,
+			Rows:          st,
 		}),
 		mode:         mode,
 		tools:        make(toolRegistry),

--- a/internal/mcp/tag_color_error_mapping_test.go
+++ b/internal/mcp/tag_color_error_mapping_test.go
@@ -1,0 +1,132 @@
+package mcp
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	tagapp "scrumboy/internal/application/tag"
+	"scrumboy/internal/store"
+)
+
+func assertTagColorAdapterError(
+	t *testing.T,
+	got *adapterError,
+	wantStatus int,
+	wantCode string,
+	wantMessage string,
+	wantDetails any,
+) {
+	t.Helper()
+	if got.Status != wantStatus || got.Code != wantCode || got.Message != wantMessage || !reflect.DeepEqual(got.Details, wantDetails) {
+		t.Fatalf(
+			"mapped error = {status:%d code:%q message:%q details:%#v}, want {status:%d code:%q message:%q details:%#v}",
+			got.Status,
+			got.Code,
+			got.Message,
+			got.Details,
+			wantStatus,
+			wantCode,
+			wantMessage,
+			wantDetails,
+		)
+	}
+}
+
+func TestMapTagColorPrepareError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantStatus  int
+		wantCode    string
+		wantMessage string
+	}{
+		{
+			name:        "actor required",
+			err:         tagapp.ErrActorRequired,
+			wantStatus:  http.StatusUnauthorized,
+			wantCode:    CodeAuthRequired,
+			wantMessage: "Sign-in required for this tool",
+		},
+		{
+			name:        "wrapped actor required",
+			err:         fmt.Errorf("prepare mine: %w", tagapp.ErrActorRequired),
+			wantStatus:  http.StatusUnauthorized,
+			wantCode:    CodeAuthRequired,
+			wantMessage: "Sign-in required for this tool",
+		},
+		{
+			name:        "maintainer required",
+			err:         tagapp.ErrMaintainerRequired,
+			wantStatus:  http.StatusForbidden,
+			wantCode:    CodeForbidden,
+			wantMessage: "maintainer or higher required",
+		},
+		{
+			name:        "wrapped maintainer required",
+			err:         fmt.Errorf("prepare project: %w", tagapp.ErrMaintainerRequired),
+			wantStatus:  http.StatusForbidden,
+			wantCode:    CodeForbidden,
+			wantMessage: "maintainer or higher required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assertTagColorAdapterError(
+				t,
+				mapTagColorPrepareError(tc.err),
+				tc.wantStatus,
+				tc.wantCode,
+				tc.wantMessage,
+				nil,
+			)
+		})
+	}
+
+	t.Run("store errors retain shared mapping", func(t *testing.T) {
+		got := mapTagColorPrepareError(store.ErrNotFound)
+		want := mapStoreError(store.ErrNotFound)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("mapped = %#v, want shared store mapping %#v", got, want)
+		}
+	})
+}
+
+func TestMapTagColorUpdateError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "projection missing", err: tagapp.ErrColorProjectionMissing},
+		{name: "wrapped projection missing", err: fmt.Errorf("post-read: %w", tagapp.ErrColorProjectionMissing)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mapTagColorUpdateError(tc.err)
+			wantDetails := map[string]any{"detail": "updated project tag not found in post-read"}
+			assertTagColorAdapterError(
+				t,
+				got,
+				http.StatusInternalServerError,
+				CodeInternal,
+				"internal error",
+				wantDetails,
+			)
+			if got.Cause == nil || got.Cause.Error() != wantDetails["detail"] {
+				t.Fatalf("internal cause = %v, want legacy post-read diagnostic", got.Cause)
+			}
+			if details := clientErrorDetails(got); len(details) != 0 {
+				t.Fatalf("public internal details = %#v, want empty", details)
+			}
+		})
+	}
+
+	t.Run("store errors retain shared mapping", func(t *testing.T) {
+		got := mapTagColorUpdateError(store.ErrNotFound)
+		want := mapStoreError(store.ErrNotFound)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("mapped = %#v, want shared store mapping %#v", got, want)
+		}
+	})
+}

--- a/internal/mcp/tag_deletion_error_mapping_test.go
+++ b/internal/mcp/tag_deletion_error_mapping_test.go
@@ -1,0 +1,174 @@
+package mcp
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	tagapp "scrumboy/internal/application/tag"
+	"scrumboy/internal/store"
+)
+
+func assertTagDeletionAdapterError(
+	t *testing.T,
+	got *adapterError,
+	wantStatus int,
+	wantCode string,
+	wantMessage string,
+	wantDetails any,
+) {
+	t.Helper()
+	if got.Status != wantStatus ||
+		got.Code != wantCode ||
+		got.Message != wantMessage ||
+		!reflect.DeepEqual(got.Details, wantDetails) {
+		t.Fatalf(
+			"mapped error = {status:%d code:%q message:%q details:%#v}, want {status:%d code:%q message:%q details:%#v}",
+			got.Status,
+			got.Code,
+			got.Message,
+			got.Details,
+			wantStatus,
+			wantCode,
+			wantMessage,
+			wantDetails,
+		)
+	}
+}
+
+func TestMapTagDeletionPrepareError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantStatus  int
+		wantCode    string
+		wantMessage string
+	}{
+		{
+			name:        "actor required",
+			err:         tagapp.ErrActorRequired,
+			wantStatus:  http.StatusUnauthorized,
+			wantCode:    CodeAuthRequired,
+			wantMessage: "Sign-in required for this tool",
+		},
+		{
+			name:        "wrapped actor required",
+			err:         fmt.Errorf("prepare mine deletion: %w", tagapp.ErrActorRequired),
+			wantStatus:  http.StatusUnauthorized,
+			wantCode:    CodeAuthRequired,
+			wantMessage: "Sign-in required for this tool",
+		},
+		{
+			name:        "maintainer required",
+			err:         tagapp.ErrMaintainerRequired,
+			wantStatus:  http.StatusForbidden,
+			wantCode:    CodeForbidden,
+			wantMessage: "maintainer or higher required",
+		},
+		{
+			name:        "wrapped maintainer required",
+			err:         fmt.Errorf("prepare project deletion: %w", tagapp.ErrMaintainerRequired),
+			wantStatus:  http.StatusForbidden,
+			wantCode:    CodeForbidden,
+			wantMessage: "maintainer or higher required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assertTagDeletionAdapterError(
+				t,
+				mapTagDeletionPrepareError(tc.err),
+				tc.wantStatus,
+				tc.wantCode,
+				tc.wantMessage,
+				nil,
+			)
+		})
+	}
+
+	for _, err := range []error{store.ErrNotFound, store.ErrUnauthorized} {
+		got := mapTagDeletionPrepareError(err)
+		want := mapStoreError(err)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("preparation error %v mapped to %#v, want shared store mapping %#v", err, got, want)
+		}
+	}
+}
+
+func TestMapTagDeletionExecuteError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantStatus  int
+		wantCode    string
+		wantMessage string
+	}{
+		{
+			name:        "not found",
+			err:         store.ErrNotFound,
+			wantStatus:  http.StatusNotFound,
+			wantCode:    CodeNotFound,
+			wantMessage: "not found",
+		},
+		{
+			name:        "wrapped not found",
+			err:         fmt.Errorf("delete mine tag: %w", store.ErrNotFound),
+			wantStatus:  http.StatusNotFound,
+			wantCode:    CodeNotFound,
+			wantMessage: "not found",
+		},
+		{
+			name:        "unauthorized",
+			err:         store.ErrUnauthorized,
+			wantStatus:  http.StatusForbidden,
+			wantCode:    CodeForbidden,
+			wantMessage: store.ErrUnauthorized.Error(),
+		},
+		{
+			name:       "wrapped unauthorized preserves input text",
+			err:        fmt.Errorf("delete project tag: %w", store.ErrUnauthorized),
+			wantStatus: http.StatusForbidden,
+			wantCode:   CodeForbidden,
+		},
+		{
+			name:        "conflict",
+			err:         store.ErrConflict,
+			wantStatus:  http.StatusConflict,
+			wantCode:    CodeConflict,
+			wantMessage: store.ErrConflict.Error(),
+		},
+		{
+			name:       "wrapped conflict preserves input text",
+			err:        fmt.Errorf("delete mine tag: %w", store.ErrConflict),
+			wantStatus: http.StatusConflict,
+			wantCode:   CodeConflict,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wantMessage := tc.wantMessage
+			if wantMessage == "" {
+				wantMessage = tc.err.Error()
+			}
+			assertTagDeletionAdapterError(
+				t,
+				mapTagDeletionExecuteError(tc.err),
+				tc.wantStatus,
+				tc.wantCode,
+				wantMessage,
+				nil,
+			)
+		})
+	}
+
+	t.Run("other store errors retain shared mapping", func(t *testing.T) {
+		got := mapTagDeletionExecuteError(store.ErrForbidden)
+		want := mapStoreError(store.ErrForbidden)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("mapped = %#v, want shared store mapping %#v", got, want)
+		}
+	})
+}

--- a/internal/mcp/tag_mutation_transport_contract_test.go
+++ b/internal/mcp/tag_mutation_transport_contract_test.go
@@ -1,0 +1,699 @@
+package mcp_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"scrumboy/internal/db"
+	"scrumboy/internal/httpapi"
+	"scrumboy/internal/mcp"
+	"scrumboy/internal/migrate"
+	"scrumboy/internal/store"
+)
+
+type tagMutationMCPStore struct {
+	*store.Store
+
+	mu sync.Mutex
+
+	active  bool
+	trace   []string
+	mutated bool
+
+	postReadErr error
+	omitPostTag bool
+	targetTagID int64
+	targetName  string
+
+	projectReadCalls int
+	mineReadCalls    int
+	updateCalls      int
+	deleteCalls      int
+}
+
+func (s *tagMutationMCPStore) activate() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.active = true
+	s.trace = nil
+	s.mutated = false
+	s.projectReadCalls = 0
+	s.mineReadCalls = 0
+	s.updateCalls = 0
+	s.deleteCalls = 0
+}
+
+func (s *tagMutationMCPStore) record(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.active {
+		return false
+	}
+	s.trace = append(s.trace, name)
+	return true
+}
+
+func (s *tagMutationMCPStore) traceSnapshot() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.trace...)
+}
+
+func (s *tagMutationMCPStore) GetProjectContextBySlug(ctx context.Context, slug string, mode store.Mode) (store.ProjectContext, error) {
+	if !s.record("access") {
+		return s.Store.GetProjectContextBySlug(ctx, slug, mode)
+	}
+	return s.Store.GetProjectContextBySlug(ctx, slug, mode)
+}
+
+func (s *tagMutationMCPStore) ListUserTags(ctx context.Context, userID int64) ([]store.TagWithColor, error) {
+	if !s.record("mine-read") {
+		return s.Store.ListUserTags(ctx, userID)
+	}
+	s.mu.Lock()
+	s.mineReadCalls++
+	s.mu.Unlock()
+	return s.Store.ListUserTags(ctx, userID)
+}
+
+func (s *tagMutationMCPStore) ListTagCounts(ctx context.Context, pc *store.ProjectContext) ([]store.TagCount, error) {
+	s.mu.Lock()
+	if !s.active {
+		s.mu.Unlock()
+		return s.Store.ListTagCounts(ctx, pc)
+	}
+	s.projectReadCalls++
+	isPost := s.mutated
+	stage := "project-read-pre"
+	if isPost {
+		stage = "project-read-post"
+	}
+	s.trace = append(s.trace, stage)
+	postErr := s.postReadErr
+	omit := s.omitPostTag
+	targetID := s.targetTagID
+	targetName := s.targetName
+	s.mu.Unlock()
+	if isPost && postErr != nil {
+		return nil, postErr
+	}
+	tags, err := s.Store.ListTagCounts(ctx, pc)
+	if err != nil || !isPost || !omit {
+		return tags, err
+	}
+	filtered := tags[:0]
+	for _, tag := range tags {
+		if (targetID != 0 && tag.TagID == targetID) || (targetName != "" && tag.Name == targetName) {
+			continue
+		}
+		filtered = append(filtered, tag)
+	}
+	return filtered, nil
+}
+
+func (s *tagMutationMCPStore) UpdateTagColor(ctx context.Context, viewerUserID *int64, tagID int64, color *string) error {
+	if !s.record("mine-color") {
+		return s.Store.UpdateTagColor(ctx, viewerUserID, tagID, color)
+	}
+	s.mu.Lock()
+	s.updateCalls++
+	s.mu.Unlock()
+	return s.Store.UpdateTagColor(ctx, viewerUserID, tagID, color)
+}
+
+func (s *tagMutationMCPStore) UpdateTagColorForDurableProjectByID(ctx context.Context, projectID, viewerUserID, tagID int64, color *string) error {
+	if !s.record("durable-id-color") {
+		return s.Store.UpdateTagColorForDurableProjectByID(ctx, projectID, viewerUserID, tagID, color)
+	}
+	s.mu.Lock()
+	s.updateCalls++
+	s.mu.Unlock()
+	err := s.Store.UpdateTagColorForDurableProjectByID(ctx, projectID, viewerUserID, tagID, color)
+	if err == nil {
+		s.mu.Lock()
+		s.mutated = true
+		s.mu.Unlock()
+	}
+	return err
+}
+
+func (s *tagMutationMCPStore) UpdateTagColorForTemporaryBoard(ctx context.Context, projectID int64, viewerUserID *int64, tagID int64, color *string) error {
+	if !s.record("temporary-id-color") {
+		return s.Store.UpdateTagColorForTemporaryBoard(ctx, projectID, viewerUserID, tagID, color)
+	}
+	s.mu.Lock()
+	s.updateCalls++
+	s.mu.Unlock()
+	err := s.Store.UpdateTagColorForTemporaryBoard(ctx, projectID, viewerUserID, tagID, color)
+	if err == nil {
+		s.mu.Lock()
+		s.mutated = true
+		s.mu.Unlock()
+	}
+	return err
+}
+
+func (s *tagMutationMCPStore) SetViewerTagColorByName(ctx context.Context, projectID, viewerUserID int64, name string, color *string) error {
+	if !s.record("name-color") {
+		return s.Store.SetViewerTagColorByName(ctx, projectID, viewerUserID, name, color)
+	}
+	s.mu.Lock()
+	s.updateCalls++
+	s.mu.Unlock()
+	err := s.Store.SetViewerTagColorByName(ctx, projectID, viewerUserID, name, color)
+	if err == nil {
+		s.mu.Lock()
+		s.mutated = true
+		s.mu.Unlock()
+	}
+	return err
+}
+
+func (s *tagMutationMCPStore) GetProjectScopedTagByID(ctx context.Context, projectID, tagID int64) (store.TagWithColor, error) {
+	if !s.record("project-target") {
+		return s.Store.GetProjectScopedTagByID(ctx, projectID, tagID)
+	}
+	return s.Store.GetProjectScopedTagByID(ctx, projectID, tagID)
+}
+
+func (s *tagMutationMCPStore) DeleteTag(ctx context.Context, userID, tagID int64, isAnonymousBoard bool) error {
+	if !s.record("delete") {
+		return s.Store.DeleteTag(ctx, userID, tagID, isAnonymousBoard)
+	}
+	s.mu.Lock()
+	s.deleteCalls++
+	s.mu.Unlock()
+	err := s.Store.DeleteTag(ctx, userID, tagID, isAnonymousBoard)
+	if err == nil {
+		s.mu.Lock()
+		s.mutated = true
+		s.mu.Unlock()
+	}
+	return err
+}
+
+type tagMutationMCPFixture struct {
+	ts      *httptest.Server
+	db      *sql.DB
+	st      *store.Store
+	wrapped *tagMutationMCPStore
+	client  *http.Client
+	ownerID int64
+	ctx     context.Context
+	project store.Project
+}
+
+func newTagMutationMCPFixture(t *testing.T, name string) *tagMutationMCPFixture {
+	t.Helper()
+	sqlDB, err := db.Open(filepath.Join(t.TempDir(), "app.db"), db.Options{
+		BusyTimeout: 5000,
+		JournalMode: "WAL",
+		Synchronous: "FULL",
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := migrate.Apply(context.Background(), sqlDB); err != nil {
+		_ = sqlDB.Close()
+		t.Fatalf("migrate: %v", err)
+	}
+	st := store.New(sqlDB, nil)
+	wrapped := &tagMutationMCPStore{Store: st}
+	srv := httpapi.NewServer(wrapped, httpapi.Options{
+		MaxRequestBody: 1 << 20,
+		ScrumboyMode:   "full",
+		MCPHandler:     mcp.New(wrapped, mcp.Options{Mode: "full"}),
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(func() {
+		ts.Close()
+		_ = sqlDB.Close()
+	})
+	client := newCookieClient(t, ts)
+	bootstrapUser(t, client, ts.URL)
+	ownerID := firstUserID(t, sqlDB)
+	ctx := store.WithUserID(context.Background(), ownerID)
+	project, err := st.CreateProject(ctx, name)
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	return &tagMutationMCPFixture{
+		ts: ts, db: sqlDB, st: st, wrapped: wrapped, client: client,
+		ownerID: ownerID, ctx: ctx, project: project,
+	}
+}
+
+func createTagMutationMCPPersonalTag(t *testing.T, fx *tagMutationMCPFixture, name string) int64 {
+	t.Helper()
+	_, err := fx.st.CreateTodo(fx.ctx, fx.project.ID, store.CreateTodoInput{
+		Title: "todo " + name, Tags: []string{name}, ColumnKey: "backlog",
+	}, store.ModeFull)
+	if err != nil {
+		t.Fatalf("create personal tag fixture %q: %v", name, err)
+	}
+	var tagID int64
+	if err := fx.db.QueryRow(`SELECT id FROM tags WHERE user_id = ? AND name = ?`, fx.ownerID, name).Scan(&tagID); err != nil {
+		t.Fatalf("read personal tag %q: %v", name, err)
+	}
+	return tagID
+}
+
+func subscribeTagMutationMCPEvents(t *testing.T, fx *tagMutationMCPFixture, project store.Project) *todoUpdateMCPEventStream {
+	t.Helper()
+	return subscribeTodoUpdateMCPEvents(t, fx.client, fx.ts.URL+"/api/board/"+project.Slug+"/events")
+}
+
+func assertTagMutationMCPSilence(t *testing.T, stream *todoUpdateMCPEventStream) {
+	t.Helper()
+	if events := collectTodoUpdateMCPEvents(t, stream); len(events) != 0 {
+		t.Fatalf("MCP tag mutation emitted realtime events: %+v", events)
+	}
+}
+
+func assertTagMutationMCPTrace(t *testing.T, wrapped *tagMutationMCPStore, want ...string) {
+	t.Helper()
+	if got := wrapped.traceSnapshot(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("store trace=%v want=%v", got, want)
+	}
+}
+
+func assertTagMutationMCPTag(t *testing.T, data map[string]any, wantID int64, wantName string, wantColor any) {
+	t.Helper()
+	if got, want := sortedMapKeys(data), []string{"tag"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("data keys=%v want=%v data=%+v", got, want, data)
+	}
+	tag, ok := data["tag"].(map[string]any)
+	if !ok {
+		t.Fatalf("tag projection type=%T data=%+v", data["tag"], data)
+	}
+	if int64(tag["tagId"].(float64)) != wantID || tag["name"] != wantName || tag["color"] != wantColor {
+		t.Fatalf("tag=%+v want id=%d name=%q color=%+v", tag, wantID, wantName, wantColor)
+	}
+}
+
+// TestMCPTagsMutationTransportsAliasesAndRealtime proves that all four canonical
+// mutation names and their permanent dotted aliases execute over both MCP transports.
+// It also freezes the intentional absence of board refresh/SSE publication.
+func TestMCPTagsMutationTransportsAliasesAndRealtime(t *testing.T) {
+	tools := []struct {
+		canonical string
+		alias     string
+		kind      string
+	}{
+		{"tags_updateMineColor", "tags.updateMineColor", "update-mine"},
+		{"tags_updateProjectColor", "tags.updateProjectColor", "update-project"},
+		{"tags_deleteMine", "tags.deleteMine", "delete-mine"},
+		{"tags_deleteProject", "tags.deleteProject", "delete-project"},
+	}
+	for _, toolCase := range tools {
+		for _, toolName := range []string{toolCase.canonical, toolCase.alias} {
+			for _, transport := range []string{"legacy", "jsonrpc"} {
+				t.Run(transport+"/"+toolName, func(t *testing.T) {
+					fx := newTagMutationMCPFixture(t, strings.ReplaceAll(toolName, ".", "-")+"-"+transport)
+					var tagID int64
+					var args map[string]any
+					switch toolCase.kind {
+					case "update-mine":
+						tagID = createTagMutationMCPPersonalTag(t, fx, "mine-update")
+						args = map[string]any{"tagId": tagID, "color": "#123456"}
+					case "delete-mine":
+						tagID = createTagMutationMCPPersonalTag(t, fx, "mine-delete")
+						args = map[string]any{"tagId": tagID}
+					case "update-project":
+						tagID = insertProjectScopedTag(t, fx.db, fx.project.ID, "project-update", nil)
+						args = map[string]any{"projectSlug": fx.project.Slug, "tagId": tagID, "color": "#654321"}
+					case "delete-project":
+						tagID = insertProjectScopedTag(t, fx.db, fx.project.ID, "project-delete", nil)
+						args = map[string]any{"projectSlug": fx.project.Slug, "tagId": tagID}
+					}
+
+					stream := subscribeTagMutationMCPEvents(t, fx, fx.project)
+					defer stream.close()
+					resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, transport, toolName, args)
+					if resp.StatusCode != http.StatusOK {
+						t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+					}
+					data := todoLinkMCPData(t, transport, out)
+					switch toolCase.kind {
+					case "update-mine":
+						assertTagMutationMCPTag(t, data, tagID, "mine-update", "#123456")
+					case "update-project":
+						assertTagMutationMCPTag(t, data, tagID, "project-update", "#654321")
+					case "delete-mine":
+						deleted := data["deleted"].(map[string]any)
+						if got, want := sortedMapKeys(deleted), []string{"tagId"}; !reflect.DeepEqual(got, want) || int64(deleted["tagId"].(float64)) != tagID {
+							t.Fatalf("deleted=%+v", deleted)
+						}
+					case "delete-project":
+						deleted := data["deleted"].(map[string]any)
+						if got, want := sortedMapKeys(deleted), []string{"projectSlug", "tagId"}; !reflect.DeepEqual(got, want) || deleted["projectSlug"] != fx.project.Slug || int64(deleted["tagId"].(float64)) != tagID {
+							t.Fatalf("deleted=%+v", deleted)
+						}
+					}
+					assertTagMutationMCPSilence(t, stream)
+				})
+			}
+		}
+	}
+}
+
+// TestMCPTagsMutationReadAndDispatchSequencing characterizes the application-boundary
+// store call sequence: mine update is pre-read plus synthetic projection, project ID
+// update is pre-read/mutate/post-read, name update is mutate/post-read, and deletes do
+// not perform a post-delete read.
+func TestMCPTagsMutationReadAndDispatchSequencing(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		t.Run(transport+"/mine update synthetic result", func(t *testing.T) {
+			fx := newTagMutationMCPFixture(t, "mine-sequence-"+transport)
+			tagID := createTagMutationMCPPersonalTag(t, fx, "mine-sequence")
+			fx.wrapped.activate()
+			resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, transport, "tags_updateMineColor", map[string]any{"tagId": tagID, "color": "  #abcdef  "})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+			}
+			assertTagMutationMCPTag(t, todoLinkMCPData(t, transport, out), tagID, "mine-sequence", "#abcdef")
+			assertTagMutationMCPTrace(t, fx.wrapped, "mine-read", "mine-color")
+			if fx.wrapped.mineReadCalls != 1 || fx.wrapped.updateCalls != 1 || fx.wrapped.projectReadCalls != 0 {
+				t.Fatalf("calls mine=%d update=%d project=%d", fx.wrapped.mineReadCalls, fx.wrapped.updateCalls, fx.wrapped.projectReadCalls)
+			}
+		})
+
+		t.Run(transport+"/durable id update pre and post read", func(t *testing.T) {
+			fx := newTagMutationMCPFixture(t, "id-sequence-"+transport)
+			tagID := insertProjectScopedTag(t, fx.db, fx.project.ID, "id-sequence", nil)
+			fx.wrapped.activate()
+			resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, transport, "tags_updateProjectColor", map[string]any{"projectSlug": fx.project.Slug, "tagId": tagID, "color": "#abcdef"})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+			}
+			assertTagMutationMCPTrace(t, fx.wrapped, "access", "project-read-pre", "durable-id-color", "project-read-post")
+		})
+
+		t.Run(transport+"/temporary id update skips durable role gate", func(t *testing.T) {
+			fx := newTagMutationMCPFixture(t, "temporary-id-sequence-"+transport)
+			temporary, err := fx.st.CreateAnonymousBoard(fx.ctx)
+			if err != nil {
+				t.Fatalf("create creator temporary board: %v", err)
+			}
+			if _, err := fx.st.CreateTodo(fx.ctx, temporary.ID, store.CreateTodoInput{
+				Title: "temporary", Tags: []string{"temporary-id"}, ColumnKey: "backlog",
+			}, store.ModeFull); err != nil {
+				t.Fatalf("create temporary tag fixture: %v", err)
+			}
+			var tagID int64
+			if err := fx.db.QueryRow(`SELECT id FROM tags WHERE user_id = ? AND name = 'temporary-id'`, fx.ownerID).Scan(&tagID); err != nil {
+				t.Fatalf("read temporary tag: %v", err)
+			}
+			fx.wrapped.activate()
+			resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, transport, "tags_updateProjectColor", map[string]any{"projectSlug": temporary.Slug, "tagId": tagID, "color": "#abcdef"})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+			}
+			assertTagMutationMCPTrace(t, fx.wrapped, "access", "project-read-pre", "temporary-id-color", "project-read-post")
+		})
+
+		t.Run(transport+"/name update post read only", func(t *testing.T) {
+			fx := newTagMutationMCPFixture(t, "name-sequence-"+transport)
+			createTagMutationMCPPersonalTag(t, fx, "name-sequence")
+			fx.wrapped.activate()
+			resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, transport, "tags_updateProjectColor", map[string]any{"projectSlug": fx.project.Slug, "tagName": "name-sequence", "color": "#abcdef"})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+			}
+			assertTagMutationMCPTrace(t, fx.wrapped, "access", "name-color", "project-read-post")
+		})
+
+		t.Run(transport+"/mine delete has no post read", func(t *testing.T) {
+			fx := newTagMutationMCPFixture(t, "mine-delete-sequence-"+transport)
+			tagID := createTagMutationMCPPersonalTag(t, fx, "mine-delete-sequence")
+			fx.wrapped.activate()
+			resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, transport, "tags_deleteMine", map[string]any{"tagId": tagID})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+			}
+			_ = todoLinkMCPData(t, transport, out)
+			assertTagMutationMCPTrace(t, fx.wrapped, "mine-read", "delete")
+		})
+
+		t.Run(transport+"/project delete has no post read", func(t *testing.T) {
+			fx := newTagMutationMCPFixture(t, "project-delete-sequence-"+transport)
+			tagID := insertProjectScopedTag(t, fx.db, fx.project.ID, "project-delete-sequence", nil)
+			fx.wrapped.activate()
+			resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, transport, "tags_deleteProject", map[string]any{"projectSlug": fx.project.Slug, "tagId": tagID})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+			}
+			_ = todoLinkMCPData(t, transport, out)
+			assertTagMutationMCPTrace(t, fx.wrapped, "access", "project-target", "delete")
+		})
+	}
+}
+
+// TestMCPTagsMutationCommittedUpdatePostReadFailure freezes the non-atomic public
+// behavior: a successful color write followed by a failed projection returns INTERNAL,
+// while the write remains committed and is neither retried nor rolled back.
+func TestMCPTagsMutationCommittedUpdatePostReadFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		transport string
+		byName    bool
+		readErr   bool
+	}{
+		{"legacy id post-read error", "legacy", false, true},
+		{"jsonrpc name post-read error", "jsonrpc", true, true},
+		{"jsonrpc id post-read target missing", "jsonrpc", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newTagMutationMCPFixture(t, strings.ReplaceAll(tc.name, " ", "-"))
+			args := map[string]any{"projectSlug": fx.project.Slug, "color": "#a1b2c3"}
+			var tagID int64
+			if tc.byName {
+				tagID = createTagMutationMCPPersonalTag(t, fx, "post-read-name")
+				args["tagName"] = "post-read-name"
+				fx.wrapped.targetName = "post-read-name"
+			} else {
+				tagID = insertProjectScopedTag(t, fx.db, fx.project.ID, "post-read-id", nil)
+				args["tagId"] = tagID
+				fx.wrapped.targetTagID = tagID
+			}
+			if tc.readErr {
+				fx.wrapped.postReadErr = errors.New("forced post-read failure")
+			} else {
+				fx.wrapped.omitPostTag = true
+			}
+			stream := subscribeTagMutationMCPEvents(t, fx, fx.project)
+			defer stream.close()
+			fx.wrapped.activate()
+			resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, tc.transport, "tags_updateProjectColor", args)
+			publicError := assertTodoLinkMCPError(t, tc.transport, resp, out, http.StatusInternalServerError, "INTERNAL", "internal error")
+			if tc.transport == "jsonrpc" {
+				assertEmptyTodoLinkMCPDetails(t, publicError)
+			}
+			if fx.wrapped.updateCalls != 1 {
+				t.Fatalf("update calls=%d want=1", fx.wrapped.updateCalls)
+			}
+			if tc.byName {
+				assertTagMutationMCPTrace(t, fx.wrapped, "access", "name-color", "project-read-post")
+				var color string
+				if err := fx.db.QueryRow(`SELECT color FROM user_tag_colors WHERE user_id = ? AND tag_id = ?`, fx.ownerID, tagID).Scan(&color); err != nil || color != "#a1b2c3" {
+					t.Fatalf("committed name color=%q err=%v", color, err)
+				}
+			} else {
+				assertTagMutationMCPTrace(t, fx.wrapped, "access", "project-read-pre", "durable-id-color", "project-read-post")
+				var color string
+				if err := fx.db.QueryRow(`SELECT color FROM tags WHERE id = ?`, tagID).Scan(&color); err != nil || color != "#a1b2c3" {
+					t.Fatalf("committed id color=%q err=%v", color, err)
+				}
+			}
+			assertTagMutationMCPSilence(t, stream)
+		})
+	}
+}
+
+// TestMCPTagsMutationValidationAndAuthorityOrdering pins the adapter-level decision
+// order that is otherwise easy to change while moving orchestration inward.
+func TestMCPTagsMutationValidationAndAuthorityOrdering(t *testing.T) {
+	t.Run("exactly-one validation before missing project", func(t *testing.T) {
+		fx := newTagMutationMCPFixture(t, "exactly-one-order")
+		fx.wrapped.activate()
+		resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, "jsonrpc", "tags_updateProjectColor", map[string]any{
+			"projectSlug": "missing-project", "tagId": 1, "tagName": "also-supplied", "color": "#123456",
+		})
+		assertTodoLinkMCPError(t, "jsonrpc", resp, out, http.StatusBadRequest, "VALIDATION_ERROR", "provide exactly one of tagId or tagName")
+		assertTagMutationMCPTrace(t, fx.wrapped)
+	})
+
+	t.Run("empty color validation before inaccessible project", func(t *testing.T) {
+		fx := newTagMutationMCPFixture(t, "empty-color-order")
+		fx.wrapped.activate()
+		resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, "legacy", "tags_updateProjectColor", map[string]any{
+			"projectSlug": "missing-project", "tagId": 1, "color": "   ",
+		})
+		assertTodoLinkMCPError(t, "legacy", resp, out, http.StatusBadRequest, "VALIDATION_ERROR", "color cannot be empty; use null to clear")
+		assertTagMutationMCPTrace(t, fx.wrapped)
+	})
+
+	t.Run("wrong-project color precedes insufficient role but delete role precedes target", func(t *testing.T) {
+		fx := newTagMutationMCPFixture(t, "wrong-project-role-order")
+		other, err := fx.st.CreateProject(fx.ctx, "Wrong Project Other")
+		if err != nil {
+			t.Fatalf("create other project: %v", err)
+		}
+		foreignTagID := insertProjectScopedTag(t, fx.db, other.ID, "foreign", nil)
+		viewer, err := fx.st.CreateUser(context.Background(), "tag-order-viewer@example.com", "password123", "Viewer")
+		if err != nil {
+			t.Fatalf("create viewer: %v", err)
+		}
+		if err := fx.st.AddProjectMember(context.Background(), fx.ownerID, fx.project.ID, viewer.ID, store.RoleViewer); err != nil {
+			t.Fatalf("add viewer: %v", err)
+		}
+		viewerClient := newSessionClientForUser(t, fx.ts, fx.st, viewer.ID)
+
+		fx.wrapped.activate()
+		resp, out := callTodoUpdateMCP(t, viewerClient, fx.ts.URL, "legacy", "tags_updateProjectColor", map[string]any{
+			"projectSlug": fx.project.Slug, "tagId": foreignTagID, "color": "#123456",
+		})
+		assertTodoLinkMCPError(t, "legacy", resp, out, http.StatusNotFound, "NOT_FOUND", "not found")
+		assertTagMutationMCPTrace(t, fx.wrapped, "access", "project-read-pre")
+
+		fx.wrapped.activate()
+		resp, out = callTodoUpdateMCP(t, viewerClient, fx.ts.URL, "jsonrpc", "tags_deleteProject", map[string]any{
+			"projectSlug": fx.project.Slug, "tagId": foreignTagID,
+		})
+		assertTodoLinkMCPError(t, "jsonrpc", resp, out, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required")
+		assertTagMutationMCPTrace(t, fx.wrapped, "access")
+	})
+
+	t.Run("temporary name color reaches durable-only store method", func(t *testing.T) {
+		fx := newTagMutationMCPFixture(t, "temporary-name-color")
+		temporary, err := fx.st.CreateAnonymousBoard(fx.ctx)
+		if err != nil {
+			t.Fatalf("create creator temporary board: %v", err)
+		}
+		fx.wrapped.activate()
+		resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, "jsonrpc", "tags_updateProjectColor", map[string]any{
+			"projectSlug": temporary.Slug, "tagName": "missing", "color": "#123456",
+		})
+		assertTodoLinkMCPError(t, "jsonrpc", resp, out, http.StatusBadRequest, "VALIDATION_ERROR", "validation: name-based tag operations require a durable project")
+		assertTagMutationMCPTrace(t, fx.wrapped, "access", "name-color")
+	})
+
+	t.Run("creator temporary project delete fails role gate before tag read", func(t *testing.T) {
+		fx := newTagMutationMCPFixture(t, "temporary-delete")
+		temporary, err := fx.st.CreateAnonymousBoard(fx.ctx)
+		if err != nil {
+			t.Fatalf("create creator temporary board: %v", err)
+		}
+		tagID := insertProjectScopedTag(t, fx.db, temporary.ID, "temporary-delete", nil)
+		fx.wrapped.activate()
+		resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, "legacy", "tags_deleteProject", map[string]any{
+			"projectSlug": temporary.Slug, "tagId": tagID,
+		})
+		assertTodoLinkMCPError(t, "legacy", resp, out, http.StatusForbidden, "FORBIDDEN", "maintainer or higher required")
+		assertTagMutationMCPTrace(t, fx.wrapped, "access")
+	})
+
+	t.Run("expired project hides tag before color pre-read and delete role", func(t *testing.T) {
+		fx := newTagMutationMCPFixture(t, "expired-project-order")
+		anonymous, err := fx.st.CreateAnonymousBoard(context.Background())
+		if err != nil {
+			t.Fatalf("create anonymous board: %v", err)
+		}
+		tagID := insertProjectScopedTag(t, fx.db, anonymous.ID, "expired", nil)
+		if _, err := fx.db.Exec(`UPDATE projects SET expires_at = ? WHERE id = ?`, time.Now().UTC().Add(-time.Hour).UnixMilli(), anonymous.ID); err != nil {
+			t.Fatalf("expire board: %v", err)
+		}
+
+		fx.wrapped.activate()
+		resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, "jsonrpc", "tags_updateProjectColor", map[string]any{
+			"projectSlug": anonymous.Slug, "tagId": tagID, "color": "#123456",
+		})
+		assertTodoLinkMCPError(t, "jsonrpc", resp, out, http.StatusNotFound, "NOT_FOUND", "not found")
+		assertTagMutationMCPTrace(t, fx.wrapped, "access")
+
+		fx.wrapped.activate()
+		resp, out = callTodoUpdateMCP(t, fx.client, fx.ts.URL, "legacy", "tags_deleteProject", map[string]any{
+			"projectSlug": anonymous.Slug, "tagId": tagID + 999999,
+		})
+		assertTodoLinkMCPError(t, "legacy", resp, out, http.StatusNotFound, "NOT_FOUND", "not found")
+		assertTagMutationMCPTrace(t, fx.wrapped, "access")
+	})
+}
+
+func TestMCPTagsMutationDeleteMineCrossProjectHasNoAffectedPublication(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		t.Run(transport, func(t *testing.T) {
+			fx := newTagMutationMCPFixture(t, "mine-delete-cross-project-"+transport)
+			tagID := createTagMutationMCPPersonalTag(t, fx, "cross-project-delete")
+			other, err := fx.st.CreateProject(fx.ctx, "Mine Delete Other "+transport)
+			if err != nil {
+				t.Fatalf("create other project: %v", err)
+			}
+			if _, err := fx.st.CreateTodo(fx.ctx, other.ID, store.CreateTodoInput{
+				Title: "other", Tags: []string{"cross-project-delete"}, ColumnKey: "backlog",
+			}, store.ModeFull); err != nil {
+				t.Fatalf("attach tag to other project: %v", err)
+			}
+			streamA := subscribeTagMutationMCPEvents(t, fx, fx.project)
+			defer streamA.close()
+			streamB := subscribeTagMutationMCPEvents(t, fx, other)
+			defer streamB.close()
+			fx.wrapped.activate()
+			resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, transport, "tags_deleteMine", map[string]any{"tagId": tagID})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+			}
+			_ = todoLinkMCPData(t, transport, out)
+			assertTagMutationMCPTrace(t, fx.wrapped, "mine-read", "delete")
+			var remaining int
+			if err := fx.db.QueryRow(`SELECT COUNT(*) FROM tags WHERE id = ?`, tagID).Scan(&remaining); err != nil || remaining != 0 {
+				t.Fatalf("remaining tag rows=%d err=%v", remaining, err)
+			}
+			assertTagMutationMCPSilence(t, streamA)
+			assertTagMutationMCPSilence(t, streamB)
+		})
+	}
+}
+
+func TestMCPTagsMutationClearMissingPreferenceAndInputPolicy(t *testing.T) {
+	for _, transport := range []string{"legacy", "jsonrpc"} {
+		t.Run(transport+"/mine null clear missing preference succeeds", func(t *testing.T) {
+			fx := newTagMutationMCPFixture(t, "mine-clear-"+transport)
+			tagID := createTagMutationMCPPersonalTag(t, fx, "mine-clear")
+			fx.wrapped.activate()
+			resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, transport, "tags_updateMineColor", map[string]any{"tagId": tagID, "color": nil})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d response=%+v", resp.StatusCode, out)
+			}
+			assertTagMutationMCPTag(t, todoLinkMCPData(t, transport, out), tagID, "mine-clear", nil)
+			assertTagMutationMCPTrace(t, fx.wrapped, "mine-read", "mine-color")
+		})
+
+		for _, color := range []string{"", "   "} {
+			t.Run(transport+"/reject empty color "+strconvForTagMutationTest(color), func(t *testing.T) {
+				fx := newTagMutationMCPFixture(t, "reject-empty-"+transport+strconvForTagMutationTest(color))
+				tagID := createTagMutationMCPPersonalTag(t, fx, "reject-empty")
+				fx.wrapped.activate()
+				resp, out := callTodoUpdateMCP(t, fx.client, fx.ts.URL, transport, "tags_updateMineColor", map[string]any{"tagId": tagID, "color": color})
+				assertTodoLinkMCPError(t, transport, resp, out, http.StatusBadRequest, "VALIDATION_ERROR", "color cannot be empty; use null to clear")
+				assertTagMutationMCPTrace(t, fx.wrapped)
+			})
+		}
+	}
+}
+
+func strconvForTagMutationTest(value string) string {
+	if value == "" {
+		return "empty"
+	}
+	return "whitespace"
+}

--- a/internal/mcp/tag_tools.go
+++ b/internal/mcp/tag_tools.go
@@ -60,6 +60,30 @@ func mapTagColorUpdateError(err error) *adapterError {
 	return mapStoreError(err)
 }
 
+func mapTagDeletionPrepareError(err error) *adapterError {
+	switch {
+	case errors.Is(err, tagapp.ErrActorRequired):
+		return newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
+	case errors.Is(err, tagapp.ErrMaintainerRequired):
+		return newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
+	default:
+		return mapStoreError(err)
+	}
+}
+
+func mapTagDeletionExecuteError(err error) *adapterError {
+	switch {
+	case errors.Is(err, store.ErrNotFound):
+		return newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
+	case errors.Is(err, store.ErrUnauthorized):
+		return newAdapterError(http.StatusForbidden, CodeForbidden, err.Error(), nil)
+	case errors.Is(err, store.ErrConflict):
+		return newAdapterError(http.StatusConflict, CodeConflict, err.Error(), nil)
+	default:
+		return mapStoreError(err)
+	}
+}
+
 func (a *Adapter) handleTagsListProject(ctx context.Context, input any) (any, map[string]any, *adapterError) {
 	auth, bootstrapAvailable, err := a.authState(ctx)
 	if err != nil {
@@ -228,30 +252,14 @@ func (a *Adapter) handleTagsDeleteMine(ctx context.Context, input any) (any, map
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid tagId", map[string]any{"field": "tagId"})
 	}
 
-	userID, ok := store.UserIDFromContext(ctx)
-	if !ok {
-		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
+	prepared, prepareErr := a.tagDeletions.PrepareMineID(ctx, tagapp.MCPMineIDDeletionTarget{
+		TagID: in.TagID,
+	})
+	if prepareErr != nil {
+		return nil, nil, mapTagDeletionPrepareError(prepareErr)
 	}
-
-	tags, tagsErr := a.store.ListUserTags(ctx, userID)
-	if tagsErr != nil {
-		return nil, nil, mapStoreError(tagsErr)
-	}
-	if _, found := findMineTag(tags, in.TagID); !found {
-		return nil, nil, newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
-	}
-
-	if err := a.store.DeleteTag(ctx, userID, in.TagID, false); err != nil {
-		switch {
-		case errors.Is(err, store.ErrNotFound):
-			return nil, nil, newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
-		case errors.Is(err, store.ErrUnauthorized):
-			return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, err.Error(), nil)
-		case errors.Is(err, store.ErrConflict):
-			return nil, nil, newAdapterError(http.StatusConflict, CodeConflict, err.Error(), nil)
-		default:
-			return nil, nil, mapStoreError(err)
-		}
+	if deleteErr := prepared.Delete(); deleteErr != nil {
+		return nil, nil, mapTagDeletionExecuteError(deleteErr)
 	}
 
 	return map[string]any{
@@ -361,42 +369,19 @@ func (a *Adapter) handleTagsDeleteProject(ctx context.Context, input any) (any, 
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "invalid tagId", map[string]any{"field": "tagId"})
 	}
 
-	pc, pcErr := a.store.GetProjectContextBySlug(ctx, in.ProjectSlug, a.storeMode())
-	if pcErr != nil {
-		return nil, nil, mapStoreError(pcErr)
+	// MCP project deletion deliberately remains board-scoped-only. The prepared
+	// service verifies the project-scoped row before performing the destructive
+	// operation, so personal rows continue to return not found.
+	prepared, prepareErr := a.tagDeletions.PrepareProjectID(ctx, tagapp.MCPProjectIDDeletionTarget{
+		ProjectSlug: in.ProjectSlug,
+		Mode:        a.storeMode(),
+		TagID:       in.TagID,
+	})
+	if prepareErr != nil {
+		return nil, nil, mapTagDeletionPrepareError(prepareErr)
 	}
-	userID, ok := store.UserIDFromContext(ctx)
-	if !ok {
-		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
-	}
-	if !pc.Role.HasMinimumRole(store.RoleMaintainer) {
-		return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
-	}
-
-	// Deliberately still board-scoped-only (unlike handleTagsUpdateProjectColor): DeleteTag on a
-	// user-owned tag deletes it across every project that user has used it in, not just this one,
-	// so tags.deleteProject intentionally 404s for user-owned tags (see
-	// TestMCPTagsDeleteProjectUserOwnedTagNotFound). tags.updateProjectColor is non-destructive
-	// and safely dispatches to a per-viewer color update for user-owned tags, so only that path
-	// was widened.
-	if _, tagErr := a.store.GetProjectScopedTagByID(ctx, pc.Project.ID, in.TagID); tagErr != nil {
-		return nil, nil, mapStoreError(tagErr)
-	}
-
-	p := pc.Project
-	isAnonymousBoard := p.ExpiresAt != nil && p.CreatorUserID == nil
-
-	if err := a.store.DeleteTag(ctx, userID, in.TagID, isAnonymousBoard); err != nil {
-		switch {
-		case errors.Is(err, store.ErrNotFound):
-			return nil, nil, newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
-		case errors.Is(err, store.ErrUnauthorized):
-			return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, err.Error(), nil)
-		case errors.Is(err, store.ErrConflict):
-			return nil, nil, newAdapterError(http.StatusConflict, CodeConflict, err.Error(), nil)
-		default:
-			return nil, nil, mapStoreError(err)
-		}
+	if deleteErr := prepared.Delete(); deleteErr != nil {
+		return nil, nil, mapTagDeletionExecuteError(deleteErr)
 	}
 
 	return map[string]any{
@@ -405,13 +390,4 @@ func (a *Adapter) handleTagsDeleteProject(ctx context.Context, input any) (any, 
 			"tagId":       in.TagID,
 		},
 	}, map[string]any{}, nil
-}
-
-func findMineTag(tags []store.TagWithColor, tagID int64) (store.TagWithColor, bool) {
-	for _, tag := range tags {
-		if tag.TagID == tagID {
-			return tag, true
-		}
-	}
-	return store.TagWithColor{}, false
 }

--- a/internal/mcp/tag_tools.go
+++ b/internal/mcp/tag_tools.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	tagapp "scrumboy/internal/application/tag"
 	"scrumboy/internal/store"
 )
 
@@ -34,6 +35,29 @@ type updateProjectTagColorInput struct {
 type deleteProjectTagInput struct {
 	ProjectSlug string `json:"projectSlug"`
 	TagID       int64  `json:"tagId"`
+}
+
+func mapTagColorPrepareError(err error) *adapterError {
+	switch {
+	case errors.Is(err, tagapp.ErrActorRequired):
+		return newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
+	case errors.Is(err, tagapp.ErrMaintainerRequired):
+		return newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
+	default:
+		return mapStoreError(err)
+	}
+}
+
+func mapTagColorUpdateError(err error) *adapterError {
+	if errors.Is(err, tagapp.ErrColorProjectionMissing) {
+		return newAdapterError(
+			http.StatusInternalServerError,
+			CodeInternal,
+			"internal error",
+			map[string]any{"detail": "updated project tag not found in post-read"},
+		)
+	}
+	return mapStoreError(err)
 }
 
 func (a *Adapter) handleTagsListProject(ctx context.Context, input any) (any, map[string]any, *adapterError) {
@@ -159,30 +183,18 @@ func (a *Adapter) handleTagsUpdateMineColor(ctx context.Context, input any) (any
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "color cannot be empty; use null to clear", map[string]any{"field": "color"})
 	}
 
-	userID, ok := store.UserIDFromContext(ctx)
-	if !ok {
-		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
+	prepared, prepareErr := a.tagColors.PrepareMineID(ctx, tagapp.MCPMineIDColorTarget{
+		TagID: in.TagID,
+		Color: tagapp.NewColorIntent(in.Color),
+	})
+	if prepareErr != nil {
+		return nil, nil, mapTagColorPrepareError(prepareErr)
 	}
-
-	tags, tagsErr := a.store.ListUserTags(ctx, userID)
-	if tagsErr != nil {
-		return nil, nil, mapStoreError(tagsErr)
-	}
-	tag, found := findMineTag(tags, in.TagID)
-	if !found {
-		return nil, nil, newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
-	}
-
-	updateErr := a.store.UpdateTagColor(ctx, &userID, in.TagID, in.Color)
+	tag, updateErr := prepared.Update()
 	if updateErr != nil {
-		// Clearing a color preference when none exists is a harmless no-op for this
-		// mine-scope MCP tool; normalize the store quirk into a successful clear.
-		if !(isColorClear(in.Color) && errors.Is(updateErr, store.ErrNotFound)) {
-			return nil, nil, mapStoreError(updateErr)
-		}
+		return nil, nil, mapTagColorUpdateError(updateErr)
 	}
 
-	tag.Color = normalizedMineColor(in.Color)
 	return map[string]any{
 		"tag": mineTagItem{
 			TagID:     tag.TagID,
@@ -290,80 +302,37 @@ func (a *Adapter) handleTagsUpdateProjectColor(ctx context.Context, input any) (
 		return nil, nil, newAdapterError(http.StatusBadRequest, CodeValidationError, "color cannot be empty; use null to clear", map[string]any{"field": "color"})
 	}
 
-	pc, pcErr := a.store.GetProjectContextBySlug(ctx, in.ProjectSlug, a.storeMode())
-	if pcErr != nil {
-		return nil, nil, mapStoreError(pcErr)
-	}
-	userID, ok := store.UserIDFromContext(ctx)
-	if !ok {
-		return nil, nil, newAdapterError(http.StatusUnauthorized, CodeAuthRequired, "Sign-in required for this tool", nil)
-	}
-
-	// tagName targets a grouped personal label and changes only the caller's own
-	// display preference, so any authenticated project member may do it. tagId targets
-	// a board-scoped tag whose color is shared with everyone, so it stays maintainer+.
 	if suppliedName {
-		if err := a.store.SetViewerTagColorByName(ctx, pc.Project.ID, userID, *in.TagName, in.Color); err != nil {
-			return nil, nil, mapStoreError(err)
+		prepared, prepareErr := a.tagColors.PrepareProjectName(ctx, tagapp.MCPProjectNameColorTarget{
+			ProjectSlug: in.ProjectSlug,
+			Mode:        a.storeMode(),
+			Name:        *in.TagName,
+			Color:       tagapp.NewColorIntent(in.Color),
+		})
+		if prepareErr != nil {
+			return nil, nil, mapTagColorPrepareError(prepareErr)
 		}
-		projectTags, listErr := a.store.ListTagCounts(ctx, &pc)
-		if listErr != nil {
-			return nil, nil, mapStoreError(listErr)
+		tag, updateErr := prepared.Update()
+		if updateErr != nil {
+			return nil, nil, mapTagColorUpdateError(updateErr)
 		}
-		// The listing labels a group by its grouping key, which is the canonical name
-		// when one exists and the raw stored name otherwise; TagGroupKey mirrors that.
-		if tc, found := findProjectTagCountByName(projectTags, store.TagGroupKey(*in.TagName)); found {
-			return map[string]any{"tag": toProjectTagItem(tc)}, map[string]any{}, nil
-		}
-		return nil, nil, newAdapterError(http.StatusInternalServerError, CodeInternal, "internal error", map[string]any{"detail": "updated project tag not found in post-read"})
+		return map[string]any{"tag": toProjectTagItem(tag)}, map[string]any{}, nil
 	}
 
-	tagID := *in.TagID
-
-	// On durable projects, grouped listProject exposes a real tagId only for
-	// board-scoped tags (personal groups report tagId 0), so a tagId lookup here
-	// naturally restricts this path to board-scoped tags; personal color updates must
-	// use tagName. Temporary boards keep the row-level projection, so every listed row
-	// remains addressable by tagId exactly as before.
-	projectTags, listErr := a.store.ListTagCounts(ctx, &pc)
-	if listErr != nil {
-		return nil, nil, mapStoreError(listErr)
+	prepared, prepareErr := a.tagColors.PrepareProjectID(ctx, tagapp.MCPProjectIDColorTarget{
+		ProjectSlug: in.ProjectSlug,
+		Mode:        a.storeMode(),
+		TagID:       *in.TagID,
+		Color:       tagapp.NewColorIntent(in.Color),
+	})
+	if prepareErr != nil {
+		return nil, nil, mapTagColorPrepareError(prepareErr)
 	}
-	if _, found := findProjectTagCount(projectTags, tagID); !found {
-		return nil, nil, newAdapterError(http.StatusNotFound, CodeNotFound, "not found", nil)
-	}
-
-	var updateErr error
-	if pc.Project.ExpiresAt != nil {
-		// Temporary boards are link-shareable: buildProjectContext leaves pc.Role empty
-		// on purpose, and REST uses UpdateTagColorForTemporaryBoard with no Maintainer
-		// gate. Match that for authenticated Full-mode MCP callers (anonymous MCP mode
-		// remains unavailable; pastebin visitors use REST).
-		updateErr = a.store.UpdateTagColorForTemporaryBoard(ctx, pc.Project.ID, &userID, tagID, in.Color)
-	} else {
-		// Durable board-scoped tagId: shared tags.color requires Maintainer+.
-		if !pc.Role.HasMinimumRole(store.RoleMaintainer) {
-			return nil, nil, newAdapterError(http.StatusForbidden, CodeForbidden, "maintainer or higher required", nil)
-		}
-		updateErr = a.store.UpdateTagColorForDurableProjectByID(ctx, pc.Project.ID, userID, tagID, in.Color)
-	}
+	tag, updateErr := prepared.Update()
 	if updateErr != nil {
-		if !(isColorClear(in.Color) && errors.Is(updateErr, store.ErrNotFound)) {
-			return nil, nil, mapStoreError(updateErr)
-		}
+		return nil, nil, mapTagColorUpdateError(updateErr)
 	}
-
-	projectTags, listErr = a.store.ListTagCounts(ctx, &pc)
-	if listErr != nil {
-		return nil, nil, mapStoreError(listErr)
-	}
-	if tc, found := findProjectTagCount(projectTags, tagID); found {
-		return map[string]any{"tag": toProjectTagItem(tc)}, map[string]any{}, nil
-	}
-
-	// Tag existence in project scope was already verified above; if it disappears
-	// here, treat it as an internal inconsistency rather than weakening the contract.
-	return nil, nil, newAdapterError(http.StatusInternalServerError, CodeInternal, "internal error", map[string]any{"detail": "updated project tag not found in post-read"})
+	return map[string]any{"tag": toProjectTagItem(tag)}, map[string]any{}, nil
 }
 
 func (a *Adapter) handleTagsDeleteProject(ctx context.Context, input any) (any, map[string]any, *adapterError) {
@@ -438,24 +407,6 @@ func (a *Adapter) handleTagsDeleteProject(ctx context.Context, input any) (any, 
 	}, map[string]any{}, nil
 }
 
-func findProjectTagCount(tags []store.TagCount, tagID int64) (store.TagCount, bool) {
-	for _, tag := range tags {
-		if tag.TagID == tagID {
-			return tag, true
-		}
-	}
-	return store.TagCount{}, false
-}
-
-func findProjectTagCountByName(tags []store.TagCount, canonicalName string) (store.TagCount, bool) {
-	for _, tag := range tags {
-		if tag.Name == canonicalName {
-			return tag, true
-		}
-	}
-	return store.TagCount{}, false
-}
-
 func findMineTag(tags []store.TagWithColor, tagID int64) (store.TagWithColor, bool) {
 	for _, tag := range tags {
 		if tag.TagID == tagID {
@@ -463,15 +414,4 @@ func findMineTag(tags []store.TagWithColor, tagID int64) (store.TagWithColor, bo
 		}
 	}
 	return store.TagWithColor{}, false
-}
-
-func isColorClear(color *string) bool {
-	return color == nil
-}
-
-func normalizedMineColor(color *string) *string {
-	if isColorClear(color) {
-		return nil
-	}
-	return color
 }

--- a/internal/store/tag_mutation_characterization_test.go
+++ b/internal/store/tag_mutation_characterization_test.go
@@ -1,0 +1,405 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func tagMutationStoreColor(t *testing.T, st *Store, userID, tagID int64) *string {
+	t.Helper()
+	var color sql.NullString
+	if err := st.db.QueryRow(`SELECT color FROM user_tag_colors WHERE user_id = ? AND tag_id = ?`, userID, tagID).Scan(&color); err == sql.ErrNoRows {
+		return nil
+	} else if err != nil {
+		t.Fatalf("read color preference: %v", err)
+	}
+	if !color.Valid {
+		return nil
+	}
+	value := color.String
+	return &value
+}
+
+func tagMutationStoreBoardColor(t *testing.T, st *Store, tagID int64) *string {
+	t.Helper()
+	var color sql.NullString
+	if err := st.db.QueryRow(`SELECT color FROM tags WHERE id = ?`, tagID).Scan(&color); err != nil {
+		t.Fatalf("read board color: %v", err)
+	}
+	if !color.Valid {
+		return nil
+	}
+	value := color.String
+	return &value
+}
+
+func assertTagMutationStoreColor(t *testing.T, got *string, want *string) {
+	t.Helper()
+	if got == nil || want == nil {
+		if got != nil || want != nil {
+			t.Fatalf("color=%v want=%v", got, want)
+		}
+		return
+	}
+	if *got != *want {
+		t.Fatalf("color=%q want=%q", *got, *want)
+	}
+}
+
+// TestTagMutationStoreColorClearContracts freezes the deliberately different
+// clear/idempotency semantics of the raw, mine, grouped-name, and board-row methods.
+func TestTagMutationStoreColorClearContracts(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	owner, err := st.BootstrapUser(ctx, "tag-color-owner@example.com", "password", "Owner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctxOwner := WithUserID(ctx, owner.ID)
+	project, err := st.CreateProject(ctxOwner, "Tag Color Contracts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	plNewTodo(t, st, ctxOwner, project.ID, "personal", "personal")
+	personalID := plTagRowID(t, st, "personal", owner.ID)
+	boardID := plInsertBoardScopedTag(t, st, project.ID, "board", nil)
+
+	t.Run("raw personal clear reports missing preference", func(t *testing.T) {
+		if err := st.UpdateTagColor(ctxOwner, &owner.ID, personalID, nil); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("nil clear error=%v want ErrNotFound", err)
+		}
+		empty := ""
+		if err := st.UpdateTagColor(ctxOwner, &owner.ID, personalID, &empty); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("empty clear error=%v want ErrNotFound", err)
+		}
+		whitespace := "   "
+		if err := st.UpdateTagColor(ctxOwner, &owner.ID, personalID, &whitespace); !errors.Is(err, ErrValidation) {
+			t.Fatalf("whitespace clear error=%v want ErrValidation", err)
+		}
+		trimmed := "  #a1b2c3  "
+		if err := st.UpdateTagColor(ctxOwner, &owner.ID, personalID, &trimmed); err != nil {
+			t.Fatalf("set trimmed color: %v", err)
+		}
+		if trimmed != "#a1b2c3" {
+			t.Fatalf("raw method did not normalize input pointer: %q", trimmed)
+		}
+		assertTagMutationStoreColor(t, tagMutationStoreColor(t, st, owner.ID, personalID), &trimmed)
+		if err := st.UpdateTagColor(ctxOwner, &owner.ID, personalID, nil); err != nil {
+			t.Fatalf("clear existing preference: %v", err)
+		}
+		if err := st.UpdateTagColor(ctxOwner, &owner.ID, personalID, nil); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("second raw clear error=%v want ErrNotFound", err)
+		}
+	})
+
+	t.Run("mine clear normalizes raw not-found but not whitespace validation", func(t *testing.T) {
+		if err := st.UpdateMyTagColor(ctxOwner, owner.ID, personalID, nil); err != nil {
+			t.Fatalf("nil clear: %v", err)
+		}
+		empty := ""
+		if err := st.UpdateMyTagColor(ctxOwner, owner.ID, personalID, &empty); err != nil {
+			t.Fatalf("empty clear: %v", err)
+		}
+		whitespace := "   "
+		if err := st.UpdateMyTagColor(ctxOwner, owner.ID, personalID, &whitespace); !errors.Is(err, ErrValidation) {
+			t.Fatalf("whitespace clear error=%v want ErrValidation", err)
+		}
+	})
+
+	t.Run("grouped name treats all empty forms as idempotent clear", func(t *testing.T) {
+		for _, color := range []*string{nil, func() *string { value := ""; return &value }(), func() *string { value := "   "; return &value }()} {
+			if err := st.SetViewerTagColorByName(ctxOwner, project.ID, owner.ID, "personal", color); err != nil {
+				t.Fatalf("grouped clear %v: %v", color, err)
+			}
+			assertTagMutationStoreColor(t, tagMutationStoreColor(t, st, owner.ID, personalID), nil)
+		}
+		color := "  #b1c2d3  "
+		if err := st.SetViewerTagColorByName(ctxOwner, project.ID, owner.ID, "personal", &color); err != nil {
+			t.Fatalf("grouped set: %v", err)
+		}
+		want := "#b1c2d3"
+		assertTagMutationStoreColor(t, tagMutationStoreColor(t, st, owner.ID, personalID), &want)
+		// Unlike UpdateTagColor, this method normalizes a copy and leaves its input alone.
+		if color != "  #b1c2d3  " {
+			t.Fatalf("grouped method mutated input pointer: %q", color)
+		}
+	})
+
+	t.Run("board row clear is always idempotent except whitespace validation", func(t *testing.T) {
+		if err := st.UpdateTagColor(ctxOwner, &owner.ID, boardID, nil); err != nil {
+			t.Fatalf("nil clear: %v", err)
+		}
+		empty := ""
+		if err := st.UpdateTagColor(ctxOwner, &owner.ID, boardID, &empty); err != nil {
+			t.Fatalf("empty clear: %v", err)
+		}
+		whitespace := "   "
+		if err := st.UpdateTagColor(ctxOwner, &owner.ID, boardID, &whitespace); !errors.Is(err, ErrValidation) {
+			t.Fatalf("whitespace clear error=%v want ErrValidation", err)
+		}
+		assertTagMutationStoreColor(t, tagMutationStoreBoardColor(t, st, boardID), nil)
+	})
+}
+
+// TestTagMutationStoreDurableIDCompatibilityAndAuthority freezes the HTTP-only
+// durable-ID compatibility behavior for personal rows and the Maintainer gate for
+// shared board rows.
+func TestTagMutationStoreDurableIDCompatibilityAndAuthority(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	owner, _ := st.BootstrapUser(ctx, "tag-durable-owner@example.com", "password", "Owner")
+	viewer, _ := st.CreateUser(ctx, "tag-durable-viewer@example.com", "password", "Viewer")
+	contributor, _ := st.CreateUser(ctx, "tag-durable-contributor@example.com", "password", "Contributor")
+	maintainer, _ := st.CreateUser(ctx, "tag-durable-maintainer@example.com", "password", "Maintainer")
+	ctxOwner := WithUserID(ctx, owner.ID)
+	project, _ := st.CreateProject(ctxOwner, "Tag Durable A")
+	other, _ := st.CreateProject(ctxOwner, "Tag Durable B")
+	plAddMember(t, st, project.ID, viewer.ID, RoleViewer)
+	plAddMember(t, st, project.ID, contributor.ID, RoleContributor)
+	plAddMember(t, st, project.ID, maintainer.ID, RoleMaintainer)
+	plNewTodo(t, st, ctxOwner, project.ID, "personal", "personal")
+	personalID := plTagRowID(t, st, "personal", owner.ID)
+	boardID := plInsertBoardScopedTag(t, st, project.ID, "board", nil)
+	foreignID := plInsertBoardScopedTag(t, st, other.ID, "foreign", nil)
+
+	t.Run("viewer may write preference for another member personal row by compatibility id", func(t *testing.T) {
+		color := "#123456"
+		if err := st.UpdateTagColorForDurableProjectByID(WithUserID(ctx, viewer.ID), project.ID, viewer.ID, personalID, &color); err != nil {
+			t.Fatalf("viewer personal compatibility update: %v", err)
+		}
+		assertTagMutationStoreColor(t, tagMutationStoreColor(t, st, viewer.ID, personalID), &color)
+		if ownerColor := tagMutationStoreColor(t, st, owner.ID, personalID); ownerColor != nil {
+			t.Fatalf("viewer compatibility write changed owner preference: %v", ownerColor)
+		}
+		if err := st.UpdateTagColorForDurableProjectByID(WithUserID(ctx, viewer.ID), project.ID, viewer.ID, personalID, nil); err != nil {
+			t.Fatalf("clear existing viewer preference: %v", err)
+		}
+		if err := st.UpdateTagColorForDurableProjectByID(WithUserID(ctx, viewer.ID), project.ID, viewer.ID, personalID, nil); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("second compatibility clear error=%v want ErrNotFound", err)
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		user User
+		want error
+	}{
+		{"viewer", viewer, ErrUnauthorized},
+		{"contributor", contributor, ErrUnauthorized},
+		{"maintainer", maintainer, nil},
+		{"owner", owner, nil},
+	} {
+		t.Run(tc.name+" board row authority", func(t *testing.T) {
+			color := "#abcdef"
+			err := st.UpdateTagColorForDurableProjectByID(WithUserID(ctx, tc.user.ID), project.ID, tc.user.ID, boardID, &color)
+			if tc.want == nil && err != nil {
+				t.Fatalf("update: %v", err)
+			}
+			if tc.want != nil && !errors.Is(err, tc.want) {
+				t.Fatalf("error=%v want %v", err, tc.want)
+			}
+		})
+	}
+
+	t.Run("wrong project is hidden before shared-row role matters", func(t *testing.T) {
+		color := "#abcdef"
+		err := st.UpdateTagColorForDurableProjectByID(WithUserID(ctx, viewer.ID), project.ID, viewer.ID, foreignID, &color)
+		if !errors.Is(err, ErrNotFound) {
+			t.Fatalf("error=%v want ErrNotFound", err)
+		}
+	})
+}
+
+// TestTagMutationStoreTemporaryAndExpiryContracts records the current split: anonymous
+// deletion revalidates project kind and expiry, while direct temporary color mutation
+// validates tag/project relationship but currently does not reject an expired board.
+func TestTagMutationStoreTemporaryAndExpiryContracts(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	owner, _ := st.BootstrapUser(ctx, "tag-temp-owner@example.com", "password", "Owner")
+	ctxOwner := WithUserID(ctx, owner.ID)
+	creatorTemporary, err := st.CreateAnonymousBoard(ctxOwner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherTemporary, err := st.CreateAnonymousBoard(ctxOwner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plNewTodo(t, st, ctxOwner, creatorTemporary.ID, "personal", "personal-temp")
+	personalID := plTagRowID(t, st, "personal-temp", owner.ID)
+	boardID := plInsertBoardScopedTag(t, st, creatorTemporary.ID, "board-temp", nil)
+	foreignID := plInsertBoardScopedTag(t, st, otherTemporary.ID, "foreign-temp", nil)
+
+	t.Run("creator and anonymous-link display dispatch differ for personal row", func(t *testing.T) {
+		ownerColor := "#111111"
+		if err := st.UpdateTagColorForTemporaryBoard(ctxOwner, creatorTemporary.ID, &owner.ID, personalID, &ownerColor); err != nil {
+			t.Fatalf("owner temp color: %v", err)
+		}
+		assertTagMutationStoreColor(t, tagMutationStoreColor(t, st, owner.ID, personalID), &ownerColor)
+		anonymousColor := "#222222"
+		if err := st.UpdateTagColorForTemporaryBoard(ctx, creatorTemporary.ID, nil, personalID, &anonymousColor); err != nil {
+			t.Fatalf("anonymous link color: %v", err)
+		}
+		assertTagMutationStoreColor(t, tagMutationStoreBoardColor(t, st, personalID), &anonymousColor)
+	})
+
+	t.Run("foreign board row hidden", func(t *testing.T) {
+		color := "#333333"
+		if err := st.UpdateTagColorForTemporaryBoard(ctxOwner, creatorTemporary.ID, &owner.ID, foreignID, &color); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("foreign update error=%v want ErrNotFound", err)
+		}
+	})
+
+	t.Run("creator temporary board is not anonymous deletion scope", func(t *testing.T) {
+		if err := st.DeleteTag(ctx, 0, boardID, true); !errors.Is(err, ErrUnauthorized) {
+			t.Fatalf("anonymous-claim delete error=%v want ErrUnauthorized", err)
+		}
+		if err := st.DeleteTag(ctxOwner, owner.ID, boardID, false); !errors.Is(err, ErrUnauthorized) {
+			t.Fatalf("creator authenticated delete error=%v want ErrUnauthorized", err)
+		}
+		var remaining int
+		if err := st.db.QueryRow(`SELECT COUNT(*) FROM tags WHERE id = ?`, boardID).Scan(&remaining); err != nil || remaining != 1 {
+			t.Fatalf("creator temporary board row remaining=%d err=%v want 1", remaining, err)
+		}
+	})
+
+	t.Run("expired anonymous delete rejects but direct temp color currently succeeds", func(t *testing.T) {
+		anonymous, err := st.CreateAnonymousBoard(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		anonymousTagID := plInsertBoardScopedTag(t, st, anonymous.ID, "expired", nil)
+		if _, err := st.db.Exec(`UPDATE projects SET expires_at = ? WHERE id = ?`, time.Now().UTC().Add(-time.Hour).UnixMilli(), anonymous.ID); err != nil {
+			t.Fatalf("expire anonymous board: %v", err)
+		}
+		color := "#444444"
+		if err := st.UpdateTagColorForTemporaryBoard(ctx, anonymous.ID, nil, anonymousTagID, &color); err != nil {
+			t.Fatalf("current direct temp color behavior changed: %v", err)
+		}
+		assertTagMutationStoreColor(t, tagMutationStoreBoardColor(t, st, anonymousTagID), &color)
+		if err := st.DeleteTag(ctx, 0, anonymousTagID, true); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("expired anonymous delete error=%v want ErrNotFound", err)
+		}
+		var remaining int
+		if err := st.db.QueryRow(`SELECT COUNT(*) FROM tags WHERE id = ?`, anonymousTagID).Scan(&remaining); err != nil || remaining != 1 {
+			t.Fatalf("expired tag remaining=%d err=%v", remaining, err)
+		}
+	})
+}
+
+// TestTagMutationStoreDeleteAffectedProjectsAndAtomicity freezes zero/multi-project
+// results, own-row-only grouped deletion, cascade cleanup, and transaction rollback.
+func TestTagMutationStoreDeleteAffectedProjectsAndAtomicity(t *testing.T) {
+	t.Run("unused personal row returns zero affected projects", func(t *testing.T) {
+		st, cleanup := newTestStore(t)
+		defer cleanup()
+		ctx := context.Background()
+		owner, _ := st.BootstrapUser(ctx, "tag-unused@example.com", "password", "Owner")
+		result, err := st.db.Exec(`INSERT INTO tags(user_id, name, created_at, project_id, color) VALUES (?, 'unused', ?, NULL, NULL)`, owner.ID, time.Now().UTC().UnixMilli())
+		if err != nil {
+			t.Fatal(err)
+		}
+		tagID, _ := result.LastInsertId()
+		affected, err := st.DeleteMyTagByID(WithUserID(ctx, owner.ID), owner.ID, tagID)
+		if err != nil || len(affected) != 0 {
+			t.Fatalf("affected=%v err=%v want empty success", affected, err)
+		}
+	})
+
+	t.Run("grouped personal delete removes only caller rows and returns all projects", func(t *testing.T) {
+		st, cleanup := newTestStore(t)
+		defer cleanup()
+		ctx := context.Background()
+		owner, _ := st.BootstrapUser(ctx, "tag-group-owner@example.com", "password", "Owner")
+		member, _ := st.CreateUser(ctx, "tag-group-member@example.com", "password", "Member")
+		ctxOwner := WithUserID(ctx, owner.ID)
+		ctxMember := WithUserID(ctx, member.ID)
+		projectA, _ := st.CreateProject(ctxOwner, "Tag Group A")
+		projectB, _ := st.CreateProject(ctxOwner, "Tag Group B")
+		plAddMember(t, st, projectA.ID, member.ID, RoleMaintainer)
+		plNewTodo(t, st, ctxOwner, projectA.ID, "owner a", "shared")
+		plNewTodo(t, st, ctxOwner, projectB.ID, "owner b", "shared")
+		plNewTodo(t, st, ctxMember, projectA.ID, "member a", "shared")
+		ownerTagID := plTagRowID(t, st, "shared", owner.ID)
+		memberTagID := plTagRowID(t, st, "shared", member.ID)
+
+		affected, err := st.DeleteMyTagByName(ctxOwner, projectA.ID, owner.ID, "shared")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := []int64{projectA.ID, projectB.ID}; !reflect.DeepEqual(affected, want) {
+			t.Fatalf("affected=%v want=%v", affected, want)
+		}
+		var ownerRows, memberRows int
+		_ = st.db.QueryRow(`SELECT COUNT(*) FROM tags WHERE id = ?`, ownerTagID).Scan(&ownerRows)
+		_ = st.db.QueryRow(`SELECT COUNT(*) FROM tags WHERE id = ?`, memberTagID).Scan(&memberRows)
+		if ownerRows != 0 || memberRows != 1 {
+			t.Fatalf("owner rows=%d member rows=%d want 0/1", ownerRows, memberRows)
+		}
+	})
+
+	t.Run("delete transaction rolls todo links back when tag delete fails", func(t *testing.T) {
+		st, cleanup := newTestStore(t)
+		defer cleanup()
+		ctx := context.Background()
+		owner, _ := st.BootstrapUser(ctx, "tag-rollback@example.com", "password", "Owner")
+		ctxOwner := WithUserID(ctx, owner.ID)
+		project, _ := st.CreateProject(ctxOwner, "Tag Rollback")
+		plNewTodo(t, st, ctxOwner, project.ID, "rollback", "rollback")
+		tagID := plTagRowID(t, st, "rollback", owner.ID)
+		color := "#123456"
+		if err := st.UpdateTagColor(ctxOwner, &owner.ID, tagID, &color); err != nil {
+			t.Fatal(err)
+		}
+		trigger := fmt.Sprintf(`
+CREATE TRIGGER reject_characterized_tag_delete
+BEFORE DELETE ON tags
+WHEN OLD.id = %d
+BEGIN
+  SELECT RAISE(ABORT, 'forced tag delete failure');
+END`, tagID)
+		if _, err := st.db.Exec(trigger); err != nil {
+			t.Fatalf("create test trigger: %v", err)
+		}
+		if _, err := st.DeleteMyTagByID(ctxOwner, owner.ID, tagID); err == nil {
+			t.Fatal("expected forced delete failure")
+		}
+		for table, query := range map[string]string{
+			"tags":            `SELECT COUNT(*) FROM tags WHERE id = ?`,
+			"todo_tags":       `SELECT COUNT(*) FROM todo_tags WHERE tag_id = ?`,
+			"project_tags":    `SELECT COUNT(*) FROM project_tags WHERE tag_id = ?`,
+			"user_tag_colors": `SELECT COUNT(*) FROM user_tag_colors WHERE tag_id = ?`,
+		} {
+			var count int
+			if err := st.db.QueryRow(query, tagID).Scan(&count); err != nil || count != 1 {
+				t.Fatalf("%s count=%d err=%v want 1 after rollback", table, count, err)
+			}
+		}
+		if _, err := st.db.Exec(`DROP TRIGGER reject_characterized_tag_delete`); err != nil {
+			t.Fatalf("drop test trigger: %v", err)
+		}
+		if _, err := st.DeleteMyTagByID(ctxOwner, owner.ID, tagID); err != nil {
+			t.Fatalf("delete after removing test trigger: %v", err)
+		}
+		for table, query := range map[string]string{
+			"tags":            `SELECT COUNT(*) FROM tags WHERE id = ?`,
+			"todo_tags":       `SELECT COUNT(*) FROM todo_tags WHERE tag_id = ?`,
+			"project_tags":    `SELECT COUNT(*) FROM project_tags WHERE tag_id = ?`,
+			"user_tag_colors": `SELECT COUNT(*) FROM user_tag_colors WHERE tag_id = ?`,
+		} {
+			var count int
+			if err := st.db.QueryRow(query, tagID).Scan(&count); err != nil || count != 0 {
+				t.Fatalf("%s count=%d err=%v want 0 after successful delete/cascade", table, count, err)
+			}
+		}
+	})
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.33.3"
+const Version = "3.33.4"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
all four mutation families independently prove adapter -> internal/application/tag -> store ownership, the forbidden direct-handler searches are clean, REST publication and MCP silence are structurally verified, characterization tests remain intact, and the full repository/static/build/docs gates pass.