### PR TITLE
fix: prevent SSRF in webhook delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-> **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.33.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags), **3.29.0** (MCP JSON-RPC error/`board_get` identity), **3.30.0** (reversible per-project sprint capability), **3.31.0** (per-project priority tiers), **3.33.0** (Agenda ICS feeds need `SCRUMBOY_ENCRYPTION_KEY`) - see those releases.
+> **Upgrades:** No breaking changes for **3.7.0 ≤ v ≤ 3.33.x** unless noted below. Notable upgrade impact: **3.22.0** (MCP/OAuth), **3.24.0** (MCP tool names), **3.26.0** (MCP project tags), **3.29.0** (MCP JSON-RPC error/`board_get` identity), **3.30.0** (reversible per-project sprint capability), **3.31.0** (per-project priority tiers), **3.33.0** (Agenda ICS feeds need `SCRUMBOY_ENCRYPTION_KEY`), **3.33.12** (webhook destinations must be publicly routable) - see those releases.
+
+## [3.33.12] - 2026-09-06
+
+### Security
+
+- **Webhook SSRF** - Outbound webhook delivery resolves, classifies, and dials
+  a vetted IP instead of using Go's default HTTP client. Destinations that
+  resolve to loopback, LAN/private, Docker/internal, link-local, metadata, or
+  related blocked ranges are no longer delivered, including URLs already stored
+  before upgrade. Redirects are not followed. Webhook delivery ignores
+  environment `HTTP_PROXY`/`HTTPS_PROXY`. Public `http` and `https` webhook
+  URLs remain supported.
 
 ## [3.33.11] - 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img width="372" src="internal/httpapi/web/githublogo.png" alt="scrumboy logo" />
   <br />
-  <img src="https://img.shields.io/badge/version-v3.33.11-blue" alt="version" />
+  <img src="https://img.shields.io/badge/version-v3.33.12-blue" alt="version" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--v3-orange" alt="license" /></a>
   <img src="https://img.shields.io/badge/i18n-23%20languages-yellow" alt="i18n" />
   <a href="https://github.com/markrai/scrumboy/actions/workflows/ci.yml"><img src="https://github.com/markrai/scrumboy/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
@@ -485,7 +485,7 @@ Scrumboy can **POST JSON to URLs you register** when certain events occur. This 
 - **Who can configure:** Project **maintainers**, via the HTTP API only - there is **no settings screen** for webhooks yet.
 - **API:** `POST /api/webhooks` (create), `GET /api/webhooks` (list yours), `DELETE /api/webhooks/{id}` - same session cookie / CSRF header rules as other mutating `/api/`* calls.
 - **Events:** Subscribe to specific types (e.g. `todo.assigned`) or `*` for all delivered types. The set may grow over time; unused types in your list are harmless.
-- **Security:** Optional per-webhook **secret**; when set, requests include an `X-Scrumboy-Signature` header (`sha256=` HMAC of the raw JSON body).
+- **Security:** Optional per-webhook **secret**; when set, requests include an `X-Scrumboy-Signature` header (`sha256=` HMAC of the raw JSON body). Destinations must be publicly routable `http` or `https` URLs. Loopback, private, link-local, and metadata addresses are refused at delivery time (including URLs stored before upgrade). Redirects are not followed. Webhook delivery ignores environment `HTTP_PROXY`/`HTTPS_PROXY` settings so proxy routing cannot bypass destination validation.
 - **Semantics:** Best-effort delivery with retries on failure; not a durable external queue - design for idempotent receivers using the event `id` in the JSON body.
 
 Example create (replace cookie / project id / URL):

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -34,7 +34,7 @@ Paste the provider’s **secret or published ICS address**, not a calendar webpa
 | Outlook | Calendar settings → **Publish a calendar** → ICS link |
 | Apple / iCloud | An `https://` calendar URL. `webcal://` is rejected. |
 
-Only `https` is accepted. Userinfo in the URL (`https://user:pass@…`) is rejected. Loopback, private, and link-local destinations are blocked when the server stores or fetches a feed.
+Only `https` is accepted. Userinfo in the URL (`https://user:pass@…`) is rejected. Loopback, private, and link-local destinations are blocked when the server stores or fetches a feed. Address classification is shared with outbound webhook delivery.
 
 ## Using the lane
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -80,7 +80,7 @@ Security depends on correct deployment and configuration (HTTPS, secrets, IdP ha
 
 **Intended protections:** limit damage from stolen database files (hashed secrets), stolen backups that omit hashes where designed, CSRF from foreign origins against cookie sessions, silent account takeover via email collision on OIDC, reuse of OAuth refresh tokens, and casual tampering with `audit_events` through the application.
 
-**Non-goals:** multi-tenant cloud isolation between hostile co-tenants on one process; cryptographic proof against DBA forgery of audit rows; SSRF-proof webhooks to arbitrary maintainer URLs; formal assurance cases or signed every release artifact.
+**Non-goals:** multi-tenant cloud isolation between hostile co-tenants on one process; cryptographic proof against DBA forgery of audit rows; formal assurance cases or signed every release artifact.
 
 ---
 
@@ -305,9 +305,9 @@ Assignee history uses a separate `todo_assignee_events` table (also append-orien
 
 ### Webhooks
 
-- Maintainers configure outbound HTTP URLs (http/https with a host). Optional shared secret produces `X-Scrumboy-Signature` (`sha256=` HMAC of the body).
+- Maintainers configure outbound HTTP URLs (`http`/`https` with a host). Optional shared secret produces `X-Scrumboy-Signature` (`sha256=` HMAC of the body).
 - Delivery uses a small retry worker and timeouts; secrets are stored as configured (not hashed like session tokens) and omitted from list API responses.
-- **No** application denylist for private/link-local destinations: a maintainer-chosen URL is trusted. Treat webhook URLs as sensitive configuration (SSRF risk to internal networks if a privileged user is tricked or compromised).
+- Outbound delivery resolves the destination, refuses loopback/private/link-local/special-purpose addresses, and dials a vetted IP directly (the same classification used for Agenda ICS fetches). Redirects are not followed. `HTTP_PROXY`/`HTTPS_PROXY` are ignored for webhook delivery. Create-time URL checks reject literal unsafe hosts; **dial-time enforcement** is what protects already-stored URLs after upgrade.
 - Shutdown drains in-flight mail/webhook work as implemented in process lifecycle.
 
 ---
@@ -408,7 +408,7 @@ This is not a full environment-variable catalog—see the root `[README.md](../R
 - No claim of formal security certification or third-party audit in this repository.
 - Scanner coverage is incomplete relative to “every commit on every tool” (Snyk/govulncheck manual; Trivy branch-gated; no CodeQL analyze).
 - External trust in IdPs, SMTP relays, browser push services, and webhook receivers.
-- Webhook URLs are not SSRF-filtered beyond scheme/host parse rules.
+- Webhook destinations must be publicly routable; loopback, RFC1918, link-local, and related ranges are refused at dial time (LAN/Docker-internal webhook URLs will not be delivered).
 - Some push payload / click deep-link contracts rely on manual or browser checks rather than automated field-contract tests (see ops docs).
 - Historical point-in-time “0 findings” tables are snapshots, not continuous guarantees.
 

--- a/internal/application/calendar/fetch.go
+++ b/internal/application/calendar/fetch.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"scrumboy/internal/calendar/ics"
+	"scrumboy/internal/safehttp"
 )
 
 const defaultFetchTimeout = 10 * time.Second
@@ -159,111 +160,31 @@ func (f *HTTPFetcher) validateURL(u *url.URL) error {
 }
 
 func (f *HTTPFetcher) dialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	host, port, err := net.SplitHostPort(address)
-	if err != nil {
-		return nil, ErrFeedRequest
+	conn, err := safehttp.Dialer{
+		LookupIP:  f.LookupIP,
+		Forbidden: f.blockedIP,
+	}.DialContext(ctx, network, address)
+	if err == nil {
+		return conn, nil
 	}
-	lookup := f.LookupIP
-	if lookup == nil {
-		lookup = defaultLookupIP
+	if errors.Is(err, safehttp.ErrForbidden) {
+		return nil, ErrFeedBlocked
 	}
-	ips, err := lookup(ctx, host)
-	if err != nil {
-		return nil, ErrFeedRequest
-	}
-	if len(ips) == 0 {
-		return nil, ErrFeedRequest
-	}
-	var last error
-	dialer := &net.Dialer{Timeout: 5 * time.Second}
-	for _, ip := range ips {
-		if f.blockedIP(ip) {
-			last = ErrFeedBlocked
-			continue
-		}
-		conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
-		if err == nil {
-			return conn, nil
-		}
-		last = ErrFeedRequest
-	}
-	if last == nil {
-		last = ErrFeedBlocked
-	}
-	return nil, last
+	return nil, ErrFeedRequest
 }
 
 func (f *HTTPFetcher) blockedIP(ip net.IP) bool {
 	if ip == nil {
 		return true
 	}
+	classified := ip
 	if v4 := ip.To4(); v4 != nil {
-		ip = v4
+		classified = v4
 	}
-	if ip.IsLoopback() {
+	if classified.IsLoopback() {
 		return !f.AllowLoopback
 	}
-	return ip.IsPrivate() ||
-		ip.IsLinkLocalUnicast() ||
-		ip.IsLinkLocalMulticast() ||
-		ip.IsMulticast() ||
-		ip.IsUnspecified() ||
-		blockedSpecialPurposeIP(ip)
-}
-
-var blockedSpecialPurposeNets = mustParseCIDRs(
-	"100.64.0.0/10", // CGNAT / shared address space (RFC 6598)
-	"0.0.0.0/8",     // this network
-	"192.0.0.0/24",  // IETF protocol assignments
-	"192.0.2.0/24",  // TEST-NET-1
-	"198.51.100.0/24",
-	"203.0.113.0/24",
-	"198.18.0.0/15", // benchmarking
-	"240.0.0.0/4",   // reserved
-	"255.255.255.255/32",
-	"64:ff9b::/96",  // NAT64
-	"100::/64",      // discard-only
-	"2001:db8::/32", // documentation
-	"2002::/16",     // 6to4
-	"fec0::/10",     // deprecated site-local
-)
-
-func mustParseCIDRs(cidrs ...string) []*net.IPNet {
-	out := make([]*net.IPNet, 0, len(cidrs))
-	for _, cidr := range cidrs {
-		_, network, err := net.ParseCIDR(cidr)
-		if err != nil {
-			panic(err)
-		}
-		out = append(out, network)
-	}
-	return out
-}
-
-func blockedSpecialPurposeIP(ip net.IP) bool {
-	for _, network := range blockedSpecialPurposeNets {
-		if network.Contains(ip) {
-			return true
-		}
-	}
-	return false
-}
-
-func defaultLookupIP(ctx context.Context, host string) ([]net.IP, error) {
-	if ip := net.ParseIP(host); ip != nil {
-		return []net.IP{ip}, nil
-	}
-	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]net.IP, 0, len(addrs))
-	for _, addr := range addrs {
-		if addr.IP != nil {
-			out = append(out, addr.IP)
-		}
-	}
-	return out, nil
+	return safehttp.IsForbiddenIP(ip)
 }
 
 func sanitizeFetchError(err error) error {
@@ -271,7 +192,7 @@ func sanitizeFetchError(err error) error {
 		return nil
 	}
 	switch {
-	case errors.Is(err, ErrFeedBlocked):
+	case errors.Is(err, ErrFeedBlocked), errors.Is(err, safehttp.ErrForbidden):
 		return ErrFeedBlocked
 	case errors.Is(err, ErrFeedTooLarge):
 		return ErrFeedTooLarge

--- a/internal/httpapi/eventbus_regression_test.go
+++ b/internal/httpapi/eventbus_regression_test.go
@@ -608,11 +608,12 @@ func TestWebhookWorker_SignatureHeader(t *testing.T) {
 	defer ts.Close()
 
 	q := newWebhookQueue(log.New(io.Discard, "", 0))
-	w := newWebhookWorker(q, log.New(io.Discard, "", 0))
+	client, publicURL := webhookClientToTestServer(t, ts, "hooks.example")
+	w := newWebhookWorkerWithClient(q, log.New(io.Discard, "", 0), client)
 
 	q.Enqueue(webhookDelivery{
 		WebhookID: 1,
-		URL:       ts.URL,
+		URL:       publicURL + "/",
 		Secret:    &secret,
 		EventID:   "evt-1",
 		EventType: "todo.assigned",

--- a/internal/httpapi/webhook_ssrf_test.go
+++ b/internal/httpapi/webhook_ssrf_test.go
@@ -1,0 +1,264 @@
+package httpapi
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"scrumboy/internal/safehttp"
+)
+
+func TestSendWebhookBlocksStoredLoopbackURL(t *testing.T) {
+	var hits atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		hits.Add(1)
+	}))
+	defer ts.Close()
+
+	err := sendWebhook(newWebhookHTTPClient(), webhookDelivery{
+		WebhookID: 1,
+		URL:       ts.URL + "/hook",
+		EventID:   "evt-1",
+		EventType: "todo.assigned",
+		Body:      []byte(`{"id":"evt-1"}`),
+	})
+	if !errors.Is(err, safehttp.ErrForbidden) {
+		t.Fatalf("err=%v, want ErrForbidden", err)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("loopback listener was contacted %d times", hits.Load())
+	}
+}
+
+func TestSendWebhookDialsVettedIPAndPreservesHMAC(t *testing.T) {
+	var method, ctype, event, delivery, sig string
+	var body []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		ctype = r.Header.Get("Content-Type")
+		event = r.Header.Get("X-Scrumboy-Event")
+		delivery = r.Header.Get("X-Scrumboy-Delivery")
+		sig = r.Header.Get("X-Scrumboy-Signature")
+		body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	client, publicURL := webhookClientToTestServer(t, ts, "hooks.example")
+	secret := "shared-secret"
+	payload := []byte(`{"id":"evt-9","type":"todo.created"}`)
+	if err := sendWebhook(client, webhookDelivery{
+		WebhookID: 9,
+		URL:       publicURL + "/path?q=1",
+		Secret:    &secret,
+		EventID:   "evt-9",
+		EventType: "todo.created",
+		Body:      payload,
+	}); err != nil {
+		t.Fatalf("sendWebhook: %v", err)
+	}
+	if method != http.MethodPost {
+		t.Fatalf("method=%q", method)
+	}
+	if ctype != "application/json; charset=utf-8" {
+		t.Fatalf("content-type=%q", ctype)
+	}
+	if event != "todo.created" || delivery != "evt-9" {
+		t.Fatalf("event=%q delivery=%q", event, delivery)
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	wantSig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if sig != wantSig {
+		t.Fatalf("sig=%q want %q", sig, wantSig)
+	}
+	if string(body) != string(payload) {
+		t.Fatalf("body=%q", body)
+	}
+}
+
+func TestSendWebhookDoesNotFollowRedirectToLoopback(t *testing.T) {
+	var privateHits atomic.Int32
+	private := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		privateHits.Add(1)
+	}))
+	defer private.Close()
+
+	public := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, private.URL+"/internal", http.StatusTemporaryRedirect)
+	}))
+	defer public.Close()
+
+	client, publicURL := webhookClientToTestServer(t, public, "hooks.example")
+	err := sendWebhook(client, webhookDelivery{
+		URL:       publicURL + "/start",
+		EventID:   "evt-307",
+		EventType: "todo.assigned",
+		Body:      []byte(`{"id":"evt-307"}`),
+	})
+	if !errors.Is(err, errWebhookRedirect) {
+		t.Fatalf("err=%v, want errWebhookRedirect", err)
+	}
+	if privateHits.Load() != 0 {
+		t.Fatalf("private server hits=%d", privateHits.Load())
+	}
+}
+
+func TestSendWebhookDoesNotFollow302(t *testing.T) {
+	var privateHits atomic.Int32
+	private := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		privateHits.Add(1)
+	}))
+	defer private.Close()
+
+	public := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, private.URL+"/internal", http.StatusFound)
+	}))
+	defer public.Close()
+
+	client, publicURL := webhookClientToTestServer(t, public, "hooks.example")
+	err := sendWebhook(client, webhookDelivery{
+		URL:       publicURL + "/start",
+		EventID:   "evt-302",
+		EventType: "todo.assigned",
+		Body:      []byte(`{"id":"evt-302"}`),
+	})
+	if !errors.Is(err, errWebhookRedirect) {
+		t.Fatalf("err=%v, want errWebhookRedirect", err)
+	}
+	if privateHits.Load() != 0 {
+		t.Fatalf("private server hits=%d", privateHits.Load())
+	}
+}
+
+func TestSendWebhookHostnameResolvingPrivateIsForbidden(t *testing.T) {
+	dialed := 0
+	client := newWebhookHTTPClientWithDialer(safehttp.Dialer{
+		LookupIP: func(context.Context, string) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("10.1.2.3")}, nil
+		},
+		Dial: func(context.Context, string, string) (net.Conn, error) {
+			dialed++
+			return nil, errors.New("should not dial")
+		},
+	})
+	err := sendWebhook(client, webhookDelivery{
+		URL:       "https://hooks.example/hook",
+		EventID:   "evt-priv",
+		EventType: "todo.assigned",
+		Body:      []byte(`{}`),
+	})
+	if !errors.Is(err, safehttp.ErrForbidden) {
+		t.Fatalf("err=%v, want ErrForbidden", err)
+	}
+	if dialed != 0 {
+		t.Fatalf("dialed %d times", dialed)
+	}
+}
+
+func TestWebhookForbiddenErrorIsPermanent(t *testing.T) {
+	var sendCalls atomic.Int32
+	q := newWebhookQueue(discardLogger())
+	send := func(d webhookDelivery) error {
+		sendCalls.Add(1)
+		return sendWebhook(newWebhookHTTPClient(), d)
+	}
+	inner := newRetryWorker(q, discardLogger(), "webhook", send)
+	inner.isPermanent = isPermanentWebhookError
+	w := &webhookWorker{retryWorker: inner}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go w.Run(runCtx)
+
+	q.Enqueue(webhookDelivery{
+		WebhookID: 1,
+		URL:       "http://127.0.0.1/hook",
+		EventID:   "stored-unsafe",
+		EventType: "todo.assigned",
+		Body:      []byte(`{}`),
+	})
+
+	deadline := time.After(2 * time.Second)
+	for sendCalls.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("send was never called")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	time.Sleep(250 * time.Millisecond)
+	if got := sendCalls.Load(); got != 1 {
+		t.Fatalf("attempts=%d, want 1 (permanent forbidden)", got)
+	}
+}
+
+func TestWebhookHTTPClientDisablesProxyAndRedirects(t *testing.T) {
+	client := newWebhookHTTPClient()
+	if client.CheckRedirect == nil {
+		t.Fatal("CheckRedirect must reject redirects")
+	}
+	if err := client.CheckRedirect(&http.Request{}, nil); !errors.Is(err, errWebhookRedirect) {
+		t.Fatalf("CheckRedirect err=%v", err)
+	}
+	rt, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("Transport is not *http.Transport")
+	}
+	if rt.Proxy != nil {
+		t.Fatal("Proxy must be nil")
+	}
+	if !rt.DisableKeepAlives {
+		t.Fatal("keep-alives must be disabled")
+	}
+	if rt.DialContext == nil {
+		t.Fatal("DialContext must be the vetted dialer")
+	}
+	if !rt.ForceAttemptHTTP2 {
+		t.Fatal("ForceAttemptHTTP2 must be true so HTTP/2 compatibility is preserved")
+	}
+	if rt.TLSClientConfig == nil || rt.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("TLS min version=%v, want TLS1.2", rt.TLSClientConfig)
+	}
+}
+
+func webhookClientToTestServer(t *testing.T, ts *httptest.Server, hostname string) (*http.Client, string) {
+	t.Helper()
+	parsed, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	_, port, err := net.SplitHostPort(parsed.Host)
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+	target := ts.Listener.Addr().String()
+	client := newWebhookHTTPClientWithDialer(safehttp.Dialer{
+		LookupIP: func(_ context.Context, host string) ([]net.IP, error) {
+			if host != hostname {
+				return nil, errors.New("unexpected host " + host)
+			}
+			return []net.IP{net.ParseIP("8.8.8.8")}, nil
+		},
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			want := net.JoinHostPort("8.8.8.8", port)
+			if address != want {
+				return nil, errors.New("dialed " + address + ", want " + want)
+			}
+			var n net.Dialer
+			return n.DialContext(ctx, "tcp", target)
+		},
+	})
+	return client, "http://" + hostname + ":" + port
+}

--- a/internal/httpapi/webhook_worker.go
+++ b/internal/httpapi/webhook_worker.go
@@ -4,22 +4,58 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/hex"
+	"errors"
 	"log"
 	"net/http"
 	"time"
+
+	"scrumboy/internal/safehttp"
 )
+
+var errWebhookRedirect = errors.New("webhook redirects are not allowed")
 
 type webhookWorker struct {
 	*retryWorker[webhookDelivery]
 }
 
 func newWebhookWorker(queue *webhookQueue, logger *log.Logger) *webhookWorker {
-	client := &http.Client{Timeout: 10 * time.Second}
+	return newWebhookWorkerWithClient(queue, logger, newWebhookHTTPClient())
+}
+
+func newWebhookWorkerWithClient(queue *webhookQueue, logger *log.Logger, client *http.Client) *webhookWorker {
 	send := func(d webhookDelivery) error {
 		return sendWebhook(client, d)
 	}
-	return &webhookWorker{retryWorker: newRetryWorker(queue, logger, "webhook", send)}
+	inner := newRetryWorker(queue, logger, "webhook", send)
+	inner.isPermanent = isPermanentWebhookError
+	return &webhookWorker{retryWorker: inner}
+}
+
+func newWebhookHTTPClient() *http.Client {
+	return newWebhookHTTPClientWithDialer(safehttp.Dialer{})
+}
+
+func newWebhookHTTPClientWithDialer(d safehttp.Dialer) *http.Client {
+	return &http.Client{
+		Timeout: 10 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return errWebhookRedirect
+		},
+		Transport: &http.Transport{
+			Proxy:               nil,
+			DisableKeepAlives:   true,
+			ForceAttemptHTTP2:   true,
+			TLSHandshakeTimeout: 5 * time.Second,
+			TLSClientConfig:     &tls.Config{MinVersion: tls.VersionTLS12},
+			DialContext:         safehttp.NewDialContext(d),
+		},
+	}
+}
+
+func isPermanentWebhookError(err error) bool {
+	return errors.Is(err, safehttp.ErrForbidden) || errors.Is(err, errWebhookRedirect)
 }
 
 func sendWebhook(client *http.Client, d webhookDelivery) error {

--- a/internal/safehttp/dial.go
+++ b/internal/safehttp/dial.go
@@ -1,0 +1,103 @@
+package safehttp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"time"
+)
+
+// ErrForbidden is returned when every resolved address is unsafe to dial.
+var ErrForbidden = errors.New("destination address is not allowed")
+
+const defaultDialTimeout = 5 * time.Second
+
+// LookupIPFunc resolves host to IP addresses. Host may already be a literal IP.
+type LookupIPFunc func(ctx context.Context, host string) ([]net.IP, error)
+
+// Dialer resolves address, drops forbidden IPs, and dials a vetted IP directly
+// so the HTTP transport cannot perform a second DNS lookup.
+type Dialer struct {
+	// LookupIP defaults to the process resolver (literal IPs are not looked up).
+	LookupIP LookupIPFunc
+	// Forbidden defaults to IsForbiddenIP.
+	Forbidden func(net.IP) bool
+	// Timeout is the TCP dial timeout when Dial is nil. Zero means 5s.
+	Timeout time.Duration
+	// Dial is the TCP connect function. The address argument is always host:port
+	// with a vetted IP host (never the original hostname). Nil uses net.Dialer.
+	Dial func(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// NewDialContext returns a DialContext suitable for http.Transport.
+func NewDialContext(d Dialer) func(ctx context.Context, network, address string) (net.Conn, error) {
+	return d.DialContext
+}
+
+// DialContext resolves address, skips forbidden IPs, and connects to a remaining
+// vetted address. Mixed DNS answers may only produce connections to allowed IPs.
+func (d Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	lookup := d.LookupIP
+	if lookup == nil {
+		lookup = defaultLookupIP
+	}
+	forbidden := d.Forbidden
+	if forbidden == nil {
+		forbidden = IsForbiddenIP
+	}
+	ips, err := lookup(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	if len(ips) == 0 {
+		return nil, errors.New("no IP addresses")
+	}
+	dial := d.Dial
+	if dial == nil {
+		timeout := d.Timeout
+		if timeout <= 0 {
+			timeout = defaultDialTimeout
+		}
+		inner := &net.Dialer{Timeout: timeout}
+		dial = inner.DialContext
+	}
+
+	var lastDial error
+	triedPermitted := false
+	for _, ip := range ips {
+		if forbidden(ip) {
+			continue
+		}
+		triedPermitted = true
+		conn, err := dial(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastDial = err
+	}
+	if !triedPermitted {
+		return nil, ErrForbidden
+	}
+	return nil, lastDial
+}
+
+func defaultLookupIP(ctx context.Context, host string) ([]net.IP, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return []net.IP{ip}, nil
+	}
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]net.IP, 0, len(addrs))
+	for _, addr := range addrs {
+		if addr.IP != nil {
+			out = append(out, addr.IP)
+		}
+	}
+	return out, nil
+}

--- a/internal/safehttp/dial_test.go
+++ b/internal/safehttp/dial_test.go
@@ -1,0 +1,202 @@
+package safehttp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+)
+
+func TestDialContextDialsVettedIPNotHostname(t *testing.T) {
+	t.Parallel()
+
+	var dialed []string
+	d := Dialer{
+		LookupIP: func(context.Context, string) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("8.8.8.8")}, nil
+		},
+		Dial: func(_ context.Context, network, address string) (net.Conn, error) {
+			dialed = append(dialed, network+" "+address)
+			c1, c2 := net.Pipe()
+			_ = c2.Close()
+			return c1, nil
+		},
+	}
+
+	conn, err := d.DialContext(context.Background(), "tcp", "hooks.example:443")
+	if err != nil {
+		t.Fatalf("DialContext: %v", err)
+	}
+	_ = conn.Close()
+	if len(dialed) != 1 || dialed[0] != "tcp 8.8.8.8:443" {
+		t.Fatalf("dialed %v, want tcp 8.8.8.8:443 (not the hostname)", dialed)
+	}
+}
+
+func TestDialContextSkipsForbiddenAndDialsAllowed(t *testing.T) {
+	t.Parallel()
+
+	var dialed []string
+	d := Dialer{
+		LookupIP: func(context.Context, string) ([]net.IP, error) {
+			return []net.IP{
+				net.ParseIP("10.1.2.3"),
+				net.ParseIP("8.8.8.8"),
+				net.ParseIP("192.168.0.9"),
+			}, nil
+		},
+		Dial: func(_ context.Context, _, address string) (net.Conn, error) {
+			dialed = append(dialed, address)
+			c1, c2 := net.Pipe()
+			_ = c2.Close()
+			return c1, nil
+		},
+	}
+
+	conn, err := d.DialContext(context.Background(), "tcp", "mixed.example:443")
+	if err != nil {
+		t.Fatalf("DialContext: %v", err)
+	}
+	_ = conn.Close()
+	if len(dialed) != 1 || dialed[0] != "8.8.8.8:443" {
+		t.Fatalf("dialed %v, want only 8.8.8.8:443", dialed)
+	}
+}
+
+func TestDialContextAllForbidden(t *testing.T) {
+	t.Parallel()
+
+	dialed := 0
+	d := Dialer{
+		LookupIP: func(context.Context, string) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("10.1.2.3"), net.ParseIP("169.254.169.254")}, nil
+		},
+		Dial: func(context.Context, string, string) (net.Conn, error) {
+			dialed++
+			return nil, errors.New("should not dial")
+		},
+	}
+	_, err := d.DialContext(context.Background(), "tcp", "evil.example:80")
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("err=%v, want ErrForbidden", err)
+	}
+	if dialed != 0 {
+		t.Fatalf("dialed %d times", dialed)
+	}
+}
+
+func TestDialContextLiteralLoopback(t *testing.T) {
+	t.Parallel()
+
+	dialed := 0
+	d := Dialer{
+		Dial: func(context.Context, string, string) (net.Conn, error) {
+			dialed++
+			return nil, errors.New("should not dial")
+		},
+	}
+	_, err := d.DialContext(context.Background(), "tcp", "127.0.0.1:80")
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("err=%v, want ErrForbidden", err)
+	}
+	if dialed != 0 {
+		t.Fatalf("dialed %d times", dialed)
+	}
+}
+
+func TestDialContextResolvesOnce(t *testing.T) {
+	t.Parallel()
+
+	lookups := 0
+	d := Dialer{
+		LookupIP: func(context.Context, string) ([]net.IP, error) {
+			lookups++
+			if lookups == 1 {
+				return []net.IP{net.ParseIP("8.8.8.8")}, nil
+			}
+			return []net.IP{net.ParseIP("10.0.0.1")}, nil
+		},
+		Dial: func(_ context.Context, _, address string) (net.Conn, error) {
+			if address != "8.8.8.8:443" {
+				t.Errorf("dialed %s", address)
+			}
+			c1, c2 := net.Pipe()
+			_ = c2.Close()
+			return c1, nil
+		},
+	}
+	conn, err := d.DialContext(context.Background(), "tcp", "rebind.example:443")
+	if err != nil {
+		t.Fatalf("DialContext: %v", err)
+	}
+	_ = conn.Close()
+	if lookups != 1 {
+		t.Fatalf("lookups=%d, want 1", lookups)
+	}
+}
+
+func TestDialContextPublicThenPrivateDialFailureIsNotForbidden(t *testing.T) {
+	t.Parallel()
+
+	transient := errors.New("public dial failed")
+	var dialed []string
+	d := Dialer{
+		LookupIP: func(context.Context, string) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("8.8.8.8"), net.ParseIP("10.0.0.1")}, nil
+		},
+		Dial: func(_ context.Context, _, address string) (net.Conn, error) {
+			dialed = append(dialed, address)
+			return nil, transient
+		},
+	}
+	_, err := d.DialContext(context.Background(), "tcp", "mixed.example:443")
+	if !errors.Is(err, transient) {
+		t.Fatalf("err=%v, want transient dial error", err)
+	}
+	if errors.Is(err, ErrForbidden) {
+		t.Fatal("ErrForbidden must not overwrite a permitted-IP dial failure")
+	}
+	if len(dialed) != 1 || dialed[0] != "8.8.8.8:443" {
+		t.Fatalf("dialed %v, want only 8.8.8.8:443", dialed)
+	}
+}
+
+func TestDialContextPrivateThenPublicDialFailureIsNotForbidden(t *testing.T) {
+	t.Parallel()
+
+	transient := errors.New("public dial failed")
+	var dialed []string
+	d := Dialer{
+		LookupIP: func(context.Context, string) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("8.8.8.8")}, nil
+		},
+		Dial: func(_ context.Context, _, address string) (net.Conn, error) {
+			dialed = append(dialed, address)
+			return nil, transient
+		},
+	}
+	_, err := d.DialContext(context.Background(), "tcp", "mixed.example:443")
+	if !errors.Is(err, transient) {
+		t.Fatalf("err=%v, want transient dial error", err)
+	}
+	if errors.Is(err, ErrForbidden) {
+		t.Fatal("ErrForbidden must not overwrite a permitted-IP dial failure")
+	}
+	if len(dialed) != 1 || dialed[0] != "8.8.8.8:443" {
+		t.Fatalf("dialed %v, want only 8.8.8.8:443 (private skipped)", dialed)
+	}
+}
+
+func TestNewDialContextUsesDialer(t *testing.T) {
+	t.Parallel()
+
+	fn := NewDialContext(Dialer{
+		LookupIP: func(context.Context, string) ([]net.IP, error) {
+			return []net.IP{net.ParseIP("127.0.0.1")}, nil
+		},
+	})
+	_, err := fn(context.Background(), "tcp", "localhost:80")
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("err=%v, want ErrForbidden", err)
+	}
+}

--- a/internal/safehttp/ip.go
+++ b/internal/safehttp/ip.go
@@ -1,0 +1,61 @@
+package safehttp
+
+import "net"
+
+// IsForbiddenIP reports whether ip is unsafe as an outbound destination.
+// Loopback, private (RFC1918 and IPv6 ULA), link-local, multicast, unspecified,
+// IPv4-mapped forms of those ranges, and additional special-purpose nets are
+// forbidden. A nil IP is forbidden.
+func IsForbiddenIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified() ||
+		blockedSpecialPurposeIP(ip)
+}
+
+var blockedSpecialPurposeNets = mustParseCIDRs(
+	"100.64.0.0/10", // CGNAT / shared address space (RFC 6598)
+	"0.0.0.0/8",     // this network
+	"192.0.0.0/24",  // IETF protocol assignments
+	"192.0.2.0/24",  // TEST-NET-1
+	"198.51.100.0/24",
+	"203.0.113.0/24",
+	"198.18.0.0/15", // benchmarking
+	"240.0.0.0/4",   // reserved
+	"255.255.255.255/32",
+	"64:ff9b::/96",  // NAT64
+	"100::/64",      // discard-only
+	"2001:db8::/32", // documentation
+	"2002::/16",     // 6to4
+	"fec0::/10",     // deprecated site-local
+)
+
+func mustParseCIDRs(cidrs ...string) []*net.IPNet {
+	out := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(err)
+		}
+		out = append(out, network)
+	}
+	return out
+}
+
+func blockedSpecialPurposeIP(ip net.IP) bool {
+	for _, network := range blockedSpecialPurposeNets {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/safehttp/ip_test.go
+++ b/internal/safehttp/ip_test.go
@@ -1,0 +1,58 @@
+package safehttp
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIsForbiddenIP(t *testing.T) {
+	t.Parallel()
+
+	forbidden := []string{
+		"127.0.0.1",
+		"127.0.0.2",
+		"0.0.0.0",
+		"10.1.2.3",
+		"172.16.0.1",
+		"192.168.1.1",
+		"169.254.1.1",
+		"169.254.169.254",
+		"224.0.0.1",
+		"100.64.0.1",
+		"100.127.255.254",
+		"192.0.2.1",
+		"::1",
+		"::",
+		"fc00::1",
+		"fe80::1",
+		"ff02::1",
+		"::ffff:127.0.0.1",
+		"::ffff:10.1.2.3",
+		"::ffff:169.254.169.254",
+		"::ffff:100.64.0.1",
+	}
+	for _, raw := range forbidden {
+		ip := net.ParseIP(raw)
+		if ip == nil {
+			t.Fatalf("ParseIP(%q) nil", raw)
+		}
+		if !IsForbiddenIP(ip) {
+			t.Errorf("%s: want forbidden", raw)
+		}
+	}
+
+	allowed := []string{"8.8.8.8", "1.1.1.1", "2001:4860:4860::8888"}
+	for _, raw := range allowed {
+		ip := net.ParseIP(raw)
+		if ip == nil {
+			t.Fatalf("ParseIP(%q) nil", raw)
+		}
+		if IsForbiddenIP(ip) {
+			t.Errorf("%s: want allowed", raw)
+		}
+	}
+
+	if !IsForbiddenIP(nil) {
+		t.Fatal("nil IP must be forbidden")
+	}
+}

--- a/internal/store/webhooks.go
+++ b/internal/store/webhooks.go
@@ -4,19 +4,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 	"time"
+
+	"scrumboy/internal/safehttp"
 )
 
 const maxWebhooksPerProject = 20
 
 type Webhook struct {
-	ID        int64    `json:"id"`
-	UserID    int64    `json:"userId"`
-	ProjectID int64    `json:"projectId"`
-	URL       string   `json:"url"`
-	Events    []string `json:"events"`
+	ID        int64     `json:"id"`
+	UserID    int64     `json:"userId"`
+	ProjectID int64     `json:"projectId"`
+	URL       string    `json:"url"`
+	Events    []string  `json:"events"`
 	CreatedAt time.Time `json:"createdAt"`
 	// Secret is never returned in list/get responses.
 }
@@ -35,12 +38,9 @@ func (s *Store) CreateWebhook(ctx context.Context, userID int64, in CreateWebhoo
 	if in.ProjectID <= 0 {
 		return Webhook{}, fmt.Errorf("%w: invalid project id", ErrValidation)
 	}
-	u, err := url.Parse(strings.TrimSpace(in.URL))
-	if err != nil || u.Scheme == "" || u.Host == "" {
-		return Webhook{}, fmt.Errorf("%w: invalid webhook url", ErrValidation)
-	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return Webhook{}, fmt.Errorf("%w: url scheme must be http or https", ErrValidation)
+	u, err := parseWebhookURL(in.URL)
+	if err != nil {
+		return Webhook{}, err
 	}
 	if len(in.Events) == 0 || len(in.Events) > 50 {
 		return Webhook{}, fmt.Errorf("%w: events must contain 1-50 entries", ErrValidation)
@@ -153,4 +153,24 @@ func (s *Store) DeleteWebhook(ctx context.Context, userID, webhookID int64) erro
 		return ErrNotFound
 	}
 	return nil
+}
+
+// parseWebhookURL is fail-fast syntax/literal-IP checking. Delivery still
+// resolves hostnames and refuses forbidden addresses at dial time.
+func parseWebhookURL(raw string) (*url.URL, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("%w: invalid webhook url", ErrValidation)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("%w: url scheme must be http or https", ErrValidation)
+	}
+	host := strings.ToLower(strings.TrimSuffix(u.Hostname(), "."))
+	if host == "localhost" {
+		return nil, fmt.Errorf("%w: webhook destination is not allowed", ErrValidation)
+	}
+	if ip := net.ParseIP(host); ip != nil && safehttp.IsForbiddenIP(ip) {
+		return nil, fmt.Errorf("%w: webhook destination is not allowed", ErrValidation)
+	}
+	return u, nil
 }

--- a/internal/store/webhooks_test.go
+++ b/internal/store/webhooks_test.go
@@ -1,0 +1,79 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCreateWebhookRejectsForbiddenDestinations(t *testing.T) {
+	st, cleanup := newTestStore(t)
+	defer cleanup()
+
+	owner, err := st.BootstrapUser(context.Background(), "owner@example.com", "password123", "Owner")
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	ctx := WithUserID(context.Background(), owner.ID)
+	project, err := st.CreateProject(ctx, "Webhook URL Validation")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	reject := []struct {
+		url  string
+		want string
+	}{
+		{"", "invalid webhook url"},
+		{"not-a-url", "invalid webhook url"},
+		{"ftp://example.com/hook", "url scheme must be http or https"},
+		{"file:///etc/passwd", "invalid webhook url"},
+		{"http://", "invalid webhook url"},
+		{"http://localhost/hook", "webhook destination is not allowed"},
+		{"http://LocalHost:8080/hook", "webhook destination is not allowed"},
+		{"http://127.0.0.1/hook", "webhook destination is not allowed"},
+		{"http://127.0.0.2/hook", "webhook destination is not allowed"},
+		{"http://10.1.2.3/hook", "webhook destination is not allowed"},
+		{"http://172.16.0.1/hook", "webhook destination is not allowed"},
+		{"http://192.168.1.1/hook", "webhook destination is not allowed"},
+		{"http://169.254.169.254/latest/meta-data/", "webhook destination is not allowed"},
+		{"http://[::1]/hook", "webhook destination is not allowed"},
+		{"http://[fc00::1]/hook", "webhook destination is not allowed"},
+		{"http://[fe80::1]/hook", "webhook destination is not allowed"},
+		{"http://[::ffff:127.0.0.1]/hook", "webhook destination is not allowed"},
+	}
+	for _, tc := range reject {
+		_, err := st.CreateWebhook(ctx, owner.ID, CreateWebhookInput{
+			ProjectID: project.ID,
+			URL:       tc.url,
+			Events:    []string{"*"},
+		})
+		if err == nil {
+			t.Errorf("accepted %q", tc.url)
+			continue
+		}
+		if !errors.Is(err, ErrValidation) || !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("%q: err=%v want substring %q", tc.url, err, tc.want)
+		}
+	}
+
+	for _, raw := range []string{
+		"https://example.com/scrumboy-hook",
+		"http://example.com/scrumboy-hook",
+		"https://user:pass@example.com/hook",
+	} {
+		wh, err := st.CreateWebhook(ctx, owner.ID, CreateWebhookInput{
+			ProjectID: project.ID,
+			URL:       raw,
+			Events:    []string{"todo.assigned"},
+		})
+		if err != nil {
+			t.Errorf("rejected public URL %q: %v", raw, err)
+			continue
+		}
+		if err := st.DeleteWebhook(ctx, owner.ID, wh.ID); err != nil {
+			t.Fatalf("DeleteWebhook: %v", err)
+		}
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-const Version = "3.33.11"
+const Version = "3.33.12"
 
 // ExportFormatVersion is the version of the backup/export data format.
 // Only increment this when the ExportData structure changes in a breaking way.


### PR DESCRIPTION
## Summary

Hardens outbound webhook delivery against server-side request forgery (SSRF).

Webhook destinations are now resolved and classified at delivery time, and connections are made directly to vetted IP addresses rather than allowing Go's default HTTP transport to independently resolve the hostname.

## Changes

* Add shared outbound IP classification and vetted-IP dialing in `internal/safehttp`
* Block loopback, private, link-local, metadata, IPv6 ULA, multicast, unspecified, and other special-purpose address ranges
* Prevent DNS rebinding by dialing the validated IP directly
* Reject redirects during webhook delivery
* Disable environment `HTTP_PROXY` / `HTTPS_PROXY` use for webhooks
* Preserve HTTP/2 support with the hardened transport
* Treat forbidden destinations as permanent delivery failures
* Apply delivery-time protection to webhook URLs already stored before upgrade
* Add fail-fast validation for literal unsafe webhook destinations at creation time
* Reuse the shared address-classification logic for Agenda calendar fetches
* Preserve public `http` and `https` webhook support and existing webhook HMAC/body semantics

## Compatibility

Existing webhooks targeting loopback, LAN/private, Docker/internal, link-local, metadata, or other blocked destinations will no longer be delivered.

Webhook delivery also no longer honors environment `HTTP_PROXY` / `HTTPS_PROXY` settings.

Publicly routable `http` and `https` webhook endpoints remain supported.

## Testing

Added regression coverage for:

* direct loopback and private destinations
* IPv4 and IPv6 unsafe ranges
* IPv4-mapped IPv6 addresses
* mixed public/private DNS responses
* DNS rebinding / second-resolution prevention
* redirects to private destinations
* already-stored unsafe webhook URLs
* proxy and transport configuration
* retry classification
* HTTP/2 preservation
* webhook body, headers, and HMAC behavior

Focused test suites for `safehttp`, `store`, `httpapi`, and calendar pass, along with `git diff --check`.
